### PR TITLE
Adiciona job de build Linux ao CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,3 +71,28 @@ jobs:
       # chave de assinatura.
       - name: Compila o APK de debug
         run: flutter build apk --debug
+
+  build-linux:
+    name: Build Linux
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Toolchain exigida pelo `flutter doctor` para desenvolvimento desktop
+      # Linux (CMake + GTK), além do runtime do sqflite_common_ffi.
+      - name: Instala as dependências de build
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang cmake ninja-build pkg-config libgtk-3-dev libsqlite3-dev
+
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+          cache: true
+
+      - name: Baixa as dependências
+        run: flutter pub get
+
+      - name: Compila o app Linux (debug)
+        run: flutter build linux --debug


### PR DESCRIPTION
## Summary
- Adiciona o job `build-linux` ao workflow de CI, espelhando o `build-android`
- Compila `flutter build linux --debug` para garantir que o app continue compilando para desktop Linux a cada PR/push em `master`
- Instala a toolchain necessária (`clang`, `cmake`, `ninja-build`, `pkg-config`, `libgtk-3-dev`, `libsqlite3-dev`)

## Test plan
- [x] Validado localmente: `flutter build linux --debug` compila com sucesso usando exatamente os pacotes listados no job
- [x] CI do próprio PR deve rodar o novo job `Build Linux`

🤖 Generated with [Claude Code](https://claude.com/claude-code)