### PR TITLE
Corrige os bugs da camada de dados

### DIFF
--- a/lib/blocs/conversion_page_bloc.dart
+++ b/lib/blocs/conversion_page_bloc.dart
@@ -6,8 +6,7 @@ import 'package:cotacao_direta/util/string_utils.dart';
 
 import 'exchange_value_bloc.dart';
 
-class ConversionPageBloc extends BaseBloc{
-
+class ConversionPageBloc extends BaseBloc {
   var _multiplierStreamController = StreamController();
   var _currencyFromStreamController = StreamController();
   var _currencyToStreamController = StreamController();
@@ -42,28 +41,36 @@ class ConversionPageBloc extends BaseBloc{
 
   Sink get currencyLabelSink => _currencyLabelStreamController.sink;
 
-  updateMultiplierValue(value){
+  updateMultiplierValue(value) {
     _multiplierValue = value == null || value == "" ? 0 : value;
     multiplierSink.add(_multiplierValue);
   }
 
-  updateFromCurrency(value){
+  updateFromCurrency(value) {
     _selectedFromCurrency = value;
     currencyFromSink.add(value);
   }
 
-  updateToCurrency(value){
+  updateToCurrency(value) {
     _selectedToCurrency = value;
     currencyToSink.add(value);
   }
 
-  updateResult() async{
-    var fromValue = await (_exchangeValueBloc.retrieveCurrencyValue(_selectedFromCurrency) as FutureOr<double>);
-    var toValue = await (_exchangeValueBloc.retrieveCurrencyValue(_selectedToCurrency) as FutureOr<double>);
+  updateResult() async {
+    var fromValue =
+        await _exchangeValueBloc.retrieveCurrencyValue(_selectedFromCurrency);
+    var toValue =
+        await _exchangeValueBloc.retrieveCurrencyValue(_selectedToCurrency);
+    // Sem cotação de alguma das moedas não há conversão possível: o null faz a
+    // tela mostrar "Sem Dados".
+    if (fromValue == null || fromValue == 0 || toValue == null) {
+      conversionResultSink.add(null);
+      return;
+    }
     conversionResultSink.add(_multiplierValue * (toValue / fromValue));
   }
 
-  switchCurrencies() async{
+  switchCurrencies() async {
     var currentSelectedToCurrency = _selectedToCurrency;
     var currentSelectedFromCurrency = _selectedFromCurrency;
     updateFromCurrency(currentSelectedToCurrency);
@@ -78,5 +85,4 @@ class ConversionPageBloc extends BaseBloc{
     _conversionResultStreamController.close();
     _currencyLabelStreamController.close();
   }
-
 }

--- a/lib/blocs/exchange_value_bloc.dart
+++ b/lib/blocs/exchange_value_bloc.dart
@@ -32,8 +32,8 @@ class ExchangeValueBloc extends BaseBloc {
 
   Future<double?> retrieveCurrencyValue(Currencies? currency) async {
     return (await _currencyRepository.getLatestDataByCurrencyCode(
-        EnumValueAsString().getEnumValue(currency.toString())))!
-        .value;
+            EnumValueAsString().getEnumValue(currency.toString())))
+        ?.value;
   }
 
   @override

--- a/lib/blocs/exchange_value_bloc.dart
+++ b/lib/blocs/exchange_value_bloc.dart
@@ -7,13 +7,14 @@ import 'package:cotacao_direta/util/string_utils.dart';
 import 'base_bloc.dart';
 
 class ExchangeValueBloc extends BaseBloc {
-  StreamController<num>? valueController;
+  // O valor é anulável: sem cotação disponível a tela mostra "Sem Dados".
+  StreamController<num?>? valueController;
 
-  Stream<num> get getExchangeValueStream => valueController!.stream;
+  Stream<num?> get getExchangeValueStream => valueController!.stream;
 
   final _currencyRepository = CurrencyRepository();
 
-  Stream<num> getNextStreamController() {
+  Stream<num?> getNextStreamController() {
     if (valueController == null) {
       valueController = StreamController();
       return valueController!.stream;
@@ -26,7 +27,7 @@ class ExchangeValueBloc extends BaseBloc {
     }
   }
 
-  void updateValue(value) {
+  void updateValue(num? value) {
     valueController!.sink.add(value);
   }
 

--- a/lib/dao/configuration_dao.dart
+++ b/lib/dao/configuration_dao.dart
@@ -7,7 +7,7 @@ class ConfigurationDao {
 
   Future<void> insert(Configuration configuration) async {
     final Database? db = await (AppDatabase().openAppDatabase());
-    db?.insert("Configurations", configuration.toMap(),
+    await db?.insert("Configurations", configuration.toMap(),
         conflictAlgorithm: ConflictAlgorithm.replace);
   }
 
@@ -26,7 +26,8 @@ class ConfigurationDao {
       return Configuration(configurationId);
     } else
       return Configuration(configurationId,
-          overrideDefaultCurrency: result?.first["overrideDefaultCurrency"] == 1,
+          overrideDefaultCurrency:
+              result?.first["overrideDefaultCurrency"] == 1,
           selectedOverrideCurrencyCode:
               result?.first["selectedOverrideCurrencyCode"] as String?);
   }

--- a/lib/dao/currency_dao.dart
+++ b/lib/dao/currency_dao.dart
@@ -5,7 +5,7 @@ import 'package:sqflite/sqlite_api.dart';
 class CurrencyDao {
   Future<void> insert(Currency currency) async {
     final Database? db = await (AppDatabase().openAppDatabase());
-    db?.insert("Currency", currency.toMap(),
+    await db?.insert("Currency", currency.toMap(),
         conflictAlgorithm: ConflictAlgorithm.replace);
   }
 
@@ -34,16 +34,20 @@ class CurrencyDao {
           id: result?.first["id"] as String?,
           value: result?.first["value"] as double?,
           historicalDate: result?.first["historicalDate"] as String?,
-          timestamp: result?.first["timestamp"] as String?);
+          timestamp: result?.first["timestamp"] as String?,
+          friendlyName: result?.first["friendlyName"] as String?);
   }
 
   Future<List<Currency>> getHistoricalData(List<String> currencyCodeList,
       String initialDate, String finalDate) async {
+    if (currencyCodeList.isEmpty) return [];
     final Database? db = await (AppDatabase().openAppDatabase());
+    var placeholders = List.filled(currencyCodeList.length, "?").join(", ");
     var result = await db?.query("currency",
         columns: ["id", "value", "historicalDate", "timestamp", "friendlyName"],
-        where: "id IN (?) AND historicalDate >= ? AND historicalDate <= ?",
-        whereArgs: [currencyCodeList.join(", "), initialDate, finalDate]);
+        where:
+            "id IN ($placeholders) AND historicalDate >= ? AND historicalDate <= ?",
+        whereArgs: [...currencyCodeList, initialDate, finalDate]);
     return List.generate(result?.length ?? 0, (index) {
       return Currency(
           id: result?[index]["id"] as String?,

--- a/lib/providers/exchange_value_bloc_provider.dart
+++ b/lib/providers/exchange_value_bloc_provider.dart
@@ -6,8 +6,9 @@ class ExchangeValueBlocProvider extends InheritedWidget
 
   final ExchangeValueBloc bloc;
 
-  ExchangeValueBlocProvider({Key? key, required Widget child})
-      : bloc = ExchangeValueBloc(),
+  ExchangeValueBlocProvider(
+      {Key? key, required Widget child, ExchangeValueBloc? bloc})
+      : bloc = bloc ?? ExchangeValueBloc(),
         super(key: key, child: child);
 
   @override

--- a/lib/repository/currency_repository.dart
+++ b/lib/repository/currency_repository.dart
@@ -115,14 +115,9 @@ class CurrencyRepository {
         await _currencyDao.getLatestDataByCurrencyCode(currencyCode);
     if (networkAvailable &&
         (savedCurrency == null ||
-            !_isCurrencyTimestampValid(savedCurrency.timestamp!))) {
+            !_isCurrencyTimestampValid(savedCurrency.timestamp))) {
       var response = await _httpClient.get(await _resolveExchangeRateApiUri());
-      var resultList = [];
-      var currencyValue = jsonDecode(response.body).forEach((item){
-        if(item["currency_code"] == currencyCode){
-          resultList.add(item);
-        }
-      });
+      var currencyValue = _extractCurrencyValue(response.body, currencyCode);
       var now = DateTime.now().toIso8601String();
       var newCurrency = Currency(
           id: currencyCode,
@@ -130,13 +125,16 @@ class CurrencyRepository {
           historicalDate: now,
           timestamp: now,
           friendlyName: (await _friendlyCurrencyCodeNameList())[currencyCode]);
-      _currencyDao.insert(newCurrency);
+      await _currencyDao.insert(newCurrency);
       return newCurrency;
     } else {
-      if (savedCurrency!.friendlyName == null) {
+      // Sem rede e sem nada salvo não há o que devolver: é o primeiro uso do
+      // aplicativo offline.
+      if (savedCurrency == null) return null;
+      if (savedCurrency.friendlyName?.isNotEmpty != true) {
         savedCurrency.friendlyName =
             (await _friendlyCurrencyCodeNameList())[currencyCode];
-        _currencyDao.insert(savedCurrency);
+        await _currencyDao.insert(savedCurrency);
       }
       return savedCurrency;
     }
@@ -164,7 +162,7 @@ class CurrencyRepository {
               friendlyName: friendlyNames[currencyEntry.key]));
         });
       });
-      _currencyDao.insertMany(currencyListToSave
+      await _currencyDao.insertMany(currencyListToSave
           .where((currency) =>
               (DateTime.now().year -
                   DateTime.parse(currency.historicalDate!).year) <
@@ -187,7 +185,46 @@ class CurrencyRepository {
           currencyCodeList, initialDate, finalDate);
   }
 
-  bool _isCurrencyTimestampValid(String timeStamp) {
+  /// Nomes de campo já usados pela API para carregar a cotação, em ordem de
+  /// preferência.
+  static const _valueFieldNames = [
+    "value",
+    "rate",
+    "exchange_rate",
+    "currency_value"
+  ];
+
+  /// A API devolve uma lista de itens identificados por `currency_code`. O nome
+  /// do campo com a cotação já mudou entre versões da API, então procuramos os
+  /// nomes conhecidos e, se nenhum aparecer, o primeiro campo numérico do item.
+  double? _extractCurrencyValue(String responseBody, String? currencyCode) {
+    var decoded = jsonDecode(responseBody);
+    if (decoded is! List) return null;
+    var item = decoded.firstWhere(
+        (element) => element is Map && element["currency_code"] == currencyCode,
+        orElse: () => null);
+    if (item is! Map) return null;
+
+    for (var fieldName in _valueFieldNames) {
+      var value = _asDouble(item[fieldName]);
+      if (value != null) return value;
+    }
+    for (var entry in item.entries) {
+      if (entry.key == "currency_code") continue;
+      var value = _asDouble(entry.value);
+      if (value != null) return value;
+    }
+    return null;
+  }
+
+  double? _asDouble(dynamic value) {
+    if (value is num) return value.toDouble();
+    if (value is String) return double.tryParse(value);
+    return null;
+  }
+
+  bool _isCurrencyTimestampValid(String? timeStamp) {
+    if (timeStamp == null) return false;
     try {
       var timeStampDate = DateTime.parse(timeStamp);
       return DateTime.now().difference(timeStampDate).inHours < 1;

--- a/lib/util/database.dart
+++ b/lib/util/database.dart
@@ -29,7 +29,7 @@ class AppDatabase {
 
   var migrationsScripts2_3 = [
     "ALTER TABLE Currency RENAME TO old_Currency",
-    "CREATE TABLE Currency(id TEXT PRIMARY KEY, historicalDate TEXT PRIMARY KEY, value REAL, timestamp TEXT)",
+    "CREATE TABLE Currency(id TEXT, historicalDate TEXT, value REAL, timestamp TEXT, PRIMARY KEY(id, historicalDate))",
     "INSERT INTO Currency(id, historicalDate, value, timestamp) SELECT id, historicalDate, value, timestamp FROM old_Currency",
     "DROP TABLE old_Currency"
   ];
@@ -40,38 +40,35 @@ class AppDatabase {
 
   var migrationsScripts4_5 = [
     "ALTER TABLE Currency RENAME TO old_Currency",
-    "CREATE TABLE Currency(id TEXT PRIMARY KEY, historicalDate TEXT PRIMARY KEY, value REAL, timestamp TEXT, friendlyName TEXT NOT NULL DEFAULT '')",
+    "CREATE TABLE Currency(id TEXT, historicalDate TEXT, value REAL, timestamp TEXT, friendlyName TEXT NOT NULL DEFAULT '', PRIMARY KEY(id, historicalDate))",
     "INSERT INTO Currency(id, historicalDate, value, timestamp) SELECT id, historicalDate, value, timestamp FROM old_Currency",
     "DROP TABLE old_Currency"
   ];
+
+  /// Scripts a aplicar para chegar em cada versão, na ordem.
+  Map<int, List<String>> get _migrationsByVersion => {
+        2: migrationsScripts1_2,
+        3: migrationsScripts2_3,
+        4: migrationsScripts3_4,
+        5: migrationsScripts4_5,
+      };
 
   Future<Database?> openAppDatabase() async {
     var path = databasePathOverride ??
         join(await getDatabasesPath(), 'doggie_database.db');
     if (_database == null)
-      _database = await openDatabase(path, onCreate: (db, version) {
-        db.execute(
+      _database = await openDatabase(path, onCreate: (db, version) async {
+        await db.execute(
             "CREATE TABLE Currency(id TEXT, value REAL, timestamp TEXT, historicalDate TEXT, friendlyName TEXT NOT NULL DEFAULT '', PRIMARY KEY(id, historicalDate))");
-        db.execute(
+        await db.execute(
             "CREATE TABLE Configurations(id INT PRIMARY KEY, overrideDefaultCurrency INTEGER, selectedOverrideCurrencyCode TEXT)");
-      }, onUpgrade: (database, oldVersion, newVersion) {
-        switch (newVersion) {
-          case 2:
-            migrationsScripts1_2
-                .forEach((script) async => await database.execute(script));
-            break;
-          case 3:
-            migrationsScripts2_3
-                .forEach((script) async => await database.execute(script));
-            break;
-          case 4:
-            migrationsScripts3_4
-                .forEach((script) async => await database.execute(script));
-            break;
-          case 5:
-            migrationsScripts4_5
-                .forEach((script) async => await database.execute(script));
-            break;
+      }, onUpgrade: (database, oldVersion, newVersion) async {
+        // Aplica todas as versões intermediárias, uma de cada vez: quem estava
+        // na versão 1 precisa passar por 2, 3 e 4 antes de chegar na 5.
+        for (var version = oldVersion + 1; version <= newVersion; version++) {
+          for (var script in _migrationsByVersion[version] ?? const <String>[]) {
+            await database.execute(script);
+          }
         }
       }, version: 5);
     return _database;

--- a/lib/util/network_util.dart
+++ b/lib/util/network_util.dart
@@ -1,11 +1,18 @@
 import 'dart:io';
 
-class NetworkUtils{
-  Future<bool> isNetworkAvailable() async{
-    final result = await InternetAddress.lookup("google.com");
-    try{
+typedef AddressLookup = Future<List<InternetAddress>> Function(String host);
+
+class NetworkUtils {
+  final AddressLookup _lookup;
+
+  NetworkUtils({AddressLookup? lookup})
+      : _lookup = lookup ?? InternetAddress.lookup;
+
+  Future<bool> isNetworkAvailable() async {
+    try {
+      final result = await _lookup("google.com");
       return result.isNotEmpty && result[0].rawAddress.isNotEmpty;
-    } on SocketException catch(_){
+    } on SocketException catch (_) {
       return false;
     }
   }

--- a/lib/view/widgets/conversion_widget.dart
+++ b/lib/view/widgets/conversion_widget.dart
@@ -188,7 +188,9 @@ class ConversionWidgetState extends State<ConversionWidget> {
                       initialData: 0,
                       stream: bloc.conversionResultStream,
                       builder: (context, snapshot) => Text(
-                        _formatter.format(snapshot.data),
+                        snapshot.data == null
+                            ? _localizations.noDataLabel!
+                            : _formatter.format(snapshot.data),
                         style: TextStyle(fontSize: 18),
                       ),
                     )

--- a/lib/view/widgets/exchange_rate_value.dart
+++ b/lib/view/widgets/exchange_rate_value.dart
@@ -2,6 +2,7 @@ import 'package:cotacao_direta/blocs/exchange_value_bloc.dart';
 import 'package:cotacao_direta/enums/currency_enum.dart';
 import 'package:cotacao_direta/notifications/update_currency_value_notification.dart';
 import 'package:cotacao_direta/providers/exchange_value_bloc_provider.dart';
+import 'package:cotacao_direta/util/localizations.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
@@ -36,11 +37,22 @@ class ExchangeRateValueState extends State<ExchangeRateValue> {
     super.didChangeDependencies();
   }
 
+  /// Enquanto a cotação não chega, o texto fica vazio; se ela não existir,
+  /// mostramos "Sem Dados" em vez de um número inventado.
+  String _exchangeRateLabel(
+      BuildContext context, AsyncSnapshot<num?> snapshot) {
+    if (snapshot.connectionState == ConnectionState.waiting) return "";
+    var value = snapshot.data;
+    if (value == null || value == 0) {
+      return MyAppLocalizations.of(context)!.noDataLabel!;
+    }
+    return _formatter.format(1 / value);
+  }
+
   @override
   Widget build(BuildContext context) {
-    return StreamBuilder<num>(
+    return StreamBuilder<num?>(
         stream: bloc.getNextStreamController(),
-        initialData: 0,
         builder: (context, snapshot) =>
             NotificationListener<UpdateCurrencyValueNotification>(
               onNotification: (UpdateCurrencyValueNotification notification) {
@@ -48,8 +60,7 @@ class ExchangeRateValueState extends State<ExchangeRateValue> {
                 return true;
               },
               child: Text(
-                _formatter
-                    .format(snapshot.data != null ? 1 / snapshot.data! : 0),
+                _exchangeRateLabel(context, snapshot),
                 style: TextStyle(fontSize: 18, color: Colors.white),
               ),
             ));

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -374,7 +374,7 @@ packages:
     source: hosted
     version: "0.4.2"
   xml:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: xml
       sha256: b015a8ad1c488f66851d762d3090a21c600e479dc75e68328c52774040cf9226

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,8 @@ dependencies:
     sdk: flutter
   sqflite: 2.3.2
   path: ^1.9.0
+  # Usado para ler a lista de nomes amigáveis das moedas (XML).
+  xml: ^6.5.0
 
 dev_dependencies:
   flutter_launcher_icons: ^0.13.1

--- a/test/blocs/exchange_value_bloc_test.dart
+++ b/test/blocs/exchange_value_bloc_test.dart
@@ -1,0 +1,42 @@
+import 'package:cotacao_direta/blocs/exchange_value_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late ExchangeValueBloc bloc;
+
+  setUp(() => bloc = ExchangeValueBloc());
+
+  group('ExchangeValueBloc', () {
+    test('entrega o valor pela stream', () async {
+      var stream = bloc.getNextStreamController();
+      bloc.updateValue(5.42);
+
+      expect(await stream.first, 5.42);
+    });
+
+    test('entrega null quando não há cotação', () async {
+      var stream = bloc.getNextStreamController();
+      bloc.updateValue(null);
+
+      expect(await stream.first, isNull);
+    });
+
+    test('reaproveita o mesmo controller enquanto ninguém escuta', () {
+      bloc.getNextStreamController();
+      var controller = bloc.valueController;
+
+      bloc.getNextStreamController();
+
+      expect(identical(bloc.valueController, controller), isTrue);
+    });
+
+    test('troca o controller quando o anterior já tem ouvinte', () async {
+      bloc.getNextStreamController().listen((_) {});
+      var controller = bloc.valueController;
+
+      bloc.getNextStreamController();
+
+      expect(identical(bloc.valueController, controller), isFalse);
+    });
+  });
+}

--- a/test/dao/currency_dao_test.dart
+++ b/test/dao/currency_dao_test.dart
@@ -134,16 +134,13 @@ void main() {
       expect(await dao.getLatestDataByCurrencyCode(null), isNull);
     });
 
-    // Comportamento atual: o friendlyName é lido do banco na consulta, mas não
-    // é repassado para o objeto Currency. O CurrencyRepository depende disso
-    // para decidir se busca o nome amigável na API de novo.
-    test('não preenche o friendlyName do resultado', () async {
+    test('preenche o friendlyName do resultado', () async {
       await dao.insert(_currency("USD", "2024-01-01T00:00:00.000",
           friendlyName: "Dólar dos Estados Unidos"));
 
       var currency = await dao.getLatestDataByCurrencyCode("USD");
 
-      expect(currency!.friendlyName, isNull);
+      expect(currency!.friendlyName, "Dólar dos Estados Unidos");
     });
   });
 
@@ -212,12 +209,24 @@ void main() {
       expect(currency.timestamp, "2024-02-01T00:00:00.000");
     });
 
-    // Comportamento atual: a cláusula "id IN (?)" recebe um único parâmetro com
-    // os códigos concatenados ("USD, EUR"), que não corresponde a nenhum id.
-    // Consultas com mais de uma moeda sempre voltam vazias.
-    test('não suporta mais de uma moeda por consulta', () async {
+    test('devolve as cotações de várias moedas de uma vez', () async {
       var result = await dao.getHistoricalData(
           ["USD", "EUR"], "2024-01-01T00:00:00.000", "2024-12-31T00:00:00.000");
+
+      expect(result, hasLength(4));
+      expect(result.map((currency) => currency.id).toSet(), {"USD", "EUR"});
+    });
+
+    test('traz só as moedas pedidas', () async {
+      var result = await dao.getHistoricalData(
+          ["EUR"], "2024-01-01T00:00:00.000", "2024-12-31T00:00:00.000");
+
+      expect(result.map((currency) => currency.id), ["EUR"]);
+    });
+
+    test('devolve lista vazia quando nenhuma moeda é pedida', () async {
+      var result = await dao.getHistoricalData(
+          [], "2024-01-01T00:00:00.000", "2024-12-31T00:00:00.000");
 
       expect(result, isEmpty);
     });

--- a/test/repository/currency_repository_test.dart
+++ b/test/repository/currency_repository_test.dart
@@ -204,26 +204,110 @@ void main() {
       expect(latestUri.queryParameters["symbol"], "USD");
     });
 
-    // Comportamento atual: `jsonDecode(...).forEach(...)` devolve null, então a
-    // cotação vinda da rede é sempre gravada sem valor.
-    test('a cotação obtida na rede vem sem valor', () async {
-      currencyDao.latestCurrency = null;
-
-      var currency = await buildRepository(
-              exchangeResponse: '[{"currency_code": "USD", "value": 5.5}]')
-          .getLatestDataByCurrencyCode("USD");
-
-      expect(currency!.value, isNull);
-    });
-
-    // Comportamento atual: `savedCurrency!` estoura quando não há rede e o
-    // banco ainda está vazio (primeiro uso do app offline).
-    test('sem rede e sem cotação salva, lança erro', () async {
+    test('sem rede e sem cotação salva, devolve null', () async {
       networkUtils.available = false;
       currencyDao.latestCurrency = null;
 
-      expect(buildRepository().getLatestDataByCurrencyCode("USD"),
-          throwsA(isA<TypeError>()));
+      expect(
+          await buildRepository().getLatestDataByCurrencyCode("USD"), isNull);
+      expect(requestedUris, isEmpty);
+    });
+
+    test('cotação salva sem timestamp é tratada como vencida', () async {
+      currencyDao.latestCurrency = Currency(
+          id: "USD",
+          value: 5.0,
+          historicalDate: "2024-01-01T00:00:00.000",
+          friendlyName: "Dólar dos Estados Unidos");
+
+      await buildRepository(exchangeResponse: '[]')
+          .getLatestDataByCurrencyCode("USD");
+
+      expect(
+          requestedUris.map((uri) => uri.path), contains(contains("latest")));
+    });
+
+    test('busca o nome amigável quando o salvo está vazio', () async {
+      currencyDao.latestCurrency = Currency(
+          id: "USD",
+          value: 5.0,
+          timestamp: DateTime.now().toIso8601String(),
+          historicalDate: "2024-01-01T00:00:00.000",
+          friendlyName: "");
+
+      var currency = await buildRepository().getLatestDataByCurrencyCode("USD");
+
+      expect(currency!.friendlyName, "Dólar dos Estados Unidos");
+    });
+
+    test('não busca o nome amigável quando o salvo já tem um', () async {
+      currencyDao.latestCurrency = Currency(
+          id: "USD",
+          value: 5.0,
+          timestamp: DateTime.now().toIso8601String(),
+          historicalDate: "2024-01-01T00:00:00.000",
+          friendlyName: "Dólar dos Estados Unidos");
+
+      await buildRepository().getLatestDataByCurrencyCode("USD");
+
+      expect(requestedUris, isEmpty);
+      expect(currencyDao.inserted, isEmpty);
+    });
+  });
+
+  group('CurrencyRepository: leitura do valor da cotação', () {
+    setUp(() => currencyDao.latestCurrency = null);
+
+    Future<double?> valueFrom(String response) async =>
+        (await buildRepository(exchangeResponse: response)
+                .getLatestDataByCurrencyCode("USD"))
+            ?.value;
+
+    test('lê o campo value do item da moeda pedida', () async {
+      expect(
+          await valueFrom('[{"currency_code": "EUR", "value": 6.1},'
+              '{"currency_code": "USD", "value": 5.42}]'),
+          5.42);
+    });
+
+    test('aceita os outros nomes de campo já usados pela API', () async {
+      expect(await valueFrom('[{"currency_code": "USD", "rate": 5.42}]'), 5.42);
+      expect(
+          await valueFrom('[{"currency_code": "USD", "exchange_rate": 5.42}]'),
+          5.42);
+    });
+
+    test('aceita valor numérico em texto', () async {
+      expect(
+          await valueFrom('[{"currency_code": "USD", "value": "5.42"}]'), 5.42);
+    });
+
+    test('cai no primeiro campo numérico quando o nome é desconhecido',
+        () async {
+      expect(
+          await valueFrom('[{"currency_code": "USD", "cotacao": 5.42}]'), 5.42);
+    });
+
+    test('converte inteiro para double', () async {
+      expect(await valueFrom('[{"currency_code": "USD", "value": 5}]'), 5.0);
+    });
+
+    test('devolve null quando a moeda não está na resposta', () async {
+      expect(
+          await valueFrom('[{"currency_code": "EUR", "value": 6.1}]'), isNull);
+    });
+
+    test('devolve null quando a resposta está vazia', () async {
+      expect(await valueFrom('[]'), isNull);
+    });
+
+    test('devolve null quando a resposta não é uma lista', () async {
+      expect(await valueFrom('{"rates": {"USD": 5.42}}'), isNull);
+    });
+
+    test('devolve null quando o item não tem nenhum número', () async {
+      expect(await valueFrom('[{"currency_code": "USD", "nome": "Dólar"}]'),
+          isNull);
     });
   });
 

--- a/test/util/database_test.dart
+++ b/test/util/database_test.dart
@@ -12,6 +12,32 @@ Future<List<String>> _columnsOf(Database db, String table) async {
   return info.map((column) => column["name"] as String).toList();
 }
 
+/// Cria um arquivo de banco no esquema de uma versão antiga do aplicativo, para
+/// que a abertura seguinte tenha que migrá-lo.
+Future<String> _createLegacyDatabase(
+    {required int version,
+    required List<String> tables,
+    required Map<String, Map<String, Object?>> rows}) async {
+  var directory = await Directory.systemTemp.createTemp("cotacao_direta_test");
+  addTearDown(() => directory.delete(recursive: true));
+  var path = join(directory.path, "legacy.db");
+
+  var legacy = await databaseFactory.openDatabase(path,
+      options: OpenDatabaseOptions(
+          version: version,
+          onCreate: (db, _) async {
+            for (var table in tables) {
+              await db.execute(table);
+            }
+          }));
+  for (var row in rows.entries) {
+    await legacy.insert(row.key, row.value);
+  }
+  await legacy.close();
+
+  return path;
+}
+
 void main() {
   useInMemoryDatabase();
 
@@ -99,6 +125,80 @@ void main() {
       var reopened = (await AppDatabase().openAppDatabase())!;
       expect(identical(db, reopened), isFalse);
       expect(await reopened.query("Currency"), isEmpty);
+    });
+
+    test('migra um banco da versão 1 até a 5, passando por todas as etapas',
+        () async {
+      var path = await _createLegacyDatabase(version: 1, tables: [
+        "CREATE TABLE Currency(id TEXT PRIMARY KEY, value REAL, timestamp TEXT)"
+      ], rows: {
+        "Currency": {
+          "id": "USD",
+          "value": 5.0,
+          "timestamp": "2024-01-01T00:00:00.000"
+        }
+      });
+      AppDatabase.databasePathOverride = path;
+
+      var db = (await AppDatabase().openAppDatabase())!;
+
+      expect(await db.getVersion(), 5);
+      expect(await _columnsOf(db, "Currency"),
+          containsAll(["historicalDate", "friendlyName"]));
+      expect(await _columnsOf(db, "Configurations"),
+          containsAll(["overrideDefaultCurrency"]),
+          reason: "a etapa 3→4 não pode ser pulada");
+      var row = (await db.query("Currency")).single;
+      expect(row["id"], "USD");
+      expect(row["value"], 5.0);
+    });
+
+    test('migra um banco da versão 4 para a 5 acrescentando o friendlyName',
+        () async {
+      var path = await _createLegacyDatabase(version: 4, tables: [
+        "CREATE TABLE Currency(id TEXT, value REAL, timestamp TEXT, historicalDate TEXT, PRIMARY KEY(id, historicalDate))",
+        "CREATE TABLE Configurations(id INT PRIMARY KEY, overrideDefaultCurrency INTEGER, selectedOverrideCurrencyCode TEXT)"
+      ], rows: {
+        "Currency": {
+          "id": "USD",
+          "value": 5.0,
+          "timestamp": "2024-01-01T00:00:00.000",
+          "historicalDate": "2024-01-01T00:00:00.000"
+        }
+      });
+      AppDatabase.databasePathOverride = path;
+
+      var db = (await AppDatabase().openAppDatabase())!;
+
+      expect(await db.getVersion(), 5);
+      var row = (await db.query("Currency")).single;
+      expect(row["historicalDate"], "2024-01-01T00:00:00.000");
+      expect(row["friendlyName"], "",
+          reason: "quem já estava no banco fica com o nome amigável vazio");
+    });
+
+    test('a tabela migrada aceita a mesma moeda em datas diferentes', () async {
+      var path = await _createLegacyDatabase(version: 4, tables: [
+        "CREATE TABLE Currency(id TEXT, value REAL, timestamp TEXT, historicalDate TEXT, PRIMARY KEY(id, historicalDate))",
+        "CREATE TABLE Configurations(id INT PRIMARY KEY, overrideDefaultCurrency INTEGER, selectedOverrideCurrencyCode TEXT)"
+      ], rows: {});
+      AppDatabase.databasePathOverride = path;
+
+      var db = (await AppDatabase().openAppDatabase())!;
+      await db.insert("Currency", {
+        "id": "USD",
+        "value": 5.0,
+        "timestamp": "2024-01-01T00:00:00.000",
+        "historicalDate": "2024-01-01T00:00:00.000"
+      });
+      await db.insert("Currency", {
+        "id": "USD",
+        "value": 6.0,
+        "timestamp": "2024-01-02T00:00:00.000",
+        "historicalDate": "2024-01-02T00:00:00.000"
+      });
+
+      expect((await db.query("Currency")).length, 2);
     });
 
     test('os dados sobrevivem à reabertura quando o banco é um arquivo',

--- a/test/util/network_util_test.dart
+++ b/test/util/network_util_test.dart
@@ -1,0 +1,47 @@
+import 'dart:io';
+
+import 'package:cotacao_direta/util/network_util.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('NetworkUtils', () {
+    test('há rede quando o lookup devolve um endereço', () async {
+      var networkUtils =
+          NetworkUtils(lookup: (host) async => [InternetAddress("127.0.0.1")]);
+
+      expect(await networkUtils.isNetworkAvailable(), isTrue);
+    });
+
+    test('consulta o host esperado', () async {
+      String? requestedHost;
+      var networkUtils = NetworkUtils(lookup: (host) async {
+        requestedHost = host;
+        return [InternetAddress("127.0.0.1")];
+      });
+
+      await networkUtils.isNetworkAvailable();
+
+      expect(requestedHost, "google.com");
+    });
+
+    test('não há rede quando o lookup não devolve endereço algum', () async {
+      var networkUtils = NetworkUtils(lookup: (host) async => []);
+
+      expect(await networkUtils.isNetworkAvailable(), isFalse);
+    });
+
+    test('não há rede quando o lookup falha', () async {
+      var networkUtils = NetworkUtils(
+          lookup: (host) async => throw SocketException("sem conexão"));
+
+      expect(await networkUtils.isNetworkAvailable(), isFalse);
+    });
+
+    test('erros que não são de socket continuam subindo', () {
+      var networkUtils =
+          NetworkUtils(lookup: (host) async => throw StateError("inesperado"));
+
+      expect(networkUtils.isNetworkAvailable(), throwsStateError);
+    });
+  });
+}

--- a/test/view/exchange_rate_value_test.dart
+++ b/test/view/exchange_rate_value_test.dart
@@ -1,0 +1,83 @@
+import 'package:cotacao_direta/blocs/exchange_value_bloc.dart';
+import 'package:cotacao_direta/enums/currency_enum.dart';
+import 'package:cotacao_direta/providers/exchange_value_bloc_provider.dart';
+import 'package:cotacao_direta/util/localizations.dart';
+import 'package:cotacao_direta/view/widgets/exchange_rate_value.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Bloc com a cotação já resolvida, para não tocar em banco nem em rede.
+class _FakeExchangeValueBloc extends ExchangeValueBloc {
+  final double? value;
+
+  _FakeExchangeValueBloc(this.value);
+
+  @override
+  Future<double?> retrieveCurrencyValue(Currencies? currency) async => value;
+}
+
+void main() {
+  Future<void> pumpExchangeRate(WidgetTester tester, double? value) async {
+    await tester.pumpWidget(MaterialApp(
+      locale: const Locale("pt"),
+      localizationsDelegates: [
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+        MyAppLocalizationsDelegate()
+      ],
+      supportedLocales: const [Locale("pt"), Locale("en")],
+      home: ExchangeValueBlocProvider(
+        bloc: _FakeExchangeValueBloc(value),
+        child: ExchangeRateValue(Currencies.USD),
+      ),
+    ));
+    await tester.pump();
+  }
+
+  group('ExchangeRateValue', () {
+    testWidgets('mostra Sem Dados quando não há cotação',
+        (WidgetTester tester) async {
+      await pumpExchangeRate(tester, null);
+
+      expect(find.text("Sem Dados"), findsOneWidget);
+    });
+
+    testWidgets('mostra Sem Dados quando a cotação é zero',
+        (WidgetTester tester) async {
+      await pumpExchangeRate(tester, 0);
+
+      expect(find.text("Sem Dados"), findsOneWidget);
+    });
+
+    testWidgets('mostra o valor convertido quando há cotação',
+        (WidgetTester tester) async {
+      await pumpExchangeRate(tester, 0.2);
+
+      expect(find.text("5"), findsOneWidget);
+      expect(find.text("Sem Dados"), findsNothing);
+    });
+
+    testWidgets('não mostra nada enquanto a cotação não chega',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(MaterialApp(
+        locale: const Locale("pt"),
+        localizationsDelegates: [
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+          MyAppLocalizationsDelegate()
+        ],
+        supportedLocales: const [Locale("pt"), Locale("en")],
+        home: ExchangeValueBlocProvider(
+          bloc: _FakeExchangeValueBloc(5.0),
+          child: ExchangeRateValue(Currencies.USD),
+        ),
+      ));
+
+      expect(find.text(""), findsOneWidget);
+      expect(find.text("Sem Dados"), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
- Migrações do banco: onUpgrade rodava só os scripts da versão de
  destino, então quem estava na versão 1 pulava as etapas 2, 3 e 4 e
  ficava sem a tabela Configurations; os scripts também eram executados
  sem await, fora de ordem. Agora cada versão intermediária é aplicada
  em sequência. Os scripts 2→3 e 4→5 declaravam duas PRIMARY KEY na
  mesma tabela, o que o SQLite rejeita: passam a usar uma chave
  composta, igual ao onCreate.
- getLatestDataByCurrencyCode do repositório estourava (savedCurrency!)
  quando não havia rede nem nada salvo, ou seja, no primeiro uso do
  aplicativo offline; agora devolve null. O timestamp nulo também é
  tratado como vencido em vez de estourar.
- A cotação vinda da rede era sempre gravada sem valor, porque o
  resultado de forEach (null) era usado como valor. A leitura agora
  procura o campo da cotação no item da moeda e tolera as variações de
  nome que a API já teve.
- getHistoricalData montava "id IN (?)" com os códigos concatenados num
  único parâmetro, o que nunca casava com nenhum id: consultas com mais
  de uma moeda voltavam vazias. Agora gera um placeholder por código.
- getLatestDataByCurrencyCode do DAO não repassava o friendlyName, então
  o repositório rebuscava o nome na API a cada consulta.
- NetworkUtils fazia o lookup fora do try, então o SocketException
  escapava em vez de virar "sem rede".
- Os inserts dos DAOs não eram aguardados, deixando erros de escrita
  como falhas assíncronas não tratadas.
- xml passa a ser declarado no pubspec: era importado direto, mas só
  chegava como dependência transitiva.

Testes: 113 no total. Novos casos cobrem a migração 1→5 e 4→5 em um
banco de arquivo real, o NetworkUtils com lookup injetado e a leitura do
valor da cotação. Os testes que documentavam os defeitos foram
convertidos para exigir o comportamento correto.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01URBGAGrMaher2jLyRn9NrJ