### PR TITLE
Troca o CountryNamesRepository para a REST Countries v3.1

### DIFF
--- a/lib/repository/country_names_repository.dart
+++ b/lib/repository/country_names_repository.dart
@@ -2,17 +2,47 @@ import 'dart:convert';
 
 import 'package:http/http.dart' as http;
 
+/// Nome do país a partir do código da moeda, pela REST Countries.
+///
+/// O endereço antigo (restcountries.eu, v2) saiu do ar. Na v3.1 o `name` deixou
+/// de ser um texto e passou a ser um objeto com `common` e `official`; o app
+/// usa o nome comum.
 class CountryNamesRepository {
-  final String _countryNameApi = "https://restcountries.eu/rest/v2/currency/";
+  static const _apiHost = "restcountries.com";
+  static const _currencyPath = "/v3.1/currency";
+
   final http.Client _httpClient;
 
   CountryNamesRepository({http.Client? httpClient})
       : _httpClient = httpClient ?? http.Client();
 
   Future<String?> getCountryNameByCurrencyCode(String currencyCode) async {
-    var response = await _httpClient
-        .get(Uri.parse(_countryNameApi + currencyCode.toLowerCase()));
-    var jsonResponse = jsonDecode(response.body);
-    return jsonResponse[0]["name"];
+    var response = await _httpClient.get(_countryNameUri(currencyCode));
+    return _firstCountryName(response.body);
+  }
+
+  /// `fields` deixa de fora bandeiras, traduções e fusos horários, que são a
+  /// maior parte da resposta e não têm uso aqui.
+  Uri _countryNameUri(String currencyCode) => Uri.https(_apiHost,
+      "$_currencyPath/${currencyCode.toLowerCase()}", {"fields": "name"});
+
+  String? _firstCountryName(String responseBody) {
+    var decoded = _tryDecode(responseBody);
+    // Moeda desconhecida devolve um objeto de erro, não uma lista.
+    if (decoded is! List || decoded.isEmpty) return null;
+    var country = decoded.first;
+    if (country is! Map) return null;
+    var name = country["name"];
+    if (name is Map) return name["common"] as String?;
+    // A v2 devolvia o nome direto como texto.
+    return name is String ? name : null;
+  }
+
+  dynamic _tryDecode(String responseBody) {
+    try {
+      return jsonDecode(responseBody);
+    } catch (exception) {
+      return null;
+    }
   }
 }

