### PR TITLE
Adiciona bandeiras à lista de moedas no histórico

### DIFF
--- a/lib/util/currency_flag.dart
+++ b/lib/util/currency_flag.dart
@@ -1,0 +1,52 @@
+import 'package:cotacao_direta/enums/currency_enum.dart';
+import 'package:flag/flag.dart';
+
+/// Código de bandeira (ISO 3166-1 alpha-2) usado pelo pacote `flag` para cada
+/// moeda. A maior parte das moedas usa as duas primeiras letras do próprio
+/// código ISO 4217 (ex.: BRL -> BR); o Euro é a exceção, mapeado para a
+/// bandeira da União Europeia.
+///
+/// Usamos imagens de bandeira em vez do emoji Unicode porque a maioria das
+/// distribuições Linux não tem fonte com suporte aos glifos de bandeira,
+/// mostrando um ícone genérico no lugar.
+const Map<Currencies, FlagsCode> _flagCodeByCurrency = {
+  Currencies.AUD: FlagsCode.AU,
+  Currencies.BRL: FlagsCode.BR,
+  Currencies.CAD: FlagsCode.CA,
+  Currencies.CZK: FlagsCode.CZ,
+  Currencies.DKK: FlagsCode.DK,
+  Currencies.EUR: FlagsCode.EU,
+  Currencies.GBP: FlagsCode.GB,
+  Currencies.HKD: FlagsCode.HK,
+  Currencies.IDR: FlagsCode.ID,
+  Currencies.ILS: FlagsCode.IL,
+  Currencies.INR: FlagsCode.IN,
+  Currencies.ISK: FlagsCode.IS,
+  Currencies.JPY: FlagsCode.JP,
+  Currencies.USD: FlagsCode.US,
+  Currencies.PHP: FlagsCode.PH,
+  Currencies.HUF: FlagsCode.HU,
+  Currencies.RON: FlagsCode.RO,
+  Currencies.SEK: FlagsCode.SE,
+  Currencies.RUB: FlagsCode.RU,
+  Currencies.HRK: FlagsCode.HR,
+  Currencies.THB: FlagsCode.TH,
+  Currencies.CHF: FlagsCode.CH,
+  Currencies.MYR: FlagsCode.MY,
+  Currencies.BGN: FlagsCode.BG,
+  Currencies.TRY: FlagsCode.TR,
+  Currencies.CNY: FlagsCode.CN,
+  Currencies.NOK: FlagsCode.NO,
+  Currencies.NZD: FlagsCode.NZ,
+  Currencies.ZAR: FlagsCode.ZA,
+  Currencies.MXN: FlagsCode.MX,
+  Currencies.SGD: FlagsCode.SG,
+  Currencies.KRW: FlagsCode.KR,
+  Currencies.PLN: FlagsCode.PL,
+};
+
+/// Código de bandeira correspondente à moeda informada, para uso com o
+/// widget `Flag.fromCode` do pacote `flag`.
+FlagsCode flagCodeForCurrency(Currencies currency) {
+  return _flagCodeByCurrency[currency]!;
+}

--- a/lib/view/pages/main_menu_items/currency_history_menu.dart
+++ b/lib/view/pages/main_menu_items/currency_history_menu.dart
@@ -1,9 +1,11 @@
 import 'package:cotacao_direta/enums/currency_enum.dart';
 import 'package:cotacao_direta/providers/currency_history_menu_bloc_provider.dart';
 import 'package:cotacao_direta/providers/selected_currency_details_bloc_provider.dart';
+import 'package:cotacao_direta/util/currency_flag.dart';
 import 'package:cotacao_direta/util/responsive.dart';
 import 'package:cotacao_direta/util/string_utils.dart';
 import 'package:cotacao_direta/view/pages/selected_currency_details.dart';
