### PR TITLE
Corrige escalonamento das views em telas grandes

### DIFF
--- a/lib/util/responsive.dart
+++ b/lib/util/responsive.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+
+/// As telas do app foram desenhadas com tamanhos fixos (padding, fontes,
+/// ícones) pensados para celular. Em telas grandes (tablet/desktop) esses
+/// valores fixos ficam desproporcionalmente pequenos, então usamos um fator
+/// de escala baseado na largura da tela para aumentá-los proporcionalmente.
+///
+/// Os breakpoints seguem as faixas "compact/medium/expanded" do Material 3.
+class Responsive {
+  static const double _mediumBreakpoint = 600;
+  static const double _expandedBreakpoint = 840;
+
+  static bool isLargeScreen(BuildContext context) =>
+      MediaQuery.of(context).size.width >= _mediumBreakpoint;
+
+  /// Multiplicador a ser aplicado sobre tamanhos pensados para celular.
+  static double scaleFactor(BuildContext context) {
+    final width = MediaQuery.of(context).size.width;
+    if (width >= _expandedBreakpoint) return 1.8;
+    if (width >= _mediumBreakpoint) return 1.35;
+    return 1.0;
+  }
+
+  /// Largura máxima de conteúdo para páginas com formulários/listas, para
+  /// que não fiquem esticadas de ponta a ponta em janelas muito largas.
+  static double contentMaxWidth(BuildContext context) {
+    final width = MediaQuery.of(context).size.width;
+    if (width >= _expandedBreakpoint) return 720;
+    return width;
+  }
+}

--- a/lib/view/pages/home.dart
+++ b/lib/view/pages/home.dart
@@ -5,6 +5,7 @@ import 'package:cotacao_direta/providers/conversion_page_bloc_provider.dart';
 import 'package:cotacao_direta/providers/currency_history_menu_bloc_provider.dart';
 import 'package:cotacao_direta/providers/home_bloc_provider.dart';
 import 'package:cotacao_direta/util/localizations.dart';
+import 'package:cotacao_direta/util/responsive.dart';
 import 'package:cotacao_direta/view/pages/conversion_page.dart';
 import 'package:cotacao_direta/view/pages/main_menu_items/configurations_page.dart';
 import 'package:cotacao_direta/view/widgets/canadian_dollar_exchange_rate.dart';
@@ -44,10 +45,12 @@ class HomeState extends State<Home> {
     final orientation = MediaQuery.of(context).orientation;
     final _localization = MyAppLocalizations.of(context)!;
     final _screenDimensions = MediaQuery.of(context);
+    final _scale = Responsive.scaleFactor(context);
     _bloc = HomeBlocProvider.of(context);
 
-    WidgetsBinding.instance
-        .addPostFrameCallback((_) => _bloc.getSelectedOverrideCurrency());
+    WidgetsBinding.instance.addPostFrameCallback(
+      (_) => _bloc.getSelectedOverrideCurrency(),
+    );
 
     final pageHeader = StreamBuilder(
       builder: (BuildContext context, snapshot) {
@@ -59,9 +62,7 @@ class HomeState extends State<Home> {
             width: _screenDimensions.size.width,
             child: Text(
               sprintf(_localization.homePageHeadsUpText!, [snapshot.data]),
-              style: TextStyle(
-                fontSize: 28,
-              ),
+              style: TextStyle(fontSize: 28 * _scale),
               textAlign: TextAlign.center,
             ),
           );
@@ -79,9 +80,7 @@ class HomeState extends State<Home> {
                   Row(
                     mainAxisAlignment: MainAxisAlignment.center,
                     children: <Widget>[
-                      Column(
-                        children: <Widget>[pageHeader],
-                      ),
+                      Column(children: <Widget>[pageHeader]),
                     ],
                   ),
                   Row(
@@ -90,9 +89,11 @@ class HomeState extends State<Home> {
                       Column(
                         children: <Widget>[
                           Container(
-                            padding: EdgeInsets.all(40.0),
+                            padding: EdgeInsets.all(40.0 * _scale),
                             decoration: BoxDecoration(
-                                shape: BoxShape.circle, color: Colors.amber),
+                              shape: BoxShape.circle,
+                              color: Colors.amber,
+                            ),
                             child: dollarExchangeRate,
                           ),
                         ],
@@ -100,14 +101,15 @@ class HomeState extends State<Home> {
                       Column(
                         children: <Widget>[
                           Container(
-                            padding: EdgeInsets.all(40.0),
+                            padding: EdgeInsets.all(40.0 * _scale),
                             decoration: BoxDecoration(
-                                shape: BoxShape.circle,
-                                color: Colors.blueAccent),
+                              shape: BoxShape.circle,
+                              color: Colors.blueAccent,
+                            ),
                             child: euroExchangeRate,
-                          )
+                          ),
                         ],
-                      )
+                      ),
                     ],
                   ),
                   Row(
@@ -116,26 +118,30 @@ class HomeState extends State<Home> {
                       Column(
                         children: <Widget>[
                           Container(
-                            padding: EdgeInsets.all(60.0),
+                            padding: EdgeInsets.all(60.0 * _scale),
                             decoration: BoxDecoration(
-                                shape: BoxShape.circle,
-                                color: Colors.deepOrange),
+                              shape: BoxShape.circle,
+                              color: Colors.deepOrange,
+                            ),
                             child: canadianDollarExchangeRate,
-                          )
+                          ),
                         ],
-                      )
+                      ),
                     ],
                   ),
                   Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
                     children: <Widget>[
                       Container(
-                        padding: EdgeInsets.all(33.0),
+                        padding: EdgeInsets.all(33.0 * _scale),
                         decoration: BoxDecoration(
-                            shape: BoxShape.circle, color: Colors.pink),
+                          shape: BoxShape.circle,
+                          color: Colors.pink,
+                        ),
                         child: yenExchangeRate,
-                      )
+                      ),
                     ],
