### PR TITLE
Adiciona CI com GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,76 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+# Um push novo na mesma branch cancela a execução anterior, que já não interessa.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Versão fixa de propósito: o pubspec.lock exige Dart >= 3.5, enquanto o
+  # pubspec.yaml ainda declara um limite antigo (< 3.0.0). Fixar evita que uma
+  # versão nova do Flutter mude a resolução sem ninguém pedir. Para atualizar,
+  # rode os testes na versão nova antes de trocar aqui.
+  FLUTTER_VERSION: 3.24.5
+
+jobs:
+  test:
+    name: Análise e testes
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Os testes de DAO rodam o sqflite sobre o SQLite nativo
+      # (sqflite_common_ffi), que carrega a biblioteca do sistema.
+      - name: Instala o SQLite
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libsqlite3-dev
+
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+          cache: true
+
+      - name: Baixa as dependências
+        run: flutter pub get
+
+      # O projeto tem apontamentos antigos do analisador (imports
+      # desnecessários e uma variável sem uso), todos de severidade info ou
+      # warning. Por ora só erros derrubam o CI; quando eles forem resolvidos,
+      # basta remover as duas flags para apertar a régua.
+      - name: Analisa
+        run: flutter analyze --no-fatal-infos --no-fatal-warnings
+
+      - name: Testa
+        run: flutter test
+
+  build-android:
+    name: Build Android
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+          cache: true
+
+      - name: Baixa as dependências
+        run: flutter pub get
+
+      # Build de debug: verifica que o lado Android compila sem depender de
+      # chave de assinatura.
+      - name: Compila o APK de debug
+        run: flutter build apk --debug

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # cotacao_direta
 
+[![CI](https://github.com/hhldiniz/cotacao_direta/actions/workflows/ci.yml/badge.svg)](https://github.com/hhldiniz/cotacao_direta/actions/workflows/ci.yml)
+
 A new Flutter project.
 
 ## Testes
@@ -20,6 +22,10 @@ Os testes são unitários e não precisam de emulador nem de rede:
 Testes que tocam o banco devem chamar `useInMemoryDatabase()`
 (`test/helpers/database_test_helper.dart`) para receber um banco novo a cada
 caso.
+
+O CI (`.github/workflows/ci.yml`) roda a análise e os testes a cada push na
+`master` e em todo pull request, além de compilar o APK de debug. A versão do
+Flutter está fixada no workflow.
 
 ## Getting Started
 


### PR DESCRIPTION
O repositório não tinha nenhuma verificação automática — os PRs #5 a #9 foram abertos sem nada checando análise ou testes. Este PR fecha essa lacuna, e o próprio PR já é o primeiro teste do workflow.

## O que roda

A cada push na `master` e em **todo pull request**, em dois jobs paralelos:

**Análise e testes** — `flutter analyze` e `flutter test`. Instala o `libsqlite3-dev` antes, porque os testes de DAO rodam o sqflite sobre a biblioteca nativa do sistema (`sqflite_common_ffi`); sem ela, 25 testes quebrariam por falta de biblioteca, não por defeito no código.

**Build Android** — `flutter build apk --debug`, que verifica que o lado Android compila sem depender de chave de assinatura.

Um push novo na mesma branch cancela a execução anterior, para não gastar minutos com resultado que já não interessa.

## Duas decisões

**Versão do Flutter fixada em 3.24.5.** O `pubspec.lock` exige Dart >= 3.5, enquanto o `pubspec.yaml` ainda declara `>=2.12.0 <3.0.0` — um limite que ficou para trás. Com essa divergência, deixar o CI seguir o canal `stable` significaria a resolução de dependências mudar sozinha um dia. Para atualizar, é rodar os testes na versão nova e trocar a variável no topo do arquivo.

**A análise roda com `--no-fatal-infos --no-fatal-warnings`.** O `flutter analyze` sai com código 1 diante de qualquer apontamento, e o projeto tem 9 antigos — 7 infos e 2 warnings (imports desnecessários, um import sem uso e uma variável sem uso), nenhum deles erro. Sem as flags o CI nasceria vermelho por dívida anterior a ele. São todos triviais de resolver; feito isso, é só remover as duas flags e a régua fica apertada. Posso fazer isso num PR à parte, se quiser.

Ficou de fora um `dart format --set-exit-if-changed`, pelo mesmo motivo: alguns arquivos já estão fora do formato padrão e o gate reprovaria de saída.

## O que verifiquei, e o que não

Rodei aqui os comandos exatos do job de testes: `flutter analyze --no-fatal-infos --no-fatal-warnings` sai 0 e `flutter test` passa os **182 testes**. O YAML também foi validado.

**O job de build Android eu não consegui exercitar** — não há SDK Android neste ambiente. A configuração é a padrão (Gradle 8.3, JDK 17 via `setup-java`), mas é a parte que pode vir vermelha na primeira execução. Se vier, ou ajustamos ou removemos o job — é uma linha.

---
_Generated by [Claude Code](https://claude.ai/code/session_01URBGAGrMaher2jLyRn9NrJ)_