### PR TITLE
Troca a API de cotações pela AwesomeAPI

### DIFF
--- a/lib/repository/currency_repository.dart
+++ b/lib/repository/currency_repository.dart
@@ -8,27 +8,33 @@ import 'package:cotacao_direta/util/network_util.dart';
 import 'package:cotacao_direta/util/string_utils.dart';
 import 'package:http/http.dart' as http;
 import 'package:intl/intl.dart';
-import 'package:sprintf/sprintf.dart';
-import 'package:xml/xml.dart';
 
+/// Cotações vindas da AwesomeAPI (economia.awesomeapi.com.br).
+///
+/// A API trabalha com pares MOEDA-CONTRAPARTIDA (USD-BRL) e devolve o valor no
+/// campo `bid`, em unidades da contrapartida por uma unidade da moeda cotada:
+/// para USD-BRL, quantos reais vale um dólar.
+///
+/// O app guarda o inverso disso em [Currency.value] — quantas unidades da moeda
+/// valem uma unidade da contrapartida. É a convenção que a tela inicial
+/// (que mostra `1 / value`) e a conversão (que divide um valor pelo outro) já
+/// usavam, então a inversão feita aqui mantém o resto do app funcionando sem
+/// alteração.
 class CurrencyRepository {
   static CurrencyRepository? _instance;
+
   final CurrencyDao _currencyDao;
   final ConfigurationRepository _configurationRepository;
   final NetworkUtils _networkUtils;
   final http.Client _httpClient;
-  /*final String _exchangeRateApi =
-      "https://european-exchange-api.herokuapp.com/latest?access_key=%s&symbol=%s";*/
-  final String _exchangeRateApi =
-      "https://european-exchange-api.herokuapp.com/latest?symbol=%s";
-  /*final String _exchangeHistoricalRateApi =
-      "https://european-exchange-api.herokuapp.com/history?access_key=%s&start_at=%s&end_at=%s&base=%s&symbols=%s";*/
-  final String _exchangeHistoricalRateApi =
-      "https://european-exchange-api.herokuapp.com/history?start_at=%s&end_at=%s&base=%s&symbols=%s";
+
+  static const _apiHost = "economia.awesomeapi.com.br";
+
+  /// Teto de registros por consulta ao histórico, imposto pela API.
+  static const _maxHistoryRecords = 360;
+
   final _enumValueAsStringUtil = EnumValueAsString();
-  final _currencyCodeFriendlyNameApi =
-      "https://european-exchange-api.herokuapp.com/currencies";
-  //final String? _apiKey = null;
+  final _apiDateFormatter = DateFormat("yyyyMMdd");
 
   factory CurrencyRepository() {
     if (_instance == null)
@@ -63,48 +69,59 @@ class CurrencyRepository {
   /// Descarta o singleton para que um teste não vaze estado para o seguinte.
   static void resetInstance() => _instance = null;
 
-  /*Future<String> checkAndRetrieveApiKey() async {
-    return _apiKey ??
-        jsonDecode(await rootBundle.loadString('assets/secrets/secrets.json'))[
-            'exchange_api_key'];
-  }*/
+  /// Moeda contra a qual as cotações são expressas quando o usuário não
+  /// escolheu outra nas configurações: o app cota "frente ao real".
+  String get _defaultCounterCurrency =>
+      _enumValueAsStringUtil.getEnumValue(Currencies.BRL.toString());
 
-  Future<Uri> _resolveExchangeRateApiUri() async {
-    // final apiKey = await checkAndRetrieveApiKey();
+  Future<String> _resolveCounterCurrency() async {
     final configuration = await _configurationRepository.getConfiguration();
-    return Uri.parse(sprintf(_exchangeRateApi, [
-      /*apiKey,*/
-      configuration.overrideDefaultCurrency
-          ? configuration.selectedOverrideCurrencyCode
-          : _enumValueAsStringUtil.getEnumValue(Currencies.USD.toString())
-    ]));
+    final selected = configuration.selectedOverrideCurrencyCode;
+    if (configuration.overrideDefaultCurrency &&
+        selected != null &&
+        selected.isNotEmpty) {
+      return selected;
+    }
+    return _defaultCounterCurrency;
   }
 
-  Future<Uri> _resolveExchangeHistoricalRateApiUri(
-      currencyCodeList, initialDate, finalDate) async {
-    //final apiKey = await checkAndRetrieveApiKey();
-    final configuration = await _configurationRepository.getConfiguration();
-    return Uri.parse(sprintf(_exchangeHistoricalRateApi, [
-      /*apiKey,*/
-      initialDate,
-      finalDate,
-      configuration.overrideDefaultCurrency
-          ? configuration.selectedOverrideCurrencyCode
-          : _enumValueAsStringUtil.getEnumValue(Currencies.USD.toString()),
-      currencyCodeList.join(", ")
-    ]));
+  Uri _lastQuoteUri(String currencyCode, String counterCurrency) =>
+      Uri.https(_apiHost, "/json/last/$currencyCode-$counterCurrency");
+
+  Uri _availableCurrenciesUri() => Uri.https(_apiHost, "/json/available/uniq");
+
+  Uri _historyUri(String currencyCode, String counterCurrency,
+      DateTime? initialDate, DateTime? finalDate) {
+    var records = _maxHistoryRecords;
+    if (initialDate != null && finalDate != null) {
+      records = finalDate.difference(initialDate).inDays + 1;
+      if (records < 1) records = 1;
+      if (records > _maxHistoryRecords) records = _maxHistoryRecords;
+    }
+    var query = <String, String>{};
+    if (initialDate != null)
+      query["start_date"] = _apiDateFormatter.format(initialDate);
+    if (finalDate != null)
+      query["end_date"] = _apiDateFormatter.format(finalDate);
+    // Mapa vazio deixaria a URL terminada em "?".
+    return Uri.https(
+        _apiHost,
+        "/json/daily/$currencyCode-$counterCurrency/$records",
+        query.isEmpty ? null : query);
   }
 
+  /// Nomes amigáveis das moedas, no formato {"USD-BRL": "Dólar Americano/Real
+  /// Brasileiro"}. Só é consultada quando um registro salvo está sem nome: nas
+  /// consultas de cotação o nome já vem junto do valor.
   Future<Map<String?, String?>> _friendlyCurrencyCodeNameList() async {
-    var response =
-        await _httpClient.get(Uri.parse(_currencyCodeFriendlyNameApi));
+    var response = await _httpClient.get(_availableCurrenciesUri());
     var friendlyCurrencyNamesMap = Map<String?, String?>();
-    XmlDocument.parse(response.body)
-        .getElement("currencies")!
-        .children
-        .forEach((child) {
-      friendlyCurrencyNamesMap[child.getAttribute("currencycode")] =
-          child.getAttribute("name");
+    var decoded = _tryDecode(response.body);
+    if (decoded is! Map) return friendlyCurrencyNamesMap;
+    decoded.forEach((pair, name) {
+      if (pair is! String || name is! String) return;
+      friendlyCurrencyNamesMap[pair.split("-").first] =
+          _quotedCurrencyName(name);
     });
     return friendlyCurrencyNamesMap;
   }
@@ -116,15 +133,11 @@ class CurrencyRepository {
     if (networkAvailable &&
         (savedCurrency == null ||
             !_isCurrencyTimestampValid(savedCurrency.timestamp))) {
-      var response = await _httpClient.get(await _resolveExchangeRateApiUri());
-      var currencyValue = _extractCurrencyValue(response.body, currencyCode);
-      var now = DateTime.now().toIso8601String();
-      var newCurrency = Currency(
-          id: currencyCode,
-          value: currencyValue,
-          historicalDate: now,
-          timestamp: now,
-          friendlyName: (await _friendlyCurrencyCodeNameList())[currencyCode]);
+      var newCurrency = await _fetchLatestQuote(currencyCode);
+      // Sem cotação nova (resposta inesperada, par inexistente), o que já está
+      // salvo continua valendo: gravar um registro sem valor esconderia a
+      // última cotação boa pela hora seguinte.
+      if (newCurrency == null) return savedCurrency;
       await _currencyDao.insert(newCurrency);
       return newCurrency;
     } else {
@@ -140,28 +153,39 @@ class CurrencyRepository {
     }
   }
 
+  Future<Currency?> _fetchLatestQuote(String? currencyCode) async {
+    if (currencyCode == null || currencyCode.isEmpty) return null;
+    var counterCurrency = await _resolveCounterCurrency();
+    // Uma moeda cotada contra ela mesma vale exatamente uma unidade; a API não
+    // tem esse par.
+    if (currencyCode == counterCurrency) {
+      var now = DateTime.now();
+      return Currency(
+          id: currencyCode,
+          value: 1,
+          historicalDate: now.toIso8601String(),
+          timestamp: now.toIso8601String());
+    }
+    var response =
+        await _httpClient.get(_lastQuoteUri(currencyCode, counterCurrency));
+    var quote = _parseLastQuote(response.body, currencyCode, counterCurrency);
+    return quote == null ? null : _currencyFromQuote(quote, currencyCode);
+  }
+
   Future<List<Currency>> getCurrencyHistoricalData(
       List<String> currencyCodeList, initialDate, finalDate) async {
     if (await _networkUtils.isNetworkAvailable()) {
-      var response = await _httpClient.get(
-          await _resolveExchangeHistoricalRateApiUri(
-              currencyCodeList, initialDate, finalDate));
-      var friendlyNames = await _friendlyCurrencyCodeNameList();
-      List<MapEntry> jsonData =
-          jsonDecode(response.body)["rates"].entries.toList();
+      var counterCurrency = await _resolveCounterCurrency();
+      var start = _parseAppDate(initialDate);
+      var end = _parseAppDate(finalDate);
       var currencyListToSave = <Currency>[];
-      jsonData.forEach((MapEntry element) {
-        var historicalDate = DateFormat("yyyy-MM-dd").parse(element.key);
-
-        element.value.entries.forEach((MapEntry currencyEntry) {
-          currencyListToSave.add(Currency(
-              id: currencyEntry.key,
-              historicalDate: historicalDate.toIso8601String(),
-              value: currencyEntry.value,
-              timestamp: DateTime.now().toIso8601String(),
-              friendlyName: friendlyNames[currencyEntry.key]));
-        });
-      });
+      // A API atende um par por consulta; o app costuma pedir uma moeda só.
+      for (var currencyCode in currencyCodeList) {
+        if (currencyCode == counterCurrency) continue;
+        var response = await _httpClient
+            .get(_historyUri(currencyCode, counterCurrency, start, end));
+        currencyListToSave.addAll(_parseHistory(response.body, currencyCode));
+      }
       await _currencyDao.insertMany(currencyListToSave
           .where((currency) =>
               (DateTime.now().year -
@@ -185,36 +209,79 @@ class CurrencyRepository {
           currencyCodeList, initialDate, finalDate);
   }
 
-  /// Nomes de campo já usados pela API para carregar a cotação, em ordem de
-  /// preferência.
-  static const _valueFieldNames = [
-    "value",
-    "rate",
-    "exchange_rate",
-    "currency_value"
-  ];
+  /// A resposta de `/json/last` é um objeto com o par sem o hífen como chave:
+  /// USD-BRL vira USDBRL.
+  Map? _parseLastQuote(
+      String responseBody, String currencyCode, String counterCurrency) {
+    var decoded = _tryDecode(responseBody);
+    if (decoded is! Map) return null;
+    var item = decoded["$currencyCode$counterCurrency"];
+    if (item is Map) return item;
+    // Pedimos um par só: se a chave vier em outro formato, o único item da
+    // resposta ainda é o que queremos. Respostas de erro não têm objetos
+    // aninhados e caem fora daqui.
+    var items = decoded.values.whereType<Map>().toList();
+    return items.length == 1 ? items.first : null;
+  }
 
-  /// A API devolve uma lista de itens identificados por `currency_code`. O nome
-  /// do campo com a cotação já mudou entre versões da API, então procuramos os
-  /// nomes conhecidos e, se nenhum aparecer, o primeiro campo numérico do item.
-  double? _extractCurrencyValue(String responseBody, String? currencyCode) {
-    var decoded = jsonDecode(responseBody);
-    if (decoded is! List) return null;
-    var item = decoded.firstWhere(
-        (element) => element is Map && element["currency_code"] == currencyCode,
-        orElse: () => null);
-    if (item is! Map) return null;
+  /// A resposta de `/json/daily` é uma lista de itens no mesmo formato do
+  /// `/json/last`, um por dia.
+  List<Currency> _parseHistory(String responseBody, String currencyCode) {
+    var decoded = _tryDecode(responseBody);
+    if (decoded is! List) return [];
+    return decoded
+        .whereType<Map>()
+        .map((item) => _currencyFromQuote(item, currencyCode))
+        .whereType<Currency>()
+        .toList();
+  }
 
-    for (var fieldName in _valueFieldNames) {
-      var value = _asDouble(item[fieldName]);
-      if (value != null) return value;
-    }
-    for (var entry in item.entries) {
-      if (entry.key == "currency_code") continue;
-      var value = _asDouble(entry.value);
-      if (value != null) return value;
-    }
+  /// Converte um item da API no [Currency] que o app guarda, invertendo o
+  /// `bid` para a convenção descrita na documentação da classe.
+  Currency? _currencyFromQuote(Map item, String currencyCode) {
+    var bid = _asDouble(item["bid"]) ?? _asDouble(item["ask"]);
+    if (bid == null || bid == 0) return null;
+    var quoteDate = _quoteDate(item) ?? DateTime.now();
+    return Currency(
+        id: currencyCode,
+        value: 1 / bid,
+        historicalDate: quoteDate.toIso8601String(),
+        timestamp: DateTime.now().toIso8601String(),
+        friendlyName: _quotedCurrencyName(item["name"]));
+  }
+
+  /// O `timestamp` vem em segundos desde a época; o `create_date`, como
+  /// "yyyy-MM-dd HH:mm:ss".
+  DateTime? _quoteDate(Map item) {
+    var timestamp = item["timestamp"];
+    var seconds =
+        timestamp is num ? timestamp.toInt() : int.tryParse("$timestamp");
+    if (seconds != null)
+      return DateTime.fromMillisecondsSinceEpoch(seconds * 1000);
+    var createDate = item["create_date"];
+    return createDate is String ? DateTime.tryParse(createDate) : null;
+  }
+
+  /// O `name` vem como "Dólar Americano/Real Brasileiro": a parte antes da
+  /// barra é o nome da moeda cotada.
+  String? _quotedCurrencyName(dynamic name) {
+    if (name is! String || name.isEmpty) return null;
+    var separator = name.indexOf("/");
+    return separator < 0 ? name : name.substring(0, separator);
+  }
+
+  DateTime? _parseAppDate(dynamic date) {
+    if (date is DateTime) return date;
+    if (date is String && date.isNotEmpty) return DateTime.tryParse(date);
     return null;
+  }
+
+  dynamic _tryDecode(String responseBody) {
+    try {
+      return jsonDecode(responseBody);
+    } catch (exception) {
+      return null;
+    }
   }
 
   double? _asDouble(dynamic value) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -374,7 +374,7 @@ packages:
     source: hosted
     version: "0.4.2"
   xml:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: xml
       sha256: b015a8ad1c488f66851d762d3090a21c600e479dc75e68328c52774040cf9226

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,8 +21,6 @@ dependencies:
     sdk: flutter
   sqflite: 2.3.2
   path: ^1.9.0
-  # Usado para ler a lista de nomes amigáveis das moedas (XML).
-  xml: ^6.5.0
 
 dev_dependencies:
   flutter_launcher_icons: ^0.13.1

--- a/test/repository/currency_repository_test.dart
+++ b/test/repository/currency_repository_test.dart
@@ -9,12 +9,34 @@ import 'package:http/testing.dart';
 
 import '../helpers/fakes.dart';
 
-/// Resposta da API de nomes amigáveis (XML), usada em todas as chamadas.
-const _friendlyNamesXml = '<?xml version="1.0" encoding="UTF-8"?>'
-    '<currencies>'
-    '<currency currencycode="USD" name="Dólar dos Estados Unidos"/>'
-    '<currency currencycode="EUR" name="Euro"/>'
-    '</currencies>';
+/// Item da AwesomeAPI. Os números vêm como texto e o `bid` está em unidades da
+/// contrapartida por uma unidade da moeda cotada (USD-BRL: reais por dólar).
+Map<String, String> _quote(
+        {String code = "USD",
+        String codein = "BRL",
+        String name = "Dólar Americano/Real Brasileiro",
+        String bid = "5.42",
+        String ask = "5.43",
+        String? timestamp}) =>
+    {
+      "code": code,
+      "codein": codein,
+      "name": name,
+      "high": "5.45",
+      "low": "5.40",
+      "varBid": "-0.0021",
+      "pctChange": "-0.04",
+      "bid": bid,
+      "ask": ask,
+      "timestamp":
+          timestamp ?? "${DateTime.now().millisecondsSinceEpoch ~/ 1000}",
+      "create_date": "2026-07-24 17:00:00"
+    };
+
+String _lastResponse(Map<String, Map<String, String>> quotesByPair) =>
+    jsonEncode(quotesByPair);
+
+String _unixOf(DateTime date) => "${date.millisecondsSinceEpoch ~/ 1000}";
 
 void main() {
   late FakeCurrencyDao currencyDao;
@@ -31,16 +53,22 @@ void main() {
 
   tearDown(CurrencyRepository.resetInstance);
 
-  /// Monta o repositório com um cliente HTTP que responde de acordo com o
-  /// caminho da URL e registra tudo o que foi requisitado.
-  CurrencyRepository buildRepository({String exchangeResponse = "[]"}) {
+  /// Monta o repositório com um cliente HTTP que responde conforme o caminho da
+  /// URL e registra tudo o que foi requisitado.
+  CurrencyRepository buildRepository(
+      {String? lastResponse,
+      String? dailyResponse,
+      String? availableResponse}) {
     var client = MockClient((request) async {
       requestedUris.add(request.url);
-      if (request.url.path.contains("currencies")) {
-        return http.Response.bytes(utf8.encode(_friendlyNamesXml), 200,
-            headers: {"content-type": "application/xml; charset=utf-8"});
-      }
-      return http.Response.bytes(utf8.encode(exchangeResponse), 200,
+      var path = request.url.path;
+      var body = path.contains("/available/")
+          ? (availableResponse ??
+              jsonEncode({"USD-BRL": "Dólar Americano/Real Brasileiro"}))
+          : path.contains("/daily/")
+              ? (dailyResponse ?? "[]")
+              : (lastResponse ?? _lastResponse({"USDBRL": _quote()}));
+      return http.Response.bytes(utf8.encode(body), 200,
           headers: {"content-type": "application/json; charset=utf-8"});
     });
 
@@ -50,6 +78,12 @@ void main() {
         networkUtils: networkUtils,
         httpClient: client);
   }
+
+  Uri lastUri() =>
+      requestedUris.firstWhere((uri) => uri.path.contains("/last/"));
+
+  Uri dailyUri() =>
+      requestedUris.firstWhere((uri) => uri.path.contains("/daily/"));
 
   group('CurrencyRepository (singleton)', () {
     test('CurrencyRepository() devolve sempre a mesma instância', () {
@@ -64,144 +98,229 @@ void main() {
     });
 
     test('withDependencies não contamina o singleton', () {
-      var injected = buildRepository();
-
-      expect(identical(injected, CurrencyRepository()), isFalse);
+      expect(identical(buildRepository(), CurrencyRepository()), isFalse);
     });
   });
 
-  group('CurrencyRepository.getLatestDataByCurrencyCode', () {
-    test('sem rede, devolve a cotação salva sem chamar a API', () async {
-      networkUtils.available = false;
-      currencyDao.latestCurrency = Currency(
-          id: "USD",
-          value: 5.0,
-          timestamp: "2020-01-01T00:00:00.000",
-          historicalDate: "2020-01-01T00:00:00.000",
-          friendlyName: "Dólar dos Estados Unidos");
+  group('CurrencyRepository: montagem das URLs', () {
+    setUp(() => currencyDao.latestCurrency = null);
 
-      var currency = await buildRepository().getLatestDataByCurrencyCode("USD");
-
-      expect(currency!.value, 5.0);
-      expect(requestedUris, isEmpty);
-    });
-
-    test('com rede e cotação recente, não consulta a API de cotação', () async {
-      currencyDao.latestCurrency = Currency(
-          id: "USD",
-          value: 5.0,
-          timestamp:
-              DateTime.now().subtract(Duration(minutes: 30)).toIso8601String(),
-          historicalDate: "2024-01-01T00:00:00.000",
-          friendlyName: "Dólar dos Estados Unidos");
-
-      var currency = await buildRepository().getLatestDataByCurrencyCode("USD");
-
-      expect(currency!.value, 5.0);
-      expect(requestedUris, isEmpty);
-    });
-
-    test('completa o nome amigável quando o registro salvo não tem um',
-        () async {
-      currencyDao.latestCurrency = Currency(
-          id: "USD",
-          value: 5.0,
-          timestamp: DateTime.now().toIso8601String(),
-          historicalDate: "2024-01-01T00:00:00.000");
-
-      var currency = await buildRepository().getLatestDataByCurrencyCode("USD");
-
-      expect(currency!.friendlyName, "Dólar dos Estados Unidos");
-      expect(
-          currencyDao.inserted.single.friendlyName, "Dólar dos Estados Unidos",
-          reason: "o nome recuperado precisa ser gravado de volta");
-      expect(requestedUris.single.path, contains("currencies"));
-    });
-
-    test('com rede e cotação vencida, busca na API e grava o resultado',
-        () async {
-      currencyDao.latestCurrency = Currency(
-          id: "USD",
-          value: 5.0,
-          timestamp:
-              DateTime.now().subtract(Duration(hours: 2)).toIso8601String(),
-          historicalDate: "2024-01-01T00:00:00.000",
-          friendlyName: "Dólar dos Estados Unidos");
-
-      var currency = await buildRepository(
-              exchangeResponse: '[{"currency_code": "USD", "value": 5.5}]')
-          .getLatestDataByCurrencyCode("USD");
-
-      expect(currency!.id, "USD");
-      expect(currency.friendlyName, "Dólar dos Estados Unidos");
-      expect(
-          DateTime.parse(currency.timestamp!)
-              .isAfter(DateTime.now().subtract(Duration(minutes: 1))),
-          isTrue);
-      expect(currencyDao.inserted.single.id, "USD");
-      expect(
-          requestedUris.map((uri) => uri.path), contains(contains("latest")));
-    });
-
-    test('sem cotação salva, busca na API', () async {
-      currencyDao.latestCurrency = null;
-
-      var currency = await buildRepository(
-              exchangeResponse: '[{"currency_code": "USD", "value": 5.5}]')
-          .getLatestDataByCurrencyCode("USD");
-
-      expect(currency!.id, "USD");
-      expect(currencyDao.inserted, hasLength(1));
-    });
-
-    test('timestamp inválido é tratado como vencido', () async {
-      currencyDao.latestCurrency = Currency(
-          id: "USD",
-          value: 5.0,
-          timestamp: "não é uma data",
-          historicalDate: "2024-01-01T00:00:00.000",
-          friendlyName: "Dólar dos Estados Unidos");
-
-      await buildRepository(exchangeResponse: '[]')
-          .getLatestDataByCurrencyCode("USD");
-
-      expect(
-          requestedUris.map((uri) => uri.path), contains(contains("latest")));
-    });
-
-    test('consulta a API usando USD por padrão', () async {
-      currencyDao.latestCurrency = null;
-
+    test('pede o par da moeda contra o real por padrão', () async {
       await buildRepository().getLatestDataByCurrencyCode("USD");
 
-      var latestUri =
-          requestedUris.firstWhere((uri) => uri.path.contains("latest"));
-      expect(latestUri.queryParameters["symbol"], "USD");
+      expect(lastUri().host, "economia.awesomeapi.com.br");
+      expect(lastUri().path, "/json/last/USD-BRL");
     });
 
-    test('respeita a moeda base configurada pelo usuário', () async {
+    test('pede o par da moeda que foi solicitada, não a das configurações',
+        () async {
+      await buildRepository(
+          lastResponse: _lastResponse({
+        "EURBRL": _quote(code: "EUR", name: "Euro/Real Brasileiro", bid: "6.10")
+      })).getLatestDataByCurrencyCode("EUR");
+
+      expect(lastUri().path, "/json/last/EUR-BRL");
+    });
+
+    test('usa a moeda configurada como contrapartida', () async {
       configurationRepository.configuration = Configuration(1,
           overrideDefaultCurrency: true, selectedOverrideCurrencyCode: "EUR");
-      currencyDao.latestCurrency = null;
 
-      await buildRepository().getLatestDataByCurrencyCode("EUR");
+      await buildRepository(
+          lastResponse: _lastResponse({
+        "USDEUR": _quote(codein: "EUR", name: "Dólar Americano/Euro")
+      })).getLatestDataByCurrencyCode("USD");
 
-      var latestUri =
-          requestedUris.firstWhere((uri) => uri.path.contains("latest"));
-      expect(latestUri.queryParameters["symbol"], "EUR");
+      expect(lastUri().path, "/json/last/USD-EUR");
     });
 
     test('ignora a moeda selecionada quando o override está desligado',
         () async {
       configurationRepository.configuration = Configuration(1,
           overrideDefaultCurrency: false, selectedOverrideCurrencyCode: "EUR");
+
+      await buildRepository().getLatestDataByCurrencyCode("USD");
+
+      expect(lastUri().path, "/json/last/USD-BRL");
+    });
+
+    test('cai no real quando o override está ligado sem moeda escolhida',
+        () async {
+      configurationRepository.configuration = Configuration(1,
+          overrideDefaultCurrency: true, selectedOverrideCurrencyCode: "");
+
+      await buildRepository().getLatestDataByCurrencyCode("USD");
+
+      expect(lastUri().path, "/json/last/USD-BRL");
+    });
+
+    test('não consulta a API quando a moeda é a própria contrapartida',
+        () async {
+      var currency = await buildRepository().getLatestDataByCurrencyCode("BRL");
+
+      expect(requestedUris, isEmpty);
+      expect(currency!.value, 1);
+    });
+  });
+
+  group('CurrencyRepository.getLatestDataByCurrencyCode', () {
+    test('inverte o bid para a convenção que o app usa', () async {
+      currencyDao.latestCurrency = null;
+
+      var currency = await buildRepository(
+              lastResponse: _lastResponse({"USDBRL": _quote(bid: "5.00")}))
+          .getLatestDataByCurrencyCode("USD");
+
+      // A tela mostra 1 / value, que precisa dar os 5,00 reais por dólar.
+      expect(currency!.value, closeTo(0.2, 1e-9));
+      expect(1 / currency.value!, closeTo(5.00, 1e-9));
+    });
+
+    test('lê o nome amigável do próprio item da cotação', () async {
+      currencyDao.latestCurrency = null;
+
+      var currency = await buildRepository().getLatestDataByCurrencyCode("USD");
+
+      expect(currency!.friendlyName, "Dólar Americano");
+      expect(requestedUris.map((uri) => uri.path),
+          isNot(contains(contains("/available/"))),
+          reason: "o nome vem junto da cotação, sem uma segunda chamada");
+    });
+
+    test('usa a data da cotação como historicalDate', () async {
+      currencyDao.latestCurrency = null;
+      var quoteDate = DateTime(2026, 7, 20, 15, 30);
+
+      var currency = await buildRepository(
+              lastResponse: _lastResponse(
+                  {"USDBRL": _quote(timestamp: _unixOf(quoteDate))}))
+          .getLatestDataByCurrencyCode("USD");
+
+      expect(DateTime.parse(currency!.historicalDate!), quoteDate);
+    });
+
+    test('marca o timestamp com o momento da busca, que controla o cache',
+        () async {
+      currencyDao.latestCurrency = null;
+
+      var currency = await buildRepository().getLatestDataByCurrencyCode("USD");
+
+      expect(
+          DateTime.parse(currency!.timestamp!)
+              .isAfter(DateTime.now().subtract(Duration(minutes: 1))),
+          isTrue);
+    });
+
+    test('grava a cotação nova', () async {
       currencyDao.latestCurrency = null;
 
       await buildRepository().getLatestDataByCurrencyCode("USD");
 
-      var latestUri =
-          requestedUris.firstWhere((uri) => uri.path.contains("latest"));
-      expect(latestUri.queryParameters["symbol"], "USD");
+      expect(currencyDao.inserted.single.id, "USD");
+    });
+
+    test('aceita o par com chave fora do padrão', () async {
+      currencyDao.latestCurrency = null;
+
+      var currency = await buildRepository(
+              lastResponse: _lastResponse({"USD_BRL": _quote(bid: "4.00")}))
+          .getLatestDataByCurrencyCode("USD");
+
+      expect(1 / currency!.value!, closeTo(4.00, 1e-9));
+    });
+
+    test('mantém a cotação salva quando a API responde com erro', () async {
+      currencyDao.latestCurrency = Currency(
+          id: "USD",
+          value: 0.2,
+          timestamp:
+              DateTime.now().subtract(Duration(hours: 2)).toIso8601String(),
+          historicalDate: "2026-07-01T00:00:00.000",
+          friendlyName: "Dólar Americano");
+
+      var currency = await buildRepository(
+              lastResponse: jsonEncode(
+                  {"status": 404, "code": "CoinNotExists", "message": "erro"}))
+          .getLatestDataByCurrencyCode("USD");
+
+      expect(currency!.value, 0.2, reason: "a última cotação boa continua");
+      expect(currencyDao.inserted, isEmpty,
+          reason: "não pode gravar um registro sem valor por cima");
+    });
+
+    test('mantém a cotação salva quando a resposta não é JSON', () async {
+      currencyDao.latestCurrency = Currency(
+          id: "USD",
+          value: 0.2,
+          timestamp:
+              DateTime.now().subtract(Duration(hours: 2)).toIso8601String(),
+          historicalDate: "2026-07-01T00:00:00.000",
+          friendlyName: "Dólar Americano");
+
+      var currency = await buildRepository(lastResponse: "<html>erro</html>")
+          .getLatestDataByCurrencyCode("USD");
+
+      expect(currency!.value, 0.2);
+    });
+
+    test('sem rede, devolve a cotação salva sem chamar a API', () async {
+      networkUtils.available = false;
+      currencyDao.latestCurrency = Currency(
+          id: "USD",
+          value: 0.2,
+          timestamp: "2020-01-01T00:00:00.000",
+          historicalDate: "2020-01-01T00:00:00.000",
+          friendlyName: "Dólar Americano");
+
+      var currency = await buildRepository().getLatestDataByCurrencyCode("USD");
+
+      expect(currency!.value, 0.2);
+      expect(requestedUris, isEmpty);
+    });
+
+    test('com rede e cotação recente, não consulta a API', () async {
+      currencyDao.latestCurrency = Currency(
+          id: "USD",
+          value: 0.2,
+          timestamp:
+              DateTime.now().subtract(Duration(minutes: 30)).toIso8601String(),
+          historicalDate: "2026-07-24T00:00:00.000",
+          friendlyName: "Dólar Americano");
+
+      var currency = await buildRepository().getLatestDataByCurrencyCode("USD");
+
+      expect(currency!.value, 0.2);
+      expect(requestedUris, isEmpty);
+    });
+
+    test('com rede e cotação vencida, busca de novo', () async {
+      currencyDao.latestCurrency = Currency(
+          id: "USD",
+          value: 0.2,
+          timestamp:
+              DateTime.now().subtract(Duration(hours: 2)).toIso8601String(),
+          historicalDate: "2026-07-01T00:00:00.000",
+          friendlyName: "Dólar Americano");
+
+      var currency = await buildRepository(
+              lastResponse: _lastResponse({"USDBRL": _quote(bid: "6.00")}))
+          .getLatestDataByCurrencyCode("USD");
+
+      expect(1 / currency!.value!, closeTo(6.00, 1e-9));
+    });
+
+    test('timestamp inválido é tratado como vencido', () async {
+      currencyDao.latestCurrency = Currency(
+          id: "USD",
+          value: 0.2,
+          timestamp: "não é uma data",
+          historicalDate: "2026-07-01T00:00:00.000",
+          friendlyName: "Dólar Americano");
+
+      await buildRepository().getLatestDataByCurrencyCode("USD");
+
+      expect(
+          requestedUris.map((uri) => uri.path), contains("/json/last/USD-BRL"));
     });
 
     test('sem rede e sem cotação salva, devolve null', () async {
@@ -213,214 +332,177 @@ void main() {
       expect(requestedUris, isEmpty);
     });
 
-    test('cotação salva sem timestamp é tratada como vencida', () async {
-      currencyDao.latestCurrency = Currency(
-          id: "USD",
-          value: 5.0,
-          historicalDate: "2024-01-01T00:00:00.000",
-          friendlyName: "Dólar dos Estados Unidos");
+    test('devolve null quando o código da moeda é nulo', () async {
+      currencyDao.latestCurrency = null;
 
-      await buildRepository(exchangeResponse: '[]')
-          .getLatestDataByCurrencyCode("USD");
-
-      expect(
-          requestedUris.map((uri) => uri.path), contains(contains("latest")));
+      expect(await buildRepository().getLatestDataByCurrencyCode(null), isNull);
+      expect(requestedUris, isEmpty);
     });
 
-    test('busca o nome amigável quando o salvo está vazio', () async {
+    test('busca o nome amigável na lista quando o registro salvo não tem um',
+        () async {
       currencyDao.latestCurrency = Currency(
           id: "USD",
-          value: 5.0,
+          value: 0.2,
           timestamp: DateTime.now().toIso8601String(),
-          historicalDate: "2024-01-01T00:00:00.000",
-          friendlyName: "");
+          historicalDate: "2026-07-24T00:00:00.000");
 
       var currency = await buildRepository().getLatestDataByCurrencyCode("USD");
 
-      expect(currency!.friendlyName, "Dólar dos Estados Unidos");
+      expect(currency!.friendlyName, "Dólar Americano");
+      expect(currencyDao.inserted.single.friendlyName, "Dólar Americano");
+      expect(requestedUris.single.path, "/json/available/uniq");
     });
 
-    test('não busca o nome amigável quando o salvo já tem um', () async {
+    test('não estoura quando a lista de nomes vem em formato inesperado',
+        () async {
       currencyDao.latestCurrency = Currency(
           id: "USD",
-          value: 5.0,
+          value: 0.2,
           timestamp: DateTime.now().toIso8601String(),
-          historicalDate: "2024-01-01T00:00:00.000",
-          friendlyName: "Dólar dos Estados Unidos");
+          historicalDate: "2026-07-24T00:00:00.000");
 
-      await buildRepository().getLatestDataByCurrencyCode("USD");
+      var currency = await buildRepository(availableResponse: '{"status": 500}')
+          .getLatestDataByCurrencyCode("USD");
 
-      expect(requestedUris, isEmpty);
-      expect(currencyDao.inserted, isEmpty);
-    });
-  });
-
-  group('CurrencyRepository: leitura do valor da cotação', () {
-    setUp(() => currencyDao.latestCurrency = null);
-
-    Future<double?> valueFrom(String response) async =>
-        (await buildRepository(exchangeResponse: response)
-                .getLatestDataByCurrencyCode("USD"))
-            ?.value;
-
-    test('lê o campo value do item da moeda pedida', () async {
-      expect(
-          await valueFrom('[{"currency_code": "EUR", "value": 6.1},'
-              '{"currency_code": "USD", "value": 5.42}]'),
-          5.42);
-    });
-
-    test('aceita os outros nomes de campo já usados pela API', () async {
-      expect(await valueFrom('[{"currency_code": "USD", "rate": 5.42}]'), 5.42);
-      expect(
-          await valueFrom('[{"currency_code": "USD", "exchange_rate": 5.42}]'),
-          5.42);
-    });
-
-    test('aceita valor numérico em texto', () async {
-      expect(
-          await valueFrom('[{"currency_code": "USD", "value": "5.42"}]'), 5.42);
-    });
-
-    test('cai no primeiro campo numérico quando o nome é desconhecido',
-        () async {
-      expect(
-          await valueFrom('[{"currency_code": "USD", "cotacao": 5.42}]'), 5.42);
-    });
-
-    test('converte inteiro para double', () async {
-      expect(await valueFrom('[{"currency_code": "USD", "value": 5}]'), 5.0);
-    });
-
-    test('devolve null quando a moeda não está na resposta', () async {
-      expect(
-          await valueFrom('[{"currency_code": "EUR", "value": 6.1}]'), isNull);
-    });
-
-    test('devolve null quando a resposta está vazia', () async {
-      expect(await valueFrom('[]'), isNull);
-    });
-
-    test('devolve null quando a resposta não é uma lista', () async {
-      expect(await valueFrom('{"rates": {"USD": 5.42}}'), isNull);
-    });
-
-    test('devolve null quando o item não tem nenhum número', () async {
-      expect(await valueFrom('[{"currency_code": "USD", "nome": "Dólar"}]'),
-          isNull);
+      expect(currency!.friendlyName, isNull);
     });
   });
 
   group('CurrencyRepository.getCurrencyHistoricalData', () {
-    var ratesResponse = jsonEncode({
-      "rates": {
-        "2024-01-03": {"USD": 4.9},
-        "2024-01-01": {"USD": 5.0, "EUR": 6.0},
-      }
-    });
+    var dailyResponse = jsonEncode([
+      _quote(bid: "5.00", timestamp: _unixOf(DateTime(2026, 7, 3))),
+      _quote(bid: "4.90", timestamp: _unixOf(DateTime(2026, 7, 1))),
+    ]);
 
-    test('sem rede, delega ao DAO com os mesmos parâmetros', () async {
-      networkUtils.available = false;
-      currencyDao.historicalData = [
-        Currency(id: "USD", value: 5.0, historicalDate: "2024-01-01")
-      ];
-
-      var result = await buildRepository()
-          .getCurrencyHistoricalData(["USD"], "2024-01-01", "2024-01-31");
-
-      expect(result, currencyDao.historicalData);
-      expect(currencyDao.historicalDataCalls.single, [
-        ["USD"],
-        "2024-01-01",
-        "2024-01-31"
-      ]);
-      expect(requestedUris, isEmpty);
-    });
-
-    test('com rede, converte o mapa de cotações em moedas', () async {
-      var result = await buildRepository(exchangeResponse: ratesResponse)
-          .getCurrencyHistoricalData(
-              ["USD", "EUR"], "2024-01-01", "2024-01-31");
-
-      expect(result, hasLength(3));
-      var first = result.first;
-      expect(first.id, "USD");
-      expect(first.value, 5.0);
-      expect(first.historicalDate, DateTime(2024, 1, 1).toIso8601String());
-      expect(first.friendlyName, "Dólar dos Estados Unidos");
-      expect(result.map((currency) => currency.friendlyName), contains("Euro"));
-    });
-
-    test('devolve as cotações ordenadas da mais antiga para a mais nova',
+    test('monta a URL do histórico com o par, o intervalo e o número de dias',
         () async {
-      var result = await buildRepository(exchangeResponse: ratesResponse)
-          .getCurrencyHistoricalData(["USD"], "2024-01-01", "2024-01-31");
+      await buildRepository(dailyResponse: dailyResponse)
+          .getCurrencyHistoricalData(["USD"], "2026-07-01", "2026-07-05");
 
-      var dates =
-          result.map((currency) => DateTime.parse(currency.historicalDate!));
-      expect(dates.first.isAfter(dates.last), isFalse);
+      expect(dailyUri().path, "/json/daily/USD-BRL/5");
+      expect(dailyUri().queryParameters["start_date"], "20260701");
+      expect(dailyUri().queryParameters["end_date"], "20260705");
+    });
+
+    test('limita o número de dias ao teto da API', () async {
+      await buildRepository(dailyResponse: dailyResponse)
+          .getCurrencyHistoricalData(["USD"], "2020-01-01", "2026-07-05");
+
+      expect(dailyUri().path, "/json/daily/USD-BRL/360");
+    });
+
+    test('usa a moeda configurada como contrapartida', () async {
+      configurationRepository.configuration = Configuration(1,
+          overrideDefaultCurrency: true, selectedOverrideCurrencyCode: "EUR");
+
+      await buildRepository(dailyResponse: dailyResponse)
+          .getCurrencyHistoricalData(["USD"], "2026-07-01", "2026-07-05");
+
+      expect(dailyUri().path, "/json/daily/USD-EUR/5");
+    });
+
+    test('sem datas, pede o máximo e não deixa a URL com "?" solto', () async {
+      await buildRepository(dailyResponse: dailyResponse)
+          .getCurrencyHistoricalData(["USD"], "", "");
+
+      expect(dailyUri().toString(),
+          "https://economia.awesomeapi.com.br/json/daily/USD-BRL/360");
+    });
+
+    test('converte cada item da lista, invertendo o bid', () async {
+      var result = await buildRepository(dailyResponse: dailyResponse)
+          .getCurrencyHistoricalData(["USD"], "2026-07-01", "2026-07-05");
+
+      expect(result, hasLength(2));
+      expect(result.map((currency) => currency.id), ["USD", "USD"]);
+      expect(1 / result.first.value!, closeTo(4.90, 1e-9));
+      expect(result.first.friendlyName, "Dólar Americano");
+    });
+
+    test('devolve as cotações da mais antiga para a mais nova', () async {
+      var result = await buildRepository(dailyResponse: dailyResponse)
+          .getCurrencyHistoricalData(["USD"], "2026-07-01", "2026-07-05");
+
       expect(
-          result.last.historicalDate, DateTime(2024, 1, 3).toIso8601String());
+          result.first.historicalDate, DateTime(2026, 7, 1).toIso8601String());
+      expect(
+          result.last.historicalDate, DateTime(2026, 7, 3).toIso8601String());
     });
 
     test('grava no banco as cotações recebidas', () async {
-      await buildRepository(exchangeResponse: ratesResponse)
-          .getCurrencyHistoricalData(["USD"], "2024-01-01", "2024-01-31");
+      await buildRepository(dailyResponse: dailyResponse)
+          .getCurrencyHistoricalData(["USD"], "2026-07-01", "2026-07-05");
 
-      expect(currencyDao.insertedBatches.single, hasLength(3));
+      expect(currencyDao.insertedBatches.single, hasLength(2));
     });
 
     test('não grava cotações com mais de dez anos, mas ainda as devolve',
         () async {
       var oldYear = DateTime.now().year - 11;
-      var response = jsonEncode({
-        "rates": {
-          "$oldYear-01-01": {"USD": 2.0},
-          "2024-01-01": {"USD": 5.0},
-        }
-      });
+      var response = jsonEncode([
+        _quote(bid: "2.00", timestamp: _unixOf(DateTime(oldYear, 1, 1))),
+        _quote(bid: "5.00", timestamp: _unixOf(DateTime(2026, 7, 1))),
+      ]);
 
-      var result = await buildRepository(exchangeResponse: response)
-          .getCurrencyHistoricalData(["USD"], "2024-01-01", "2024-01-31");
+      var result = await buildRepository(dailyResponse: response)
+          .getCurrencyHistoricalData(["USD"], "2026-07-01", "2026-07-05");
 
       expect(result, hasLength(2));
       expect(currencyDao.insertedBatches.single, hasLength(1));
-      expect(currencyDao.insertedBatches.single.single.value, 5.0);
+      expect(1 / currencyDao.insertedBatches.single.single.value!,
+          closeTo(5.00, 1e-9));
     });
 
-    test('monta a URL do histórico com o intervalo, a base e os símbolos',
-        () async {
-      await buildRepository(exchangeResponse: ratesResponse)
+    test('consulta um par por moeda pedida', () async {
+      await buildRepository(dailyResponse: dailyResponse)
           .getCurrencyHistoricalData(
-              ["USD", "EUR"], "2024-01-01", "2024-01-31");
+              ["USD", "EUR"], "2026-07-01", "2026-07-05");
 
-      var historyUri =
-          requestedUris.firstWhere((uri) => uri.path.contains("history"));
-      expect(historyUri.queryParameters["start_at"], "2024-01-01");
-      expect(historyUri.queryParameters["end_at"], "2024-01-31");
-      expect(historyUri.queryParameters["base"], "USD");
-      expect(historyUri.queryParameters["symbols"], "USD, EUR");
+      expect(requestedUris.map((uri) => uri.path),
+          ["/json/daily/USD-BRL/5", "/json/daily/EUR-BRL/5"]);
     });
 
-    test('usa a moeda base configurada na URL do histórico', () async {
-      configurationRepository.configuration = Configuration(1,
-          overrideDefaultCurrency: true, selectedOverrideCurrencyCode: "EUR");
+    test('pula a moeda que é a própria contrapartida', () async {
+      await buildRepository(dailyResponse: dailyResponse)
+          .getCurrencyHistoricalData(
+              ["USD", "BRL"], "2026-07-01", "2026-07-05");
 
-      await buildRepository(exchangeResponse: ratesResponse)
-          .getCurrencyHistoricalData(["USD"], "2024-01-01", "2024-01-31");
-
-      var historyUri =
-          requestedUris.firstWhere((uri) => uri.path.contains("history"));
-      expect(historyUri.queryParameters["base"], "EUR");
+      expect(requestedUris.map((uri) => uri.path), ["/json/daily/USD-BRL/5"]);
     });
 
     test('devolve lista vazia quando a API não traz cotações', () async {
-      var result =
-          await buildRepository(exchangeResponse: jsonEncode({"rates": {}}))
-              .getCurrencyHistoricalData(["USD"], "2024-01-01", "2024-01-31");
+      var result = await buildRepository(dailyResponse: "[]")
+          .getCurrencyHistoricalData(["USD"], "2026-07-01", "2026-07-05");
 
       expect(result, isEmpty);
       expect(currencyDao.insertedBatches.single, isEmpty);
+    });
+
+    test('devolve lista vazia quando a resposta não é uma lista', () async {
+      var result =
+          await buildRepository(dailyResponse: jsonEncode({"status": 404}))
+              .getCurrencyHistoricalData(["USD"], "2026-07-01", "2026-07-05");
+
+      expect(result, isEmpty);
+    });
+
+    test('sem rede, delega ao DAO com os mesmos parâmetros', () async {
+      networkUtils.available = false;
+      currencyDao.historicalData = [
+        Currency(id: "USD", value: 0.2, historicalDate: "2026-07-01")
+      ];
+
+      var result = await buildRepository()
+          .getCurrencyHistoricalData(["USD"], "2026-07-01", "2026-07-05");
+
+      expect(result, currencyDao.historicalData);
+      expect(currencyDao.historicalDataCalls.single, [
+        ["USD"],
+        "2026-07-01",
+        "2026-07-05"
+      ]);
+      expect(requestedUris, isEmpty);
     });
   });
 }

--- a/test/view/exchange_rate_value_test.dart
+++ b/test/view/exchange_rate_value_test.dart
@@ -59,6 +59,16 @@ void main() {
       expect(find.text("Sem Dados"), findsNothing);
     });
 
+    // O CurrencyRepository guarda o inverso do `bid` da AwesomeAPI justamente
+    // para esta conta bater: um bid de 5,42 reais por dólar precisa aparecer
+    // como 5,42 na tela.
+    testWidgets('mostra a cotação da API na mesma orientação que ela publica',
+        (WidgetTester tester) async {
+      await pumpExchangeRate(tester, 1 / 5.42);
+
+      expect(find.text("5.42"), findsOneWidget);
+    });
+
     testWidgets('não mostra nada enquanto a cotação não chega',
         (WidgetTester tester) async {
       await tester.pumpWidget(MaterialApp(


### PR DESCRIPTION
O `european-exchange-api.herokuapp.com` saiu do ar. Este PR troca o `CurrencyRepository` para a [AwesomeAPI](https://docs.awesomeapi.com.br/api-de-moedas) (`economia.awesomeapi.com.br`), adaptando os parsers para que o resto do app continue funcionando sem alteração.

Escolhi a AwesomeAPI por atualizar em tempo real, inclusive no fim de semana. Isso importa para o cache de uma hora do app: numa API de uma cotação por dia útil (Frankfurter/BCE, PTAX), ele passaria o sábado inteiro rebuscando para receber sempre o dado de sexta.

## Endpoints

| Uso | Antes | Agora |
|---|---|---|
| Cotação do dia | `/latest?symbol=USD` | `/json/last/USD-BRL` |
| Histórico | `/history?start_at=&end_at=&base=&symbols=` | `/json/daily/USD-BRL/{dias}?start_date=&end_date=` |
| Nomes das moedas | `/currencies` (XML) | `/json/available/uniq` (JSON) |

## O ponto central: orientação do valor

A API trabalha com pares e devolve o valor em `bid`, como **unidades da contrapartida por uma unidade da moeda cotada** — para `USD-BRL`, quantos reais vale um dólar.

O app guarda o **inverso** disso em `Currency.value`, porque é o que o código a jusante já esperava:

- a tela inicial mostra `1 / value`;
- a conversão faz `multiplicador * (toValue / fromValue)`.

Guardar o `bid` cru inverteria as duas. A inversão ficou no parser e **nenhuma das duas precisou mudar** — que era o requisito. Um teste de widget amarra a ponta: um `bid` de 5,42 precisa aparecer como `5.42` na tela.

## Demais adaptações de formato

- Os números vêm como texto e são convertidos.
- O `timestamp` vem em segundos desde a época e vira a data da cotação, usada no `historicalDate`. O `timestamp` do registro continua sendo o momento da busca, que é o que controla o cache de uma hora.
- O nome amigável sai do próprio item (`"Dólar Americano/Real Brasileiro"` → `"Dólar Americano"`), o que **elimina a segunda requisição** que toda busca de cotação fazia. A lista de nomes só é consultada para completar um registro salvo sem nome.
- Respostas inesperadas não derrubam mais a cotação salva: sem valor novo, o repositório devolve o que já estava no banco, em vez de gravar um registro vazio que esconderia a última cotação boa pela hora seguinte.

## Duas decisões que vale revisar

**A contrapartida padrão passou a ser BRL, e não USD.** O código antigo montava a URL a partir das configurações, com USD como padrão; num modelo de pares isso viraria `USD-USD` na tela inicial. O app cota "frente ao real", então BRL é o padrão, e a moeda escolhida nas configurações continua entrando no lugar dela.

**A URL agora usa a moeda que foi pedida.** Antes, `getLatestDataByCurrencyCode("EUR")` montava a URL com a moeda das configurações e filtrava o euro da resposta — o que só funcionava porque a API devolvia todas as moedas. Com pares, é preciso pedir o par certo.

O par de uma moeda com ela mesma vale um por definição e não vai à rede.

## Testes

**176 no total**, todos passando com `flutter test`. A bateria do repositório foi reescrita para o formato da AwesomeAPI: montagem das URLs, inversão do valor, datas, nome amigável, respostas de erro, histórico e o caminho offline. Conferi que os testes falham se o valor for gravado sem inverter.

O `xml` saiu do `pubspec.yaml`: era usado só pelo parser da lista de nomes, que agora é JSON.

## O que não está aqui, e um aviso

**Não consegui chamar a API de verdade** — a política de rede do ambiente onde trabalhei bloqueia o domínio. Os parsers foram escritos a partir da documentação, e os testes usam payloads que eu montei conforme ela. Os campos principais (`bid`, `name`, `timestamp`, `create_date`, e a chave `USDBRL` no `/json/last`) são bem documentados, mas **vale rodar o app contra a API real antes de mergear**. Os parsers são tolerantes: formato inesperado degrada para "Sem Dados" em vez de estourar.

O `CountryNamesRepository` continua apontando para o `restcountries.eu`, que também saiu do ar. É a lista de países da tela de histórico, não a cotação, então ficou de fora — o sucessor é o `restcountries.com` (v3.1), com caminho diferente.

---
_Generated by [Claude Code](https://claude.ai/code/session_01URBGAGrMaher2jLyRn9NrJ)_