-                  )
+                  ),
                 ],
               )
             : Column(
@@ -143,9 +149,7 @@ class HomeState extends State<Home> {
                   Row(
                     mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                     children: <Widget>[
-                      Column(
-                        children: <Widget>[pageHeader],
-                      ),
+                      Column(children: <Widget>[pageHeader]),
                     ],
                   ),
                   Row(
@@ -154,9 +158,11 @@ class HomeState extends State<Home> {
                       Column(
                         children: <Widget>[
                           Container(
-                            padding: EdgeInsets.all(40.0),
+                            padding: EdgeInsets.all(40.0 * _scale),
                             decoration: BoxDecoration(
-                                shape: BoxShape.circle, color: Colors.amber),
+                              shape: BoxShape.circle,
+                              color: Colors.amber,
+                            ),
                             child: dollarExchangeRate,
                           ),
                         ],
@@ -164,79 +170,79 @@ class HomeState extends State<Home> {
                       Column(
                         children: <Widget>[
                           Padding(
-                            padding: EdgeInsets.only(top: 100.0),
+                            padding: EdgeInsets.only(top: 100.0 * _scale),
                             child: Container(
-                              padding: EdgeInsets.all(40.0),
+                              padding: EdgeInsets.all(40.0 * _scale),
                               decoration: BoxDecoration(
-                                  shape: BoxShape.circle,
-                                  color: Colors.blueAccent),
+                                shape: BoxShape.circle,
+                                color: Colors.blueAccent,
+                              ),
                               child: euroExchangeRate,
                             ),
-                          )
+                          ),
                         ],
                       ),
                       Column(
                         children: <Widget>[
                           Container(
-                            padding: EdgeInsets.all(40.0),
+                            padding: EdgeInsets.all(40.0 * _scale),
                             decoration: BoxDecoration(
-                                shape: BoxShape.circle,
-                                color: Colors.deepOrange),
+                              shape: BoxShape.circle,
+                              color: Colors.deepOrange,
+                            ),
                             child: canadianDollarExchangeRate,
-                          )
+                          ),
                         ],
                       ),
                       Column(
                         children: <Widget>[
                           Padding(
-                            padding: EdgeInsets.only(top: 100),
+                            padding: EdgeInsets.only(top: 100 * _scale),
                             child: Container(
-                              padding: EdgeInsets.all(35.0),
+                              padding: EdgeInsets.all(35.0 * _scale),
                               decoration: BoxDecoration(
-                                  shape: BoxShape.circle, color: Colors.pink),
+                                shape: BoxShape.circle,
+                                color: Colors.pink,
+                              ),
                               child: yenExchangeRate,
                             ),
-                          )
+                          ),
                         ],
-                      )
+                      ),
                     ],
-                  )
+                  ),
                 ],
               ),
       ),
       Container(
-        child: CurrencyHistoryMenuBlocProvider(
-          child: CurrencyHistory(),
-        ),
+        child: CurrencyHistoryMenuBlocProvider(child: CurrencyHistory()),
       ),
       Container(
-        child: ConfigurationsPageBlocProvider(
-          child: ConfigurationsPage(),
-        ),
+        child: ConfigurationsPageBlocProvider(child: ConfigurationsPage()),
       ),