+import 'package:flag/flag.dart';
 import 'package:flutter/material.dart';
 
 class CurrencyHistory extends StatelessWidget {
@@ -20,48 +22,52 @@ class CurrencyHistory extends StatelessWidget {
 
     bloc.initStreamControllers(_currencyList);
 
-    return Center(
-      child: ConstrainedBox(
-        constraints: BoxConstraints(
-          maxWidth: Responsive.contentMaxWidth(context),
-        ),
-        child: ListView.builder(
-          itemBuilder: (BuildContext context, index) {
-            return GestureDetector(
-              child: ListTile(
-                title: Text(
+    return ListView.builder(
+      itemBuilder: (BuildContext context, index) {
+        return GestureDetector(
+          child: ListTile(
+            title: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                Text(
                   _currencyList[index],
                   style: TextStyle(fontSize: 16 * _scale),
                 ),
-                subtitle: StreamBuilder<String?>(
-                  initialData: bloc.cachedCountryName(_currencyList[index]),
-                  stream: bloc.getCountryNameController(_currencyList[index]),
-                  builder: (context, snapshot) {
-                    bloc.getCountryNameByCurrencyCode(_currencyList[index]);
-                    return Text(
-                      snapshot.data ?? "",
-                      style: TextStyle(fontSize: 14 * _scale),
-                    );
-                  },
+                Flag.fromCode(
+                  flagCodeForCurrency(Currencies.values[index]),
+                  height: 24 * _scale,
+                  width: 32 * _scale,
                 ),
-              ),
-              onTap: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (context) => SelectedCurrencyDetailsBlocProvider(
-                      child: SelectedCurrencyDetails(
-                        selectedCurrencyCode: _currencyList[index],
-                      ),
-                    ),
-                  ),
+              ],
+            ),
+            subtitle: StreamBuilder<String?>(
+              initialData: bloc.cachedCountryName(_currencyList[index]),
+              stream: bloc.getCountryNameController(_currencyList[index]),
+              builder: (context, snapshot) {
+                bloc.getCountryNameByCurrencyCode(_currencyList[index]);
+                return Text(
+                  snapshot.data ?? "",
+                  style: TextStyle(fontSize: 14 * _scale),
                 );
               },
+            ),
+          ),
+          onTap: () {
+            Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (context) => SelectedCurrencyDetailsBlocProvider(
+                  child: SelectedCurrencyDetails(
+                    selectedCurrencyCode: _currencyList[index],
+                  ),
+                ),
+              ),
             );
           },
-          itemCount: _currencyList.length,
-        ),
-      ),
+        );
+      },
+      itemCount: _currencyList.length,
     );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -97,6 +97,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.9"
+  enum_to_string:
+    dependency: transitive
+    description:
+      name: enum_to_string
+      sha256: "93b75963d3b0c9f6a90c095b3af153e1feccb79f6f08282d3274ff8d9eea52bc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
   fake_async:
     dependency: transitive
     description:
@@ -121,6 +129,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  flag:
+    dependency: "direct main"
+    description:
+      name: flag
+      sha256: "69e3e1d47453349ef72e2ebf4234b88024c0d57f9bcfaa7cc7facec49cd8561f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.2"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -139,6 +155,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_svg:
+    dependency: transitive
+    description:
+      name: flutter_svg
+      sha256: "35882981abcbfb8c15b286f0cd690ff25bac12d95eff3e25ee207f37d4c42e7f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -272,6 +296,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  path_parsing:
+    dependency: transitive
+    description:
+      name: path_parsing
+      sha256: "883402936929eac138ee0a45da5b0f2c80f89913e6dc3bf77eb65b84b409c6ca"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   petitparser:
     dependency: transitive
     description:
@@ -453,6 +485,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  vector_graphics:
+    dependency: transitive
+    description:
+      name: vector_graphics
+      sha256: "2306c03da2ba81724afeb589c351ebbc0aa7d86005925be8f8735856dbe5e42d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.2"
+  vector_graphics_codec:
+    dependency: transitive
+    description:
+      name: vector_graphics_codec
+      sha256: "99fd9fbd34d9f9a32efd7b6a6aae14125d8237b10403b422a6a6dfeac2806146"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.13"
+  vector_graphics_compiler:
+    dependency: transitive
+    description:
+      name: vector_graphics_compiler
+      sha256: "142a9146f447d15b10bdc00e21d5f4d83e5b32bb5f8f8f5a04c75311344923a3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.6"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   # sqflite não tem implementação para desktop; no Linux o databaseFactory é
   # trocado para o sqflite_common_ffi (SQLite nativo) em tempo de execução.
   sqflite_common_ffi: ^2.3.3
+  flag: ^7.0.2
 
 dev_dependencies:
   flutter_launcher_icons: ^0.14.4


### PR DESCRIPTION
## Summary
- Mostra a bandeira do país após o código da moeda na tela de histórico, usando o pacote `flag`
- Organiza código e bandeira em um `Row` com `MainAxisAlignment.spaceBetween` e alinhamento vertical centralizado
- Remove a largura máxima da `ListView`, fazendo a lista ocupar todo o espaço horizontal disponível

## Test plan
- [ ] Rodar o app e verificar a tela de histórico de moedas em tela pequena e grande
- [ ] Confirmar que a bandeira aparece corretamente para cada moeda
- [ ] Confirmar que código e bandeira ficam alinhados verticalmente e distribuídos nas extremidades

🤖 Generated with [Claude Code](https://claude.com/claude-code)