### PR TITLE
Zera os apontamentos do analisador e aperta o CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,12 +40,10 @@ jobs:
       - name: Baixa as dependências
         run: flutter pub get
 
-      # O projeto tem apontamentos antigos do analisador (imports
-      # desnecessários e uma variável sem uso), todos de severidade info ou
-      # warning. Por ora só erros derrubam o CI; quando eles forem resolvidos,
-      # basta remover as duas flags para apertar a régua.
+      # Sem flags: qualquer apontamento do analisador, de info para cima,
+      # derruba o CI. O projeto está limpo, e a ideia é que continue.
       - name: Analisa
-        run: flutter analyze --no-fatal-infos --no-fatal-warnings
+        run: flutter analyze
 
       - name: Testa
         run: flutter test

--- a/lib/blocs/selected_currency_details_bloc.dart
+++ b/lib/blocs/selected_currency_details_bloc.dart
@@ -30,10 +30,13 @@ class SelectedCurrencyDetailsBloc extends BaseBloc {
   TextEditingController get endDateController => _endDateController;
 
   getCurrencyHistoryData(String selectedCurrencyCod) async {
-
-    var currencyList = await _currencyRepository.getCurrencyHistoricalData(
+    // O resultado é descartado por enquanto: o bloco que montava a série do
+    // gráfico está comentado abaixo, esperando a troca da biblioteca. A busca
+    // continua valendo porque guarda o histórico no banco.
+    await _currencyRepository.getCurrencyHistoricalData(
         [selectedCurrencyCod], _initialDate, _finalDate);
-    // TODO Replace this block when the chart library gets replaced
+    // TODO Replace this block when the chart library gets replaced. O valor
+    // devolvido pela chamada acima volta a ser usado como `currencyList`.
     // var dataToAdd = <Series<dynamic, DateTime>>[];
     /*dataToAdd.add(
         Series<Currency, DateTime>(

--- a/lib/view/pages/home.dart
+++ b/lib/view/pages/home.dart
@@ -11,9 +11,7 @@ import 'package:cotacao_direta/view/widgets/canadian_dollar_exchange_rate.dart';
 import 'package:cotacao_direta/view/widgets/dollar_exchange_rate.dart';
 import 'package:cotacao_direta/view/widgets/euro_exchange_rate.dart';
 import 'package:cotacao_direta/view/widgets/yen_exchange_rate.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:sprintf/sprintf.dart';
 
 import 'main_menu_items/currency_history_menu.dart';

--- a/lib/view/pages/main_menu_items/configurations_page.dart
+++ b/lib/view/pages/main_menu_items/configurations_page.dart
@@ -4,9 +4,7 @@ import 'package:cotacao_direta/providers/configurations_page_bloc_provider.dart'
 import 'package:cotacao_direta/util/localizations.dart';
 import 'package:cotacao_direta/util/string_utils.dart';
 import 'package:cotacao_direta/view/widgets/widget_state_helpers/override_currency_state_helper.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 
 class ConfigurationsPage extends StatelessWidget {
   @override

--- a/lib/view/pages/main_menu_items/currency_history_menu.dart
+++ b/lib/view/pages/main_menu_items/currency_history_menu.dart
@@ -4,7 +4,6 @@ import 'package:cotacao_direta/providers/selected_currency_details_bloc_provider
 import 'package:cotacao_direta/util/string_utils.dart';
 import 'package:cotacao_direta/view/pages/selected_currency_details.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 
 class CurrencyHistory extends StatelessWidget {
   @override

--- a/lib/view/pages/selected_currency_details.dart
+++ b/lib/view/pages/selected_currency_details.dart
@@ -1,6 +1,5 @@
 import 'package:cotacao_direta/providers/selected_currency_details_bloc_provider.dart';
 import 'package:cotacao_direta/util/localizations.dart';
-import 'package:cotacao_direta/view/widgets/charts.dart';
 import 'package:flutter/material.dart';
 
 class SelectedCurrencyDetails extends StatelessWidget {

--- a/lib/view/widgets/canadian_dollar_exchange_rate.dart
+++ b/lib/view/widgets/canadian_dollar_exchange_rate.dart
@@ -1,5 +1,4 @@
 import 'package:cotacao_direta/enums/currency_enum.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:cotacao_direta/providers/exchange_value_bloc_provider.dart';
 import 'package:flutter/material.dart';
 import 'exchange_rate_value.dart';

--- a/lib/view/widgets/conversion_widget.dart
+++ b/lib/view/widgets/conversion_widget.dart
@@ -4,7 +4,6 @@ import 'package:cotacao_direta/providers/conversion_page_bloc_provider.dart';
 import 'package:cotacao_direta/util/localizations.dart';
 import 'package:cotacao_direta/util/string_utils.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:intl/intl.dart';
 
 class ConversionWidget extends StatefulWidget {


### PR DESCRIPTION
Os 9 apontamentos que existiam eram anteriores ao CI e obrigavam a análise a rodar com `--no-fatal-infos --no-fatal-warnings`. Isso deixava passar coisas que o analisador pega de graça — um import sem uso novo, por exemplo.

## O que foi resolvido

**7 imports desnecessários** de `cupertino.dart` e `widgets.dart`, cujos elementos já vinham pelo `material.dart` — em `home.dart`, `configurations_page.dart`, `currency_history_menu.dart`, `canadian_dollar_exchange_rate.dart` e `conversion_widget.dart`.

**O import de `charts.dart`** em `selected_currency_details.dart`, sem uso desde que o bloco do gráfico foi comentado.

**A variável `currencyList`** em `SelectedCurrencyDetailsBloc`, sem uso pelo mesmo motivo. A chamada continua, porque é ela que guarda o histórico no banco — só o resultado é descartado, e o TODO agora diz isso, apontando que a variável volta quando o gráfico voltar.

## O aperto

Com o projeto limpo, o passo de análise voltou a ser um `flutter analyze` sem flags: qualquer apontamento, de info para cima, derruba a verificação.

```diff
-      - name: Analisa
-        run: flutter analyze --no-fatal-infos --no-fatal-warnings
+      - name: Analisa
+        run: flutter analyze
```

## Verificação

`flutter analyze` agora responde **"No issues found!"** e sai com código 0 — antes saía 1. Os **182 testes** continuam passando. Rodei aqui os comandos exatos que o CI executa, e o YAML foi validado.

O próprio CI deste PR é a prova final: se algum apontamento tivesse escapado, ele reprovaria agora.

## O que ficou de fora

Um gate de `dart format --set-exit-if-changed` continua fora. **16 arquivos** estão fora do formato padrão — reformatá-los criaria um diff grande em arquivos sem relação com esta mudança. Se quiser, faço num PR só disso, onde o ruído fica isolado e fácil de revisar.

---
_Generated by [Claude Code](https://claude.ai/code/session_01URBGAGrMaher2jLyRn9NrJ)_