### PR TITLE
Adiciona separador visual no histórico e AppBar com voltar no filtro de datas

### DIFF
--- a/lib/view/pages/main_menu_items/currency_history_menu.dart
+++ b/lib/view/pages/main_menu_items/currency_history_menu.dart
@@ -22,7 +22,10 @@ class CurrencyHistory extends StatelessWidget {
 
     bloc.initStreamControllers(_currencyList);
 
-    return ListView.builder(
+    return ListView.separated(
+      separatorBuilder: (BuildContext context, index) {
+        return const Divider(height: 1, thickness: 1);
+      },
       itemBuilder: (BuildContext context, index) {
         return GestureDetector(
           child: ListTile(

--- a/lib/view/pages/selected_currency_details.dart
+++ b/lib/view/pages/selected_currency_details.dart
@@ -16,6 +16,7 @@ class SelectedCurrencyDetails extends StatelessWidget {
     final _contentWidth = Responsive.contentMaxWidth(context);
 
     return Scaffold(
+      appBar: AppBar(title: Text(selectedCurrencyCode)),
       floatingActionButton: FloatingActionButton.extended(
         onPressed: () {
           bloc.getCurrencyHistoryData(selectedCurrencyCode);


### PR DESCRIPTION
## Summary
- Adiciona um `Divider` entre cada linha da lista de moedas na tela de histórico (`currency_history_menu.dart`), usando `ListView.separated` como separador visual.
- Adiciona uma `AppBar` (com o código da moeda como título) na tela de filtro de datas do histórico, exibida ao tocar em uma moeda (`selected_currency_details.dart`). O botão de voltar é adicionado automaticamente pelo `Scaffold` por ser uma rota que pode ser desempilhada.

## Test plan
- [ ] Rodar o app e abrir a tela de Histórico, conferir se aparece um separador entre cada moeda da lista
- [ ] Tocar em uma moeda e conferir se a AppBar aparece com o botão de voltar funcionando

🤖 Generated with [Claude Code](https://claude.com/claude-code)