### PR TITLE
Removing charts_flutter code

### DIFF
--- a/lib/blocs/selected_currency_details_bloc.dart
+++ b/lib/blocs/selected_currency_details_bloc.dart
@@ -1,8 +1,6 @@
 import 'dart:async';
 
-import 'package:charts_flutter/flutter.dart';
 import 'package:cotacao_direta/blocs/base_bloc.dart';
-import 'package:cotacao_direta/model/currency.dart';
 import 'package:cotacao_direta/repository/currency_repository.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
@@ -35,16 +33,17 @@ class SelectedCurrencyDetailsBloc extends BaseBloc {
 
     var currencyList = await _currencyRepository.getCurrencyHistoricalData(
         [selectedCurrencyCod], _initialDate, _finalDate);
-    var dataToAdd = <Series<dynamic, DateTime>>[];
-    dataToAdd.add(
+    // TODO Replace this block when the chart library gets replaced
+    // var dataToAdd = <Series<dynamic, DateTime>>[];
+    /*dataToAdd.add(
         Series<Currency, DateTime>(
             id: selectedCurrencyCod,
             data: currencyList,
             domainFn: (Currency currency, _) =>
                 DateFormat("yyyy-MM-dd").parse(currency.historicalDate!),
             measureFn: (Currency currency, _) => currency.value)
-    );
-    _selectedCurrencyHistoryDataStreamController.sink.add(dataToAdd);
+    );*/
+    // _selectedCurrencyHistoryDataStreamController.sink.add(dataToAdd);
   }
 
   updateInitialDate(dateValue){

--- a/lib/view/pages/selected_currency_details.dart
+++ b/lib/view/pages/selected_currency_details.dart
@@ -1,9 +1,7 @@
-import 'package:charts_flutter/flutter.dart';
 import 'package:cotacao_direta/providers/selected_currency_details_bloc_provider.dart';
 import 'package:cotacao_direta/util/localizations.dart';
 import 'package:cotacao_direta/view/widgets/charts.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 
 class SelectedCurrencyDetails extends StatelessWidget {
   final String selectedCurrencyCode;
@@ -87,7 +85,8 @@ class SelectedCurrencyDetails extends StatelessWidget {
             Expanded(
                 child: Row(
               children: [
-                StreamBuilder<List<Series<dynamic, dynamic>>>(
+                // TODO Substitute this block with the class from another chart library
+                /*StreamBuilder<List<Series<dynamic, dynamic>>>(
                     builder: (context, snapshot) {
                       return Expanded(
                           child: Container(
@@ -101,7 +100,7 @@ class SelectedCurrencyDetails extends StatelessWidget {
                               ),
                       ));
                     },
-                    stream: bloc.currencyHistoryStream)
+                    stream: bloc.currencyHistoryStream)*/
               ],
             ))
           ],

--- a/lib/view/widgets/charts.dart
+++ b/lib/view/widgets/charts.dart
@@ -1,16 +1,15 @@
-import 'package:charts_flutter/flutter.dart';
 import 'package:flutter/widgets.dart';
-import 'package:intl/intl.dart';
 
 class SimpleLineChart extends StatelessWidget {
-  final List<Series>? seriesList;
+  // final List<Series>? seriesList;
   final bool? animate;
 
-  SimpleLineChart({this.seriesList, this.animate});
+  SimpleLineChart({/*this.seriesList,*/ this.animate});
 
   @override
   Widget build(BuildContext context) {
-    return TimeSeriesChart(
+    // TODO Replace this with a chart from another library
+    /*return TimeSeriesChart(
       seriesList as List<Series<dynamic, DateTime>>,
       animate: animate,
       primaryMeasureAxis: NumericAxisSpec(
@@ -24,6 +23,9 @@ class SimpleLineChart extends StatelessWidget {
                   format: 'MM', transitionFormat: 'yyyy-MM-dd'),
               year: TimeFormatterSpec(
                   format: 'yyyy', transitionFormat: 'yyyy-MM-dd'))),
+    );*/
+    return Container(
+      child: Text("TODO"),
     );
   }
 }


### PR DESCRIPTION
This PR removes charts_flutter-related code since it cannot be used anymore with current app dependencies