### PR TITLE
Completa a tela de Sobre da aplicação

### DIFF
--- a/lib/util/localizations.dart
+++ b/lib/util/localizations.dart
@@ -29,7 +29,12 @@ class MyAppLocalizations {
       'noDataLabel': 'No Data',
       'getCurrencyHistoryBtnLabel': 'Get history',
       'overrideDefaultCurrencySwitchLabel': 'Override default currency',
-      'appConfigurationsSectionLabel': 'App Configurations'
+      'appConfigurationsSectionLabel': 'App Configurations',
+      'aboutAppDescription': 'A simple app that shows the exchange rate of '
+          'the main currencies against the Brazilian real.',
+      'aboutVersionLabel': 'Version',
+      'aboutDeveloperLabel': 'Developed by',
+      'aboutSourceCodeLabel': 'Source code',
     },
     'pt': {
       'conversionButtonLabel': "Conversões",
@@ -49,7 +54,12 @@ class MyAppLocalizations {
       'noDataLabel': 'Sem Dados',
       'getCurrencyHistoryBtnLabel': 'Obter histórico',
       'overrideDefaultCurrencySwitchLabel': 'Sobrescrever moeda padrão',
-      'appConfigurationsSectionLabel': 'Configurações do Aplicativo'
+      'appConfigurationsSectionLabel': 'Configurações do Aplicativo',
+      'aboutAppDescription': 'Um aplicativo simples que mostra a cotação das '
+          'principais moedas frente ao real.',
+      'aboutVersionLabel': 'Versão',
+      'aboutDeveloperLabel': 'Desenvolvido por',
+      'aboutSourceCodeLabel': 'Código fonte',
     }
   };
 
@@ -121,6 +131,22 @@ class MyAppLocalizations {
   String? get appConfigurationsSectionLabel {
     return _localizedValues[locale.languageCode]!
         ['appConfigurationsSectionLabel'];
+  }
+
+  String? get aboutAppDescription {
+    return _localizedValues[locale.languageCode]!['aboutAppDescription'];
+  }
+
+  String? get aboutVersionLabel {
+    return _localizedValues[locale.languageCode]!['aboutVersionLabel'];
+  }
+
+  String? get aboutDeveloperLabel {
+    return _localizedValues[locale.languageCode]!['aboutDeveloperLabel'];
+  }
+
+  String? get aboutSourceCodeLabel {
+    return _localizedValues[locale.languageCode]!['aboutSourceCodeLabel'];
   }
 }
 

--- a/lib/view/pages/home.dart
+++ b/lib/view/pages/home.dart
@@ -7,6 +7,7 @@ import 'package:cotacao_direta/providers/home_bloc_provider.dart';
 import 'package:cotacao_direta/util/localizations.dart';
 import 'package:cotacao_direta/util/responsive.dart';
 import 'package:cotacao_direta/view/pages/conversion_page.dart';
+import 'package:cotacao_direta/view/pages/main_menu_items/about_page.dart';
 import 'package:cotacao_direta/view/pages/main_menu_items/configurations_page.dart';
 import 'package:cotacao_direta/view/widgets/canadian_dollar_exchange_rate.dart';
 import 'package:cotacao_direta/view/widgets/dollar_exchange_rate.dart';