-      Container(
-        child: Text("sobre"),
-      )
+      Container(child: Text("sobre")),
     ];
     return Scaffold(
-      appBar: AppBar(
-        title: Text(_pageTitle),
-      ),
+      appBar: AppBar(title: Text(_pageTitle)),
       bottomNavigationBar: BottomNavigationBar(
         type: BottomNavigationBarType.fixed,
         items: [
           BottomNavigationBarItem(
-              icon: Icon(Icons.attach_money),
-              label: _localization.mainCurrenciesBottomNavItemLabel),
+            icon: Icon(Icons.attach_money),
+            label: _localization.mainCurrenciesBottomNavItemLabel,
+          ),
           BottomNavigationBarItem(
-              icon: Icon(Icons.history),
-              label: _localization.currencyHistoryBottomNavItemLabel),
+            icon: Icon(Icons.history),
+            label: _localization.currencyHistoryBottomNavItemLabel,
+          ),
           BottomNavigationBarItem(
-              icon: Icon(Icons.settings),
-              label: _localization.getConfigBottomNavItemLabel),
+            icon: Icon(Icons.settings),
+            label: _localization.getConfigBottomNavItemLabel,
+          ),
           BottomNavigationBarItem(
-              icon: Icon(Icons.short_text),
-              label: _localization.aboutBottomNavItemLabel),
+            icon: Icon(Icons.short_text),
+            label: _localization.aboutBottomNavItemLabel,
+          ),
         ],
         currentIndex: _selectedIndex,
         onTap: (index) {
@@ -250,11 +256,15 @@ class HomeState extends State<Home> {
         visible: fabVisibility,
         child: FloatingActionButton.extended(
           onPressed: () {
-            Navigator.of(context).push(MaterialPageRoute(builder: (context) {
-              return ConversionPageBlocProvider(
-                child: ConversionPage(_localization.conversionPageTitle),
-              );
-            }));
+            Navigator.of(context).push(
+              MaterialPageRoute(
+                builder: (context) {
+                  return ConversionPageBlocProvider(
+                    child: ConversionPage(_localization.conversionPageTitle),
+                  );
+                },
+              ),
+            );
           },
           label: Text(_localization.conversionButtonLabel!),
           icon: Icon(Icons.compare_arrows),

--- a/lib/view/pages/main_menu_items/configurations_page.dart
+++ b/lib/view/pages/main_menu_items/configurations_page.dart
@@ -2,6 +2,7 @@ import 'package:cotacao_direta/blocs/configurations_page_bloc.dart';
 import 'package:cotacao_direta/enums/currency_enum.dart';
 import 'package:cotacao_direta/providers/configurations_page_bloc_provider.dart';
 import 'package:cotacao_direta/util/localizations.dart';
+import 'package:cotacao_direta/util/responsive.dart';
 import 'package:cotacao_direta/util/string_utils.dart';
 import 'package:cotacao_direta/view/widgets/widget_state_helpers/override_currency_state_helper.dart';
 import 'package:flutter/material.dart';
@@ -10,64 +11,95 @@ class ConfigurationsPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     ConfigurationsPageBloc _bloc = ConfigurationsPageBlocProvider.of(context);
-    WidgetsBinding.instance
-        .addPostFrameCallback((_) => _bloc.loadCurrentConfiguration());
+    WidgetsBinding.instance.addPostFrameCallback(
+      (_) => _bloc.loadCurrentConfiguration(),
+    );
     final _currencyList = List.generate(Currencies.values.length, (index) {
-      return EnumValueAsString()
-          .getEnumValue(Currencies.values.elementAt(index).toString());
+      return EnumValueAsString().getEnumValue(
+        Currencies.values.elementAt(index).toString(),
+      );
     });
     var _localization = MyAppLocalizations.of(context)!;
-    return Column(
-      children: [
-        Expanded(
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceAround,
-            children: [
-              Container(
-                child: Row(
-                  children: [
-                    StreamBuilder<OverrideCurrencyStateHelper>(
-                      builder: (BuildContext context, snapshot) {
-                        return Switch(
-                            value: snapshot.data!.enableCurrencyOverride,
-                            onChanged: (bool checked) {
-                              _bloc.updateOverrideCurrencySwitch(checked);
-                            });
-                      },
-                      stream: _bloc.overrideDefaultCurrencyValueStream as Stream<OverrideCurrencyStateHelper>?,
-                      initialData: _bloc.overrideCurrencyStateHelper,
+    final _scale = Responsive.scaleFactor(context);
+    return Center(
+      child: ConstrainedBox(
+        constraints: BoxConstraints(
+          maxWidth: Responsive.contentMaxWidth(context),
+        ),
+        child: Column(
+          children: [
+            Expanded(
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceAround,
+                children: [
+                  Container(
+                    child: Row(
+                      children: [
+                        StreamBuilder<OverrideCurrencyStateHelper>(
+                          builder: (BuildContext context, snapshot) {
+                            return Transform.scale(
+                              scale: _scale,
+                              child: Switch(
+                                value: snapshot.data!.enableCurrencyOverride,
+                                onChanged: (bool checked) {
+                                  _bloc.updateOverrideCurrencySwitch(checked);
+                                },
+                              ),
+                            );
+                          },
+                          stream:
+                              _bloc.overrideDefaultCurrencyValueStream
+                                  as Stream<OverrideCurrencyStateHelper>?,
+                          initialData: _bloc.overrideCurrencyStateHelper,
+                        ),
+                        Text(
+                          _localization.overrideDefaultCurrencySwitchLabel!,
+                          style: TextStyle(fontSize: 16 * _scale),
+                        ),
+                      ],
                     ),
-                    Text(_localization.overrideDefaultCurrencySwitchLabel!)
-                  ],
-                ),
-              ),
-              StreamBuilder<OverrideCurrencyStateHelper>(
-                builder: (BuildContext context, switchSnapshot) {
-                  return DropdownButton(
-                    items: List.generate(
-                        _currencyList.length,
-                        (index) => DropdownMenuItem(
+                  ),
+                  StreamBuilder<OverrideCurrencyStateHelper>(
+                    builder: (BuildContext context, switchSnapshot) {
+                      return DropdownButton(
+                        items: List.generate(
+                          _currencyList.length,
+                          (index) => DropdownMenuItem(
                             value: _currencyList[index],
-                            child: Text(_currencyList[index]))),
-                    onChanged:
-                        switchSnapshot.data!.enableCurrencyOverride == true
+                            child: Text(
+                              _currencyList[index],
+                              style: TextStyle(fontSize: 16 * _scale),
+                            ),
+                          ),
+                        ),
+                        onChanged:
+                            switchSnapshot.data!.enableCurrencyOverride == true
                             ? (dynamic value) {
                                 _bloc.updateSelectedOverrideCurrency(value);
                               }
                             : null,
-                    value: switchSnapshot.data!.selectedCurrencyOverride!.isEmpty
-                        ? _currencyList[0]
-                        : switchSnapshot.data!.selectedCurrencyOverride,
-                  );
-                },
-                stream: _bloc.overrideDefaultCurrencyValueStream as Stream<OverrideCurrencyStateHelper>?,
-                initialData: _bloc.overrideCurrencyStateHelper,
-              )
-            ],
-          ),
-          flex: 1,
-        )
-      ],
+                        value:
+                            switchSnapshot
+                                .data!
+                                .selectedCurrencyOverride!
+                                .isEmpty
+                            ? _currencyList[0]
+                            : switchSnapshot.data!.selectedCurrencyOverride,
+                        iconSize: 24 * _scale,
+                      );
+                    },
+                    stream:
+                        _bloc.overrideDefaultCurrencyValueStream
+                            as Stream<OverrideCurrencyStateHelper>?,
+                    initialData: _bloc.overrideCurrencyStateHelper,
+                  ),
+                ],
+              ),
+              flex: 1,
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/view/pages/main_menu_items/currency_history_menu.dart
+++ b/lib/view/pages/main_menu_items/currency_history_menu.dart
@@ -1,6 +1,7 @@
 import 'package:cotacao_direta/enums/currency_enum.dart';
 import 'package:cotacao_direta/providers/currency_history_menu_bloc_provider.dart';
 import 'package:cotacao_direta/providers/selected_currency_details_bloc_provider.dart';
+import 'package:cotacao_direta/util/responsive.dart';
 import 'package:cotacao_direta/util/string_utils.dart';
 import 'package:cotacao_direta/view/pages/selected_currency_details.dart';
 import 'package:flutter/material.dart';
@@ -9,42 +10,57 @@ class CurrencyHistory extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final bloc = CurrencyHistoryMenuBlocProvider.of(context);
+    final _scale = Responsive.scaleFactor(context);
 
     final _currencyList = List.generate(Currencies.values.length, (index) {
-      return EnumValueAsString()
-          .getEnumValue(Currencies.values.elementAt(index).toString());
+      return EnumValueAsString().getEnumValue(
+        Currencies.values.elementAt(index).toString(),
+      );
     });
 
     bloc.initStreamControllers(_currencyList);
 
     return Center(
-      child: ListView.builder(
-        itemBuilder: (BuildContext context, index) {
-          return GestureDetector(
-            child: ListTile(
-              title: Text(_currencyList[index]),
-              subtitle: StreamBuilder<String?>(
-                initialData: bloc.cachedCountryName(_currencyList[index]),
-                stream: bloc.getCountryNameController(_currencyList[index]),
-                builder: (context, snapshot){
+      child: ConstrainedBox(
+        constraints: BoxConstraints(
+          maxWidth: Responsive.contentMaxWidth(context),
+        ),
+        child: ListView.builder(
+          itemBuilder: (BuildContext context, index) {
+            return GestureDetector(
+              child: ListTile(
+                title: Text(
+                  _currencyList[index],
+                  style: TextStyle(fontSize: 16 * _scale),
+                ),
+                subtitle: StreamBuilder<String?>(
+                  initialData: bloc.cachedCountryName(_currencyList[index]),
+                  stream: bloc.getCountryNameController(_currencyList[index]),
+                  builder: (context, snapshot) {
                     bloc.getCountryNameByCurrencyCode(_currencyList[index]);
-                    return Text(snapshot.data ?? "");
-                },
+                    return Text(
+                      snapshot.data ?? "",
+                      style: TextStyle(fontSize: 14 * _scale),
+                    );
+                  },
+                ),
               ),
-            ),
-            onTap: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute(
+              onTap: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
                     builder: (context) => SelectedCurrencyDetailsBlocProvider(
-                            child: SelectedCurrencyDetails(
-                          selectedCurrencyCode: _currencyList[index],
-                        ))),
-              );
-            },
-          );
-        },
-        itemCount: _currencyList.length,
+                      child: SelectedCurrencyDetails(
+                        selectedCurrencyCode: _currencyList[index],
+                      ),
+                    ),
+                  ),
+                );
+              },
+            );
+          },
+          itemCount: _currencyList.length,
+        ),
       ),
     );
   }

--- a/lib/view/pages/selected_currency_details.dart
+++ b/lib/view/pages/selected_currency_details.dart
@@ -1,91 +1,100 @@
 import 'package:cotacao_direta/providers/selected_currency_details_bloc_provider.dart';
 import 'package:cotacao_direta/util/localizations.dart';
+import 'package:cotacao_direta/util/responsive.dart';
 import 'package:flutter/material.dart';
 
 class SelectedCurrencyDetails extends StatelessWidget {
   final String selectedCurrencyCode;
 
   SelectedCurrencyDetails({Key? key, required this.selectedCurrencyCode})
-      : super(key: key);
+    : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    final Size _screenSize = MediaQuery.of(context).size;
     final localizations = MyAppLocalizations.of(context)!;
     var bloc = SelectedCurrencyDetailsBlocProvider.of(context);
+    final _contentWidth = Responsive.contentMaxWidth(context);
 
     return Scaffold(
-        floatingActionButton: FloatingActionButton.extended(
-            onPressed: () {
-              bloc.getCurrencyHistoryData(selectedCurrencyCode);
-            },
-            label: Text(localizations.getCurrencyHistoryBtnLabel!)),
-        body: Column(
-          children: [
-            Row(
-              children: [
-                Column(
-                  children: [
-                    Container(
-                      width: _screenSize.width / 2,
-                      child: Padding(
-                        padding: EdgeInsets.all(8.0),
-                        child: TextField(
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: () {
+          bloc.getCurrencyHistoryData(selectedCurrencyCode);
+        },
+        label: Text(localizations.getCurrencyHistoryBtnLabel!),
+      ),
+      body: Center(
+        child: ConstrainedBox(
+          constraints: BoxConstraints(maxWidth: _contentWidth),
+          child: Column(
+            children: [
+              Row(
+                children: [
+                  Column(
+                    children: [
+                      Container(
+                        width: _contentWidth / 2,
+                        child: Padding(
+                          padding: EdgeInsets.all(8.0),
+                          child: TextField(
                             controller: bloc.initialDateController,
                             onTap: () {
                               FocusScope.of(context).requestFocus(FocusNode());
                               showDatePicker(
-                                      context: context,
-                                      initialDate: DateTime.now(),
-                                      firstDate: DateTime(1999),
-                                      lastDate: DateTime.now())
-                                  .then((value) {
+                                context: context,
+                                initialDate: DateTime.now(),
+                                firstDate: DateTime(1999),
+                                lastDate: DateTime.now(),
+                              ).then((value) {
                                 if (value != null)
                                   bloc.updateInitialDate(value);
                               });
                             },
                             decoration: InputDecoration(
-                                border: OutlineInputBorder(),
-                                labelText: localizations
-                                    .currencyHistoryFromDateLabel)),
+                              border: OutlineInputBorder(),
+                              labelText:
+                                  localizations.currencyHistoryFromDateLabel,
+                            ),
+                          ),
+                        ),
                       ),
-                    )
-                  ],
-                ),
-                Column(
-                  children: [
-                    Container(
-                      width: _screenSize.width / 2,
-                      child: Padding(
-                        padding: EdgeInsets.all(8.0),
-                        child: TextField(
+                    ],
+                  ),
+                  Column(
+                    children: [
+                      Container(
+                        width: _contentWidth / 2,
+                        child: Padding(
+                          padding: EdgeInsets.all(8.0),
+                          child: TextField(
                             controller: bloc.endDateController,
                             onTap: () {
                               FocusScope.of(context).requestFocus(FocusNode());
                               showDatePicker(
-                                      context: context,
-                                      initialDate: DateTime.now(),
-                                      firstDate: DateTime(1999),
-                                      lastDate: DateTime.now())
-                                  .then((value) {
+                                context: context,
+                                initialDate: DateTime.now(),
+                                firstDate: DateTime(1999),
+                                lastDate: DateTime.now(),
+                              ).then((value) {
                                 if (value != null) bloc.updateFinalDate(value);
                               });
                             },
                             decoration: InputDecoration(
-                                border: OutlineInputBorder(),
-                                labelText:
-                                    localizations.currencyHistoryToDateLabel)),
+                              border: OutlineInputBorder(),
+                              labelText:
+                                  localizations.currencyHistoryToDateLabel,
+                            ),
+                          ),
+                        ),
                       ),
-                    )
-                  ],
-                )
-              ],
-            ),
-            Expanded(
+                    ],
+                  ),
+                ],
+              ),
+              Expanded(
                 child: Row(
-              children: [
-                // TODO Substitute this block with the class from another chart library
-                /*StreamBuilder<List<Series<dynamic, dynamic>>>(
+                  children: [
+                    // TODO Substitute this block with the class from another chart library
+                    /*StreamBuilder<List<Series<dynamic, dynamic>>>(
                     builder: (context, snapshot) {
                       return Expanded(
                           child: Container(
@@ -100,9 +109,13 @@ class SelectedCurrencyDetails extends StatelessWidget {
                       ));
                     },
                     stream: bloc.currencyHistoryStream)*/
-              ],
-            ))
-          ],
-        ));
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
   }
 }

--- a/lib/view/widgets/canadian_dollar_exchange_rate.dart
+++ b/lib/view/widgets/canadian_dollar_exchange_rate.dart
@@ -1,11 +1,10 @@
 import 'package:cotacao_direta/enums/currency_enum.dart';
 import 'package:cotacao_direta/providers/exchange_value_bloc_provider.dart';
+import 'package:cotacao_direta/util/responsive.dart';
 import 'package:flutter/material.dart';
 import 'exchange_rate_value.dart';
 
-class CanadianDollarExchangeRate extends StatelessWidget
-{
-
+class CanadianDollarExchangeRate extends StatelessWidget {
   final exchangeRateValue = ExchangeRateValue(Currencies.CAD);
 
   @override
@@ -14,18 +13,21 @@ class CanadianDollarExchangeRate extends StatelessWidget
       children: <Widget>[
         Column(
           children: <Widget>[
-            Text("CAD ", style: TextStyle(fontSize: 18, color: Colors.white),)
+            Text(
+              "CAD ",
+              style: TextStyle(
+                fontSize: 18 * Responsive.scaleFactor(context),
+                color: Colors.white,
+              ),
+            ),
           ],
         ),
         Column(
           children: <Widget>[
-            ExchangeValueBlocProvider(
-              child: exchangeRateValue,
-            )
+            ExchangeValueBlocProvider(child: exchangeRateValue),
           ],
-        )
+        ),
       ],
     );
   }
-
 }

--- a/lib/view/widgets/conversion_widget.dart
+++ b/lib/view/widgets/conversion_widget.dart
@@ -2,6 +2,7 @@ import 'package:cotacao_direta/blocs/conversion_page_bloc.dart';
 import 'package:cotacao_direta/enums/currency_enum.dart';
 import 'package:cotacao_direta/providers/conversion_page_bloc_provider.dart';
 import 'package:cotacao_direta/util/localizations.dart';
+import 'package:cotacao_direta/util/responsive.dart';
 import 'package:cotacao_direta/util/string_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
@@ -28,19 +29,26 @@ class ConversionWidgetState extends State<ConversionWidget> {
   @override
   Widget build(BuildContext context) {
     final _localizations = MyAppLocalizations.of(context)!;
+    final _scale = Responsive.scaleFactor(context);
 
-    return Container(
+    return Center(
+      child: ConstrainedBox(
+        constraints: BoxConstraints(
+          maxWidth: Responsive.contentMaxWidth(context),
+        ),
         child: Column(
           children: <Widget>[
             Row(
               children: <Widget>[
                 Expanded(
-                  child: Padding(padding: EdgeInsets.only(top: 16),
-                  child: Text(
-                    _localizations.conversionPageExplanationText!,
-                    style: TextStyle(fontSize: 16),
-                    textAlign: TextAlign.center,
-                  ),)
+                  child: Padding(
+                    padding: EdgeInsets.only(top: 16 * _scale),
+                    child: Text(
+                      _localizations.conversionPageExplanationText!,
+                      style: TextStyle(fontSize: 16 * _scale),
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
                 ),
               ],
             ),
@@ -48,23 +56,25 @@ class ConversionWidgetState extends State<ConversionWidget> {
               mainAxisAlignment: MainAxisAlignment.center,
               children: <Widget>[
                 Padding(
-                  padding: EdgeInsets.only(top: 120),
+                  padding: EdgeInsets.only(top: 120 * _scale),
                   child: Container(
-                      width: 120,
-                      child: StreamBuilder(
-                        initialData: 1,
-                        stream: bloc.multiplierStream,
-                        builder: (context, snapshot) => TextField(
-                          decoration: InputDecoration(
-                              border: OutlineInputBorder(),
-                              labelText: _localizations.conversionMultiplierHint),
-                          keyboardType: TextInputType.number,
-                          onChanged: (value) {
-                            bloc.updateMultiplierValue(double.parse(value));
-                          },
+                    width: 120 * _scale,
+                    child: StreamBuilder(
+                      initialData: 1,
+                      stream: bloc.multiplierStream,
+                      builder: (context, snapshot) => TextField(
+                        decoration: InputDecoration(
+                          border: OutlineInputBorder(),
+                          labelText: _localizations.conversionMultiplierHint,
                         ),
-                      )),
-                )
+                        keyboardType: TextInputType.number,
+                        onChanged: (value) {
+                          bloc.updateMultiplierValue(double.parse(value));
+                        },
+                      ),
+                    ),
+                  ),
+                ),
               ],
             ),
             Row(
@@ -81,31 +91,35 @@ class ConversionWidgetState extends State<ConversionWidget> {
                           items: Currencies.values.map((value) {
                             return DropdownMenuItem(
                               value: value,
-                              child: Text(EnumValueAsString()
-                                  .getEnumValue(value.toString())),
+                              child: Text(
+                                EnumValueAsString().getEnumValue(
+                                  value.toString(),
+                                ),
+                              ),
                             );
                           }).toList(),
                           onChanged: (dynamic value) {
                             bloc.updateFromCurrency(value);
                           },
                           icon: Icon(Icons.arrow_downward),
-                          iconSize: 24,
+                          iconSize: 24 * _scale,
                           elevation: 16,
                           value: snapshot.data,
                         );
                       },
-                    )
+                    ),
                   ],
                 ),
                 Padding(
-                  padding: EdgeInsets.symmetric(horizontal: 8),
+                  padding: EdgeInsets.symmetric(horizontal: 8 * _scale),
                   child: Column(
                     mainAxisAlignment: MainAxisAlignment.center,
                     children: <Widget>[
                       Icon(
                         Icons.arrow_forward,
                         color: Colors.grey,
-                      )
+                        size: 24 * _scale,
+                      ),
                     ],
                   ),
                 ),
@@ -120,15 +134,18 @@ class ConversionWidgetState extends State<ConversionWidget> {
                           items: Currencies.values.map((value) {
                             return DropdownMenuItem(
                               value: value,
-                              child: Text(EnumValueAsString()
-                                  .getEnumValue(value.toString())),
+                              child: Text(
+                                EnumValueAsString().getEnumValue(
+                                  value.toString(),
+                                ),
+                              ),
                             );
                           }).toList(),
                           onChanged: (dynamic value) {
                             bloc.updateToCurrency(value);
                           },
                           icon: Icon(Icons.arrow_downward),
-                          iconSize: 24,
+                          iconSize: 24 * _scale,
                           elevation: 16,
                           value: snapshot.data,
                         );
@@ -142,43 +159,42 @@ class ConversionWidgetState extends State<ConversionWidget> {
                       icon: Icon(
                         Icons.repeat,
                         color: Theme.of(context).colorScheme.secondary,
+                        size: 24 * _scale,
                       ),
                       onPressed: () {
                         bloc.switchCurrencies();
                       },
-                    )
+                    ),
                   ],
-                )
+                ),
               ],
             ),
             Row(
               mainAxisAlignment: MainAxisAlignment.center,
               children: <Widget>[
                 Padding(
-                  padding: EdgeInsets.symmetric(
-                    horizontal: 8,
-                  ),
+                  padding: EdgeInsets.symmetric(horizontal: 8 * _scale),
                   child: Column(
                     mainAxisAlignment: MainAxisAlignment.center,
                     children: <Widget>[
-                      Text(
-                        "=",
-                        style: TextStyle(fontSize: 32),
-                      )
+                      Text("=", style: TextStyle(fontSize: 32 * _scale)),
                     ],
                   ),
                 ),
                 Padding(
-                  padding: EdgeInsets.symmetric(horizontal: 8),
+                  padding: EdgeInsets.symmetric(horizontal: 8 * _scale),
                   child: Column(
                     children: <Widget>[
                       StreamBuilder(
                         stream: bloc.currencyLabelStream,
                         initialData: "",
                         builder: (context, snapshot) {
-                          return Text(snapshot.data.toString());
+                          return Text(
+                            snapshot.data.toString(),
+                            style: TextStyle(fontSize: 16 * _scale),
+                          );
                         },
-                      )
+                      ),
                     ],
                   ),
                 ),
@@ -192,14 +208,16 @@ class ConversionWidgetState extends State<ConversionWidget> {
                         snapshot.data == null
                             ? _localizations.noDataLabel!
                             : _formatter.format(snapshot.data),
-                        style: TextStyle(fontSize: 18),
+                        style: TextStyle(fontSize: 18 * _scale),
                       ),
-                    )
+                    ),
                   ],
-                )
+                ),
               ],