--- a/test/repository/country_names_repository_test.dart
+++ b/test/repository/country_names_repository_test.dart
@@ -5,46 +5,100 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 
+/// País no formato da REST Countries v3.1, em que o nome é um objeto.
+Map<String, dynamic> _country(String common, {String? official}) => {
+      "name": {"common": common, "official": official ?? "República d$common"}
+    };
+
 void main() {
   late List<Uri> requestedUris;
 
   setUp(() => requestedUris = []);
 
-  CountryNamesRepository buildRepository(String body) {
+  CountryNamesRepository buildRepository(String body, {int status = 200}) {
     return CountryNamesRepository(httpClient: MockClient((request) async {
       requestedUris.add(request.url);
-      return http.Response.bytes(utf8.encode(body), 200,
+      return http.Response.bytes(utf8.encode(body), status,
           headers: {"content-type": "application/json; charset=utf-8"});
     }));
   }
 
-  group('CountryNamesRepository', () {
-    test('devolve o nome do primeiro país da resposta', () async {
-      var name =
-          await buildRepository('[{"name": "Brazil"}, {"name": "Outro país"}]')
-              .getCountryNameByCurrencyCode("BRL");
+  group('CountryNamesRepository: montagem da URL', () {
+    test('consulta a v3.1 com o código em minúsculas', () async {
+      await buildRepository(jsonEncode([_country("Brazil")]))
+          .getCountryNameByCurrencyCode("BRL");
+
+      expect(requestedUris.single.host, "restcountries.com");
+      expect(requestedUris.single.path, "/v3.1/currency/brl");
+    });
+
+    test('pede só o campo do nome', () async {
+      await buildRepository(jsonEncode([_country("Brazil")]))
+          .getCountryNameByCurrencyCode("BRL");
+
+      expect(requestedUris.single.queryParameters["fields"], "name");
+    });
+  });
+
+  group('CountryNamesRepository.getCountryNameByCurrencyCode', () {
+    test('devolve o nome comum do primeiro país', () async {
+      var name = await buildRepository(
+              jsonEncode([_country("Brazil"), _country("Outro país")]))
+          .getCountryNameByCurrencyCode("BRL");
 
       expect(name, "Brazil");
     });
 
-    test('consulta a API com o código em minúsculas', () async {
-      await buildRepository('[{"name": "United States"}]')
-          .getCountryNameByCurrencyCode("USD");
+    test('prefere o nome comum ao oficial', () async {
+      var name = await buildRepository(jsonEncode(
+              [_country("Brazil", official: "Federative Republic of Brazil")]))
+          .getCountryNameByCurrencyCode("BRL");
 
-      expect(requestedUris.single.toString(),
-          "https://restcountries.eu/rest/v2/currency/usd");
+      expect(name, "Brazil");
     });
 
-    test('devolve null quando a resposta não traz o nome', () async {
-      var name = await buildRepository('[{"capital": "Brasília"}]')
+    test('ainda aceita o formato antigo, com o nome em texto', () async {
+      var name = await buildRepository(jsonEncode([
+        {"name": "Brazil"}
+      ])).getCountryNameByCurrencyCode("BRL");
+
+      expect(name, "Brazil");
+    });
+
+    test('devolve null quando a moeda não existe', () async {
+      var name = await buildRepository(
+              jsonEncode({"status": 404, "message": "Not Found"}),
+              status: 404)
+          .getCountryNameByCurrencyCode("XYZ");
+
+      expect(name, isNull);
+    });
+
+    test('devolve null para uma lista vazia', () async {
+      var name =
+          await buildRepository("[]").getCountryNameByCurrencyCode("XYZ");
+
+      expect(name, isNull);
+    });
+
+    test('devolve null quando o país não traz nome', () async {
+      var name = await buildRepository(jsonEncode([
+        {"cca2": "BR"}
+      ])).getCountryNameByCurrencyCode("BRL");
+
+      expect(name, isNull);
+    });
+
+    test('devolve null quando a resposta não é JSON', () async {
+      var name = await buildRepository("<html>erro</html>")
           .getCountryNameByCurrencyCode("BRL");
 
       expect(name, isNull);
     });
 
-    test('lança erro quando a API devolve uma lista vazia', () {
-      expect(buildRepository('[]').getCountryNameByCurrencyCode("XYZ"),
-          throwsA(isA<RangeError>()));
+    test('não lança para o chamador em nenhum desses casos', () async {
+      await expectLater(
+          buildRepository("[]").getCountryNameByCurrencyCode("XYZ"), completes);
     });
   });
 }


### PR DESCRIPTION
Última API morta do app: o `restcountries.eu` saiu do ar junto com a v2. O endereço agora é `restcountries.com/v3.1/currency/{moeda}`.

## Não bastava trocar a URL

Na v3.1 o `name` deixou de ser um texto e virou um objeto:

```json
[{"name": {"common": "Brazil", "official": "Federative Republic of Brazil"}}]
```

O parser antigo fazia `jsonResponse[0]["name"]` e devolvia isso como `String?` — com a v3.1 ele entregaria um `Map` num retorno tipado como texto, estourando na chamada. Agora lê o nome comum, e ainda aceita o texto simples da v2 caso a resposta venha no formato antigo.

## Duas melhorias que vieram junto

**`fields=name` na consulta.** Sem isso cada país vem com bandeiras, traduções, fusos horários e o resto — a maior parte da resposta, sem uso aqui. A tela de histórico faz uma consulta por moeda, então a economia é real.

**Respostas inesperadas devolvem null em vez de estourar.** Moeda desconhecida (que na v3.1 responde 404 com um objeto de erro, não uma lista), lista vazia, corpo que não é JSON. O `CurrencyHistoryMenuBloc` já tratava a falha e guardava o resultado vazio para não repetir a chamada, então o efeito na tela é o mesmo — só deixa de depender de exceção para um caminho que é normal.

## Testes

**182 no total**, todos passando com `flutter test`. Os do repositório foram reescritos para o formato da v3.1: montagem da URL, nome comum vs. oficial, compatibilidade com o formato antigo e os quatro casos de resposta ruim. Conferi que falham se o parser voltar a ler o nome como texto.

## Aviso

Como no PR anterior, **não consegui chamar a API de verdade** — a política de rede do ambiente bloqueia o domínio. O formato veio da [documentação](https://restcountries.com/docs/currencies). O `fields` é documentado como filtro geral (obrigatório só no `/all`), mas é a parte que eu mais gostaria de ver confirmada contra a API real. Se ele não for aceito nesse endpoint, o parser degrada para null e a tela de histórico fica sem os nomes dos países — sem quebrar nada.

---
_Generated by [Claude Code](https://claude.ai/code/session_01URBGAGrMaher2jLyRn9NrJ)_