@@ -220,7 +221,7 @@ class HomeState extends State<Home> {
       Container(
         child: ConfigurationsPageBlocProvider(child: ConfigurationsPage()),
       ),
-      Container(child: Text("sobre")),
+      Container(child: AboutPage()),
     ];
     return Scaffold(
       appBar: AppBar(title: Text(_pageTitle)),

--- a/lib/view/pages/main_menu_items/about_page.dart
+++ b/lib/view/pages/main_menu_items/about_page.dart
@@ -1,0 +1,72 @@
+import 'package:cotacao_direta/util/localizations.dart';
+import 'package:cotacao_direta/util/responsive.dart';
+import 'package:flutter/material.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+class AboutPage extends StatelessWidget {
+  static const String _sourceCodeUrl =
+      'https://github.com/hhldiniz/cotacao_direta';
+
+  @override
+  Widget build(BuildContext context) {
+    final localization = MyAppLocalizations.of(context)!;
+    final scale = Responsive.scaleFactor(context);
+
+    return Center(
+      child: ConstrainedBox(
+        constraints: BoxConstraints(maxWidth: Responsive.contentMaxWidth(context)),
+        child: SingleChildScrollView(
+          padding: EdgeInsets.all(24.0 * scale),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(Icons.attach_money, size: 72 * scale, color: Colors.amber),
+              SizedBox(height: 16 * scale),
+              Text(
+                'Cotação Direta',
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  fontSize: 24 * scale,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              SizedBox(height: 8 * scale),
+              FutureBuilder<PackageInfo>(
+                future: PackageInfo.fromPlatform(),
+                builder: (context, snapshot) {
+                  final info = snapshot.data;
+                  final version = info == null
+                      ? ''
+                      : '${info.version}+${info.buildNumber}';
+                  return Text(
+                    '${localization.aboutVersionLabel} $version',
+                    textAlign: TextAlign.center,
+                    style: TextStyle(fontSize: 14 * scale),
+                  );
+                },
+              ),
+              SizedBox(height: 24 * scale),
+              Text(
+                localization.aboutAppDescription!,
+                textAlign: TextAlign.center,
+                style: TextStyle(fontSize: 16 * scale),
+              ),
+              SizedBox(height: 24 * scale),
+              Text(
+                '${localization.aboutDeveloperLabel} hhldiniz',
+                textAlign: TextAlign.center,
+                style: TextStyle(fontSize: 14 * scale),
+              ),
+              SizedBox(height: 8 * scale),
+              Text(
+                '${localization.aboutSourceCodeLabel}: $_sourceCodeUrl',
+                textAlign: TextAlign.center,
+                style: TextStyle(fontSize: 14 * scale),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -168,6 +168,11 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   glob:
     dependency: transitive
     description:
@@ -288,6 +293,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.19.2"
+  package_info_plus:
+    dependency: "direct main"
+    description:
+      name: package_info_plus
+      sha256: "16eee997588c60225bda0488b6dcfac69280a6b7a3cf02c741895dd370a02968"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.3.1"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: "202a487f08836a592a6bd4f901ac69b3a8f146af552bbd14407b6b41e1c3f086"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.1"
   path:
     dependency: "direct main"
     description:
@@ -533,6 +554,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      sha256: d7cb55e04cd34096cd3a79b3330245f54cb96a370a1c27adb3c84b917de8b08e
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.15.0"
   xml:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,6 +23,7 @@ dependencies:
   # trocado para o sqflite_common_ffi (SQLite nativo) em tempo de execução.
   sqflite_common_ffi: ^2.3.3
   flag: ^7.0.2
+  package_info_plus: ^8.1.2
 
 dev_dependencies:
   flutter_launcher_icons: ^0.14.4

--- a/test/util/localizations_test.dart
+++ b/test/util/localizations_test.dart
@@ -22,6 +22,10 @@ List<String?> _allLabels(MyAppLocalizations localizations) => [
       localizations.getConfigBottomNavItemLabel,
       localizations.overrideDefaultCurrencySwitchLabel,
       localizations.appConfigurationsSectionLabel,
+      localizations.aboutAppDescription,
+      localizations.aboutVersionLabel,
+      localizations.aboutDeveloperLabel,
+      localizations.aboutSourceCodeLabel,
     ];
 
 void main() {


### PR DESCRIPTION
## Summary
- Substitui o placeholder `Text("sobre")` por uma tela real (`about_page.dart`): ícone, nome do app, versão (lida dinamicamente via `package_info_plus`), descrição, desenvolvedor e link do repositório.
- Adiciona a dependência `package_info_plus: ^8.1.2` ao `pubspec.yaml`.
- Adiciona as traduções pt/en (`aboutAppDescription`, `aboutVersionLabel`, `aboutDeveloperLabel`, `aboutSourceCodeLabel`) em `localizations.dart` e as cobre no teste existente de `os dois idiomas têm todos os textos preenchidos`.

## Test plan
- [x] `flutter analyze` sem problemas
- [x] `flutter test` — todos os 182 testes passando
- [ ] Abrir a aba "Sobre" no app e conferir visualmente o layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)