-            )
+            ),
           ],
-        ));
+        ),
+      ),
+    );
   }
 }

--- a/lib/view/widgets/dollar_exchange_rate.dart
+++ b/lib/view/widgets/dollar_exchange_rate.dart
@@ -1,5 +1,6 @@
 import 'package:cotacao_direta/enums/currency_enum.dart';
 import 'package:cotacao_direta/providers/exchange_value_bloc_provider.dart';
+import 'package:cotacao_direta/util/responsive.dart';
 import 'package:cotacao_direta/view/widgets/exchange_rate_value.dart';
 import 'package:flutter/material.dart';
 
@@ -14,17 +15,18 @@ class DollarExchangeRate extends StatelessWidget {
           children: <Widget>[
             Text(
               "USD ",
-              style: TextStyle(fontSize: 18, color: Colors.white),
-            )
+              style: TextStyle(
+                fontSize: 18 * Responsive.scaleFactor(context),
+                color: Colors.white,
+              ),
+            ),
           ],
         ),
         Column(
           children: <Widget>[
-            ExchangeValueBlocProvider(
-              child: exchangeRateValue,
-            )
+            ExchangeValueBlocProvider(child: exchangeRateValue),
           ],
-        )
+        ),
       ],
     );
   }

--- a/lib/view/widgets/euro_exchange_rate.dart
+++ b/lib/view/widgets/euro_exchange_rate.dart
@@ -1,10 +1,10 @@
 import 'package:cotacao_direta/enums/currency_enum.dart';
 import 'package:cotacao_direta/providers/exchange_value_bloc_provider.dart';
