### PR TITLE
Atualiza as dependências

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: archive
-      sha256: cb6a278ef2dbb298455e1a713bda08524a175630ec643a242c399c932a0a1f7d
+      sha256: a96e8b390886ee8abb49b7bd3ac8df6f451c621619f52a26e815fdcf568959ff
       url: "https://pub.dev"
     source: hosted
-    version: "3.6.1"
+    version: "4.0.9"
   args:
     dependency: transitive
     description:
       name: args
-      sha256: "7cf60b9f0cc88203c5a190b4cd62a99feea42759a7fa695010eb5de1c0b2252a"
+      sha256: d0481093c50b1da8910eb0bb301626d4d8eb7284aa739614d2b394ee09e3ea04
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.0"
+    version: "2.7.0"
   async:
     dependency: transitive
     description:
@@ -53,10 +53,10 @@ packages:
     dependency: transitive
     description:
       name: cli_util
-      sha256: c05b7406fdabc7a49a3929d4af76bcaccbbffcbcdcf185b082e1ae07da323d19
+      sha256: ff6785f7e9e3c38ac98b2fb035701789de90154024a75b6cb926445e83197d1c
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.1"
+    version: "0.4.2"
   clock:
     dependency: transitive
     description:
@@ -73,14 +73,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.18.0"
-  crypto:
-    dependency: transitive
-    description:
-      name: crypto
-      sha256: ec30d999af904f33454ba22ed9a86162b35e52b44ac4807d1d93c288041d7d27
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.0.5"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -114,10 +106,10 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_launcher_icons
-      sha256: "526faf84284b86a4cb36d20a5e45147747b7563d921373d4ee0559c54fcdbcea"
+      sha256: "10f13781741a2e3972126fae08393d3c4e01fa4cd7473326b94b72cf594195e7"
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.1"
+    version: "0.14.4"
   flutter_localizations:
     dependency: "direct main"
     description: flutter
@@ -132,10 +124,10 @@ packages:
     dependency: "direct main"
     description:
       name: http
-      sha256: a2bbf9d017fcced29139daa8ed2bba4ece450ab222871df93ca9eec6f80c34ba
+      sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.6.0"
   http_parser:
     dependency: transitive
     description:
@@ -148,10 +140,10 @@ packages:
     dependency: transitive
     description:
       name: image
-      sha256: "2237616a36c0d69aef7549ab439b833fb7f9fb9fc861af2cc9ac3eedddd69ca8"
+      sha256: f9881ff4998044947ec38d098bc7c8316ae1186fa786eddffdb867b9bc94dfce
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.0"
+    version: "4.8.0"
   intl:
     dependency: "direct main"
     description:
@@ -160,14 +152,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.19.0"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: c1b2e9b5ea78c45e1a0788d29606ba27dc5f71f019f32ca5140f61ef071838cf
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.1"
   json_annotation:
     dependency: transitive
     description:
@@ -240,6 +224,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.2"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.6"
+  plugin_platform_interface:
+    dependency: transitive
+    description:
+      name: plugin_platform_interface
+      sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.8"
+  posix:
+    dependency: transitive
+    description:
+      name: posix
+      sha256: bc1bad54ad2b735816e31f8d4600cfde6c7839975085ddfbca48b6c9f7c4044e
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.5.2"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -265,18 +273,26 @@ packages:
     dependency: "direct main"
     description:
       name: sqflite
-      sha256: a9016f495c927cb90557c909ff26a6d92d9bd54fc42ba92e19d4e79d61e798c6
+      sha256: "2d7299468485dca85efeeadf5d38986909c5eb0cd71fd3db2c2f000e6c9454bb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.2"
+    version: "2.4.1"
+  sqflite_android:
+    dependency: transitive
+    description:
+      name: sqflite_android
+      sha256: "78f489aab276260cdd26676d2169446c7ecd3484bbd5fead4ca14f3ed4dd9ee3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
   sqflite_common:
     dependency: transitive
     description:
       name: sqflite_common
-      sha256: "4468b24876d673418a7b7147e5a08a715b4998a7ae69227acafaab762e0e5490"
+      sha256: "761b9740ecbd4d3e66b8916d784e581861fd3c3553eda85e167bc49fdb68f709"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.4+5"
+    version: "2.5.4+6"
   sqflite_common_ffi:
     dependency: "direct dev"
     description:
@@ -285,14 +301,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.4+4"
+  sqflite_darwin:
+    dependency: transitive
+    description:
+      name: sqflite_darwin
+      sha256: "22adfd9a2c7d634041e96d6241e6e1c8138ca6817018afc5d443fef91dcefa9c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1+1"
+  sqflite_platform_interface:
+    dependency: transitive
+    description:
+      name: sqflite_platform_interface
+      sha256: "8dd4515c7bdcae0a785b0062859336de775e8c65db81ae33dd5445f35be61920"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
   sqlite3:
     dependency: transitive
     description:
       name: sqlite3
-      sha256: "1abbeb84bf2b1a10e5e1138c913123c8aa9d83cd64e5f9a0dd847b3c83063202"
+      sha256: "3145bd74dcdb4fd6f5c6dda4d4e4490a8087d7f286a14dee5d37087290f0f8a2"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.9.4"
   stack_trace:
     dependency: transitive
     description:
@@ -345,10 +377,10 @@ packages:
     dependency: transitive
     description:
       name: typed_data
-      sha256: facc8d6582f16042dd49f2463ff1bd6e2c9ef9f3d5da3d9b087e244a7b564b3c
+      sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.4.0"
   vector_math:
     dependency: transitive
     description:
@@ -369,10 +401,10 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: "4188706108906f002b3a293509234588823c8c979dc83304e229ff400c996b05"
+      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.2"
+    version: "1.1.1"
   xml:
     dependency: transitive
     description:
@@ -385,10 +417,10 @@ packages:
     dependency: transitive
     description:
       name: yaml
-      sha256: "75769501ea3489fca56601ff33454fe45507ea3bfb014161abc3b43ae25989d5"
+      sha256: b9da305ac7c39faa3f030eccd175340f968459dae4af175130b3fc47e40d76ce
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.2"
+    version: "3.1.3"
 sdks:
   dart: ">=3.5.0 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  flutter: ">=3.24.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,25 +12,29 @@ dependencies:
   flutter:
     sdk: flutter
   sprintf: ^7.0.0
-  http: 1.2.0
+  http: ^1.6.0
   intl: ^0.19.0
   # flutter 1.22 not supported by this lib
   #  flutter_stetho: ^0.6.0-dev.1
   cupertino_icons: ^1.0.6
   flutter_localizations:
     sdk: flutter
-  sqflite: 2.3.2
+  sqflite: ^2.4.1
   path: ^1.9.0
 
 dev_dependencies:
-  flutter_launcher_icons: ^0.13.1
+  flutter_launcher_icons: ^0.14.4
   flutter_test:
     sdk: flutter
   # Roda o sqflite sobre o SQLite nativo, permitindo testar os DAOs sem um
   # emulador/dispositivo.
   sqflite_common_ffi: ^2.3.3
 
-flutter_icons:
+# A chave flutter_icons foi deprecada na versão 0.14 do gerador.
+# Atenção: assets/launcher/icon.png não existe no repositório, então
+# `dart run flutter_launcher_icons` falha. É preciso adicionar a imagem (ou
+# corrigir o caminho) antes de gerar os ícones.
+flutter_launcher_icons:
   android: true
   ios: false
   image_path_android: "assets/launcher/icon.png"


### PR DESCRIPTION
**12 pacotes atualizados, 2 removidos.** Nenhum arquivo `.dart` precisou mudar: os 182 testes e a análise passam sem alteração.

## Diretas

| Pacote | De | Para |
|---|---|---|
| `http` | 1.2.0 | **1.6.0** |
| `sqflite` | 2.3.2 | **2.4.1** |
| `flutter_launcher_icons` | 0.13.1 | **0.14.4** |

O `http` e o `sqflite` estavam presos a uma **versão exata** (`http: 1.2.0`), o que impedia até correções de patch. Passaram a usar intervalo, como as demais.

## Transitivas

Subiram `archive`, `args`, `cli_util`, `image`, `sqflite_common`, `sqlite3` (2.4.2 → 2.9.4), `typed_data`, `web` (0.4.2 → 1.1.1) e `yaml`. Entraram os pacotes de plataforma novos do sqflite (`sqflite_android`, `sqflite_darwin`, `sqflite_platform_interface`), que passou a ser federado.

Saíram `crypto` e **`js`, que foi descontinuado** pelos autores.

## Um achado no caminho

O gerador de ícones deixou de aceitar a chave `flutter_icons` sem reclamar na 0.14 — avisa que está deprecada. Renomeei para `flutter_launcher_icons`.

Ao rodá-lo para conferir, descobri que **`assets/launcher/icon.png` não existe no repositório**:

```
✕ Could not generate launcher icons
PathNotFoundException: Cannot open file, path = 'assets/launcher/icon.png'
```

É anterior a esta mudança e não dá para resolver sem a imagem, então só deixei registrado num comentário no `pubspec.yaml`. Como o gerador é manual, nada no CI depende disso.

## O que não subiu, e por quê

Não é restrição nossa — é o **Flutter 3.24.5** que segura:

- `intl` 0.19.0 → 0.20.3 — fixado pelo `flutter_localizations` do SDK
- `cupertino_icons`, `path` — fixados pelo SDK
- `sqflite` 2.4.3 e `sqflite_common_ffi` 2.4.2 — exigem Dart mais novo

Confirmei com `flutter pub upgrade --major-versions`: nada além do que está aqui é alcançável. Destravar o resto significa subir o Flutter, que é uma decisão de maior alcance — mexe no pin do CI, na versão de linguagem do Dart e no build Android. Posso fazer num PR à parte, se quiser.

Vale notar que o `environment.sdk` do `pubspec.yaml` ainda declara `>=2.12.0 <3.0.0`, enquanto o `pubspec.lock` exige Dart >= 3.5. Não mexi: o limite inferior define a versão de linguagem, e alterá-lo muda a semântica do Dart no projeto — merece um PR próprio, com os testes como rede.

## Verificação

`flutter analyze` responde **"No issues found!"** e os **182 testes** passam com as versões novas. O CI confirma nos dois jobs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01URBGAGrMaher2jLyRn9NrJ)_