+import 'package:cotacao_direta/util/responsive.dart';
 import 'package:cotacao_direta/view/widgets/exchange_rate_value.dart';
 import 'package:flutter/material.dart';
 
-class EuroExchangeRate extends StatelessWidget{
-
+class EuroExchangeRate extends StatelessWidget {
   final exchangeRateValue = ExchangeRateValue(Currencies.EUR);
 
   @override
@@ -13,16 +13,20 @@ class EuroExchangeRate extends StatelessWidget{
       children: <Widget>[
         Column(
           children: <Widget>[
-            Text("EUR ", style: TextStyle(fontSize: 18, color: Colors.white),)
+            Text(
+              "EUR ",
+              style: TextStyle(
+                fontSize: 18 * Responsive.scaleFactor(context),
+                color: Colors.white,
+              ),
+            ),
           ],
         ),
         Column(
           children: <Widget>[
-            ExchangeValueBlocProvider(
-              child: exchangeRateValue,
-            )
+            ExchangeValueBlocProvider(child: exchangeRateValue),
           ],
-        )
+        ),
       ],
     );
   }

--- a/lib/view/widgets/exchange_rate_value.dart
+++ b/lib/view/widgets/exchange_rate_value.dart
@@ -3,6 +3,7 @@ import 'package:cotacao_direta/enums/currency_enum.dart';
 import 'package:cotacao_direta/notifications/update_currency_value_notification.dart';
 import 'package:cotacao_direta/providers/exchange_value_bloc_provider.dart';
 import 'package:cotacao_direta/util/localizations.dart';
+import 'package:cotacao_direta/util/responsive.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
@@ -29,20 +30,23 @@ class ExchangeRateValueState extends State<ExchangeRateValue> {
   @override
   void didChangeDependencies() {
     bloc = ExchangeValueBlocProvider.of(context);
-    bloc.retrieveCurrencyValue(_currency).then((value) {
-      bloc.updateValue(value);
-    }).onError(
-      (error, stackTrace) {
-        print(error.toString());
-      },
-    );
+    bloc
+        .retrieveCurrencyValue(_currency)
+        .then((value) {
+          bloc.updateValue(value);
+        })
+        .onError((error, stackTrace) {
+          print(error.toString());
+        });
     super.didChangeDependencies();
   }
 
   /// Enquanto a cotação não chega, o texto fica vazio; se ela não existir,
   /// mostramos "Sem Dados" em vez de um número inventado.
   String _exchangeRateLabel(
-      BuildContext context, AsyncSnapshot<num?> snapshot) {
+    BuildContext context,
+    AsyncSnapshot<num?> snapshot,
+  ) {
     if (snapshot.connectionState == ConnectionState.waiting) return "";
     var value = snapshot.data;
     if (value == null || value == 0) {
@@ -54,17 +58,21 @@ class ExchangeRateValueState extends State<ExchangeRateValue> {
   @override
   Widget build(BuildContext context) {
     return StreamBuilder<num?>(
-        stream: bloc.getNextStreamController(),
-        builder: (context, snapshot) =>
-            NotificationListener<UpdateCurrencyValueNotification>(
-              onNotification: (UpdateCurrencyValueNotification notification) {
-                didChangeDependencies();
-                return true;
-              },
-              child: Text(
-                _exchangeRateLabel(context, snapshot),
-                style: TextStyle(fontSize: 18, color: Colors.white),
+      stream: bloc.getNextStreamController(),
+      builder: (context, snapshot) =>
+          NotificationListener<UpdateCurrencyValueNotification>(
+            onNotification: (UpdateCurrencyValueNotification notification) {
+              didChangeDependencies();
+              return true;
+            },
+            child: Text(
+              _exchangeRateLabel(context, snapshot),
+              style: TextStyle(
+                fontSize: 18 * Responsive.scaleFactor(context),
+                color: Colors.white,
               ),
-            ));
+            ),
+          ),
+    );
   }
 }

--- a/lib/view/widgets/yen_exchange_rate.dart
+++ b/lib/view/widgets/yen_exchange_rate.dart
@@ -1,11 +1,10 @@
 import 'package:cotacao_direta/enums/currency_enum.dart';
 import 'package:cotacao_direta/providers/exchange_value_bloc_provider.dart';
+import 'package:cotacao_direta/util/responsive.dart';
 import 'package:cotacao_direta/view/widgets/exchange_rate_value.dart';
 import 'package:flutter/material.dart';
 
-class YenExchangeRate extends StatelessWidget
-{
-
+class YenExchangeRate extends StatelessWidget {
   final exchangeRateValue = ExchangeRateValue(Currencies.JPY);
 
   @override
@@ -14,18 +13,21 @@ class YenExchangeRate extends StatelessWidget
       children: <Widget>[
         Column(
           children: <Widget>[
-            Text("JPY ", style: TextStyle(fontSize: 18, color: Colors.white),)
+            Text(
+              "JPY ",
+              style: TextStyle(
+                fontSize: 18 * Responsive.scaleFactor(context),
+                color: Colors.white,
+              ),
+            ),
           ],
         ),
         Column(
           children: <Widget>[
-            ExchangeValueBlocProvider(
-              child: exchangeRateValue,
-            )
+            ExchangeValueBlocProvider(child: exchangeRateValue),
           ],
-        )
+        ),
       ],
     );
   }
-
 }


### PR DESCRIPTION
## Summary
- Em telas grandes (desktop), os tamanhos fixos (fontes, paddings, círculos das cotações) pensados para celular ficavam desproporcionalmente pequenos.
- Adiciona `lib/util/responsive.dart`, um helper `Responsive` com fator de escala baseado nos breakpoints do Material 3 (compact <600px, medium >=600px = 1.35x, expanded >=840px = 1.8x).
- Aplica o fator de escala em todas as views: home (círculos e cabeçalho), widgets de cotação (USD/EUR/CAD/JPY), tela de conversão, histórico de moedas, configurações e detalhes da moeda selecionada.
- Centraliza formulários/listas com largura máxima (`Responsive.contentMaxWidth`) em telas expandidas, evitando que fiquem esticados de ponta a ponta.

## Test plan
- [x] `dart analyze lib` — sem erros.
- [x] `dart format` — arquivos alterados formatados sem quebra de sintaxe.
- [x] `flutter build linux --debug` — build concluído com sucesso.
- [x] Executado o binário Linux (`build/linux/x64/debug/bundle/cotacao_direta`) — processo sobe sem crashes.
- [ ] Verificação visual do redimensionamento em janela desktop (recomendado antes do merge, não foi possível capturar screenshot neste ambiente).

🤖 Generated with [Claude Code](https://claude.com/claude-code)