### PR TITLE
Adiciona animações de entrada nos círculos e na lista de histórico

### DIFF
--- a/lib/view/pages/home.dart
+++ b/lib/view/pages/home.dart
@@ -27,7 +27,7 @@ class Home extends StatefulWidget {
   State<StatefulWidget> createState() => HomeState(_pageTitle);
 }
 
-class HomeState extends State<Home> {
+class HomeState extends State<Home> with SingleTickerProviderStateMixin {
   final dollarExchangeRate = DollarExchangeRate();
   final euroExchangeRate = EuroExchangeRate();
   final canadianDollarExchangeRate = CanadianDollarExchangeRate();
@@ -39,7 +39,58 @@ class HomeState extends State<Home> {
 
   var fabVisibility = true;
 
+  late final AnimationController _circlesAnimationController;
+  late final List<Animation<double>> _circleScaleAnimations;
+  late final List<Animation<double>> _circleFadeAnimations;
+
   HomeState(this._pageTitle);
+
+  @override
+  void initState() {
+    super.initState();
+    _circlesAnimationController = AnimationController(
+      vsync: this,
+      duration: Duration(milliseconds: 900),
+    );
+    final ranges = List.generate(4, (index) {
+      final start = index * 0.15;
+      final end = (start + 0.6).clamp(0.0, 1.0);
+      return (start: start, end: end);
+    });
+    _circleScaleAnimations = ranges
+        .map(
+          (range) => CurvedAnimation(
+            parent: _circlesAnimationController,
+            curve: Interval(range.start, range.end, curve: Curves.easeOutBack),
+          ),
+        )
+        .toList();
+    _circleFadeAnimations = ranges
+        .map(
+          (range) => CurvedAnimation(
+            parent: _circlesAnimationController,
+            curve: Interval(range.start, range.end, curve: Curves.easeOut),
+          ),
+        )
+        .toList();
+    _circlesAnimationController.forward();
+  }
+
+  @override
+  void dispose() {
+    _circlesAnimationController.dispose();
+    super.dispose();
+  }
+
+  Widget _animatedCircle(int index, Widget circle) {
+    return ScaleTransition(
+      scale: _circleScaleAnimations[index],
+      child: FadeTransition(
+        opacity: _circleFadeAnimations[index],
+        child: circle,
+      ),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -89,25 +140,31 @@ class HomeState extends State<Home> {
                     children: <Widget>[
                       Column(
                         children: <Widget>[
-                          Container(
-                            padding: EdgeInsets.all(40.0 * _scale),
-                            decoration: BoxDecoration(
-                              shape: BoxShape.circle,
-                              color: Colors.amber,
+                          _animatedCircle(
+                            0,
+                            Container(
+                              padding: EdgeInsets.all(40.0 * _scale),
+                              decoration: BoxDecoration(
+                                shape: BoxShape.circle,
+                                color: Colors.amber,
+                              ),
+                              child: dollarExchangeRate,
                             ),
-                            child: dollarExchangeRate,
                           ),
                         ],
                       ),
                       Column(
                         children: <Widget>[
-                          Container(
-                            padding: EdgeInsets.all(40.0 * _scale),
-                            decoration: BoxDecoration(
-                              shape: BoxShape.circle,
-                              color: Colors.blueAccent,
+                          _animatedCircle(
+                            1,
+                            Container(
+                              padding: EdgeInsets.all(40.0 * _scale),
+                              decoration: BoxDecoration(
+                                shape: BoxShape.circle,
+                                color: Colors.blueAccent,
+                              ),
+                              child: euroExchangeRate,
                             ),
-                            child: euroExchangeRate,
                           ),
                         ],
                       ),
@@ -118,13 +175,16 @@ class HomeState extends State<Home> {
                     children: <Widget>[
                       Column(
                         children: <Widget>[
-                          Container(
-                            padding: EdgeInsets.all(60.0 * _scale),
-                            decoration: BoxDecoration(
-                              shape: BoxShape.circle,
-                              color: Colors.deepOrange,
+                          _animatedCircle(
+                            2,
+                            Container(
+                              padding: EdgeInsets.all(60.0 * _scale),
+                              decoration: BoxDecoration(
+                                shape: BoxShape.circle,
+                                color: Colors.deepOrange,
+                              ),
+                              child: canadianDollarExchangeRate,
                             ),
-                            child: canadianDollarExchangeRate,
                           ),
                         ],
                       ),
@@ -133,13 +193,16 @@ class HomeState extends State<Home> {
                   Row(
                     mainAxisAlignment: MainAxisAlignment.center,
                     children: <Widget>[
-                      Container(
-                        padding: EdgeInsets.all(33.0 * _scale),
-                        decoration: BoxDecoration(
-                          shape: BoxShape.circle,
-                          color: Colors.pink,
+                      _animatedCircle(
+                        3,
+                        Container(
+                          padding: EdgeInsets.all(33.0 * _scale),
+                          decoration: BoxDecoration(
+                            shape: BoxShape.circle,
+                            color: Colors.pink,
+                          ),
+                          child: yenExchangeRate,
                         ),
-                        child: yenExchangeRate,
                       ),
                     ],
                   ),
@@ -158,13 +221,16 @@ class HomeState extends State<Home> {
                     children: <Widget>[
                       Column(
                         children: <Widget>[
-                          Container(
-                            padding: EdgeInsets.all(40.0 * _scale),
-                            decoration: BoxDecoration(
-                              shape: BoxShape.circle,
-                              color: Colors.amber,
+                          _animatedCircle(
+                            0,
+                            Container(
+                              padding: EdgeInsets.all(40.0 * _scale),
+                              decoration: BoxDecoration(
+                                shape: BoxShape.circle,
+                                color: Colors.amber,
+                              ),
+                              child: dollarExchangeRate,
                             ),
-                            child: dollarExchangeRate,
                           ),
                         ],
                       ),
@@ -172,26 +238,32 @@ class HomeState extends State<Home> {
                         children: <Widget>[
                           Padding(
                             padding: EdgeInsets.only(top: 100.0 * _scale),
-                            child: Container(
-                              padding: EdgeInsets.all(40.0 * _scale),
-                              decoration: BoxDecoration(
-                                shape: BoxShape.circle,
-                                color: Colors.blueAccent,
+                            child: _animatedCircle(
+                              1,
+                              Container(
+                                padding: EdgeInsets.all(40.0 * _scale),
+                                decoration: BoxDecoration(
+                                  shape: BoxShape.circle,
+                                  color: Colors.blueAccent,
+                                ),
+                                child: euroExchangeRate,
                               ),
-                              child: euroExchangeRate,
                             ),
                           ),
                         ],
                       ),
                       Column(
                         children: <Widget>[
-                          Container(
-                            padding: EdgeInsets.all(40.0 * _scale),
-                            decoration: BoxDecoration(
-                              shape: BoxShape.circle,
-                              color: Colors.deepOrange,
+                          _animatedCircle(
+                            2,
+                            Container(
+                              padding: EdgeInsets.all(40.0 * _scale),
+                              decoration: BoxDecoration(
+                                shape: BoxShape.circle,
+                                color: Colors.deepOrange,
+                              ),
+                              child: canadianDollarExchangeRate,
                             ),
-                            child: canadianDollarExchangeRate,
                           ),
                         ],
                       ),
@@ -199,13 +271,16 @@ class HomeState extends State<Home> {
                         children: <Widget>[
                           Padding(
                             padding: EdgeInsets.only(top: 100 * _scale),
-                            child: Container(
-                              padding: EdgeInsets.all(35.0 * _scale),
-                              decoration: BoxDecoration(
-                                shape: BoxShape.circle,
-                                color: Colors.pink,
+                            child: _animatedCircle(
+                              3,
+                              Container(
+                                padding: EdgeInsets.all(35.0 * _scale),
+                                decoration: BoxDecoration(
+                                  shape: BoxShape.circle,
+                                  color: Colors.pink,
+                                ),
+                                child: yenExchangeRate,
                               ),
-                              child: yenExchangeRate,
                             ),
                           ),
                         ],

--- a/lib/view/pages/main_menu_items/currency_history_menu.dart
+++ b/lib/view/pages/main_menu_items/currency_history_menu.dart
@@ -5,6 +5,7 @@ import 'package:cotacao_direta/util/currency_flag.dart';
 import 'package:cotacao_direta/util/responsive.dart';
 import 'package:cotacao_direta/util/string_utils.dart';
 import 'package:cotacao_direta/view/pages/selected_currency_details.dart';
+import 'package:cotacao_direta/view/widgets/animated_list_entry.dart';
 import 'package:flag/flag.dart';
 import 'package:flutter/material.dart';
 
@@ -27,47 +28,50 @@ class CurrencyHistory extends StatelessWidget {
         return const Divider(height: 1, thickness: 1);
       },
       itemBuilder: (BuildContext context, index) {
-        return GestureDetector(
-          child: ListTile(
-            title: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: [
-                Text(
-                  _currencyList[index],
-                  style: TextStyle(fontSize: 16 * _scale),
-                ),
-                Flag.fromCode(
-                  flagCodeForCurrency(Currencies.values[index]),
-                  height: 24 * _scale,
-                  width: 32 * _scale,
-                ),
-              ],
+        return AnimatedListEntry(
+          index: index,
+          child: GestureDetector(
+            child: ListTile(
+              title: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  Text(
+                    _currencyList[index],
+                    style: TextStyle(fontSize: 16 * _scale),
+                  ),
+                  Flag.fromCode(
+                    flagCodeForCurrency(Currencies.values[index]),
+                    height: 24 * _scale,
+                    width: 32 * _scale,
+                  ),
+                ],
+              ),
+              subtitle: StreamBuilder<String?>(
+                initialData: bloc.cachedCountryName(_currencyList[index]),
+                stream: bloc.getCountryNameController(_currencyList[index]),
+                builder: (context, snapshot) {
+                  bloc.getCountryNameByCurrencyCode(_currencyList[index]);
+                  return Text(
+                    snapshot.data ?? "",
+                    style: TextStyle(fontSize: 14 * _scale),
+                  );
+                },
+              ),
             ),
-            subtitle: StreamBuilder<String?>(
-              initialData: bloc.cachedCountryName(_currencyList[index]),
-              stream: bloc.getCountryNameController(_currencyList[index]),
-              builder: (context, snapshot) {
-                bloc.getCountryNameByCurrencyCode(_currencyList[index]);
-                return Text(
-                  snapshot.data ?? "",
-                  style: TextStyle(fontSize: 14 * _scale),
-                );
-              },
-            ),
-          ),
-          onTap: () {
-            Navigator.push(
-              context,
-              MaterialPageRoute(
-                builder: (context) => SelectedCurrencyDetailsBlocProvider(
-                  child: SelectedCurrencyDetails(
-                    selectedCurrencyCode: _currencyList[index],
+            onTap: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (context) => SelectedCurrencyDetailsBlocProvider(
+                    child: SelectedCurrencyDetails(
+                      selectedCurrencyCode: _currencyList[index],
+                    ),
                   ),
                 ),
-              ),
-            );
-          },
+              );
+            },
+          ),
         );
       },
       itemCount: _currencyList.length,

--- a/lib/view/widgets/animated_list_entry.dart
+++ b/lib/view/widgets/animated_list_entry.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+
+class AnimatedListEntry extends StatefulWidget {
+  final Widget child;
+  final int index;
+
+  const AnimatedListEntry({
+    super.key,
+    required this.child,
+    required this.index,
+  });
+
+  @override
+  State<AnimatedListEntry> createState() => _AnimatedListEntryState();
+}
+
+class _AnimatedListEntryState extends State<AnimatedListEntry>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _fadeAnimation;
+  late final Animation<Offset> _slideAnimation;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 350),
+    );
+    _fadeAnimation = CurvedAnimation(parent: _controller, curve: Curves.easeOut);
+    _slideAnimation = Tween<Offset>(
+      begin: const Offset(0.08, 0),
+      end: Offset.zero,
+    ).animate(_fadeAnimation);
+
+    final delay = Duration(milliseconds: 40 * widget.index.clamp(0, 12));
+    Future.delayed(delay, () {
+      if (mounted) _controller.forward();
+    });
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FadeTransition(
+      opacity: _fadeAnimation,
+      child: SlideTransition(position: _slideAnimation, child: widget.child),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Os círculos de cotação (USD, EUR, CAD, JPY) na tela inicial agora aparecem com fade + scale escalonado (bounce via `easeOutBack`) ao carregar a página.
- Os itens da lista de moedas na tela de histórico agora entram com fade + slide, escalonados por índice conforme são construídos pelo `ListView.builder`/`separated`.
- Novo widget reutilizável `AnimatedListEntry` em `lib/view/widgets/animated_list_entry.dart`.

## Test plan
- [x] `dart analyze` sem problemas nos arquivos alterados
- [x] `flutter build linux --debug` compila com sucesso
- [x] App executado localmente sem erros de assertion (opacidade fora do intervalo [0,1] foi verificada e evitada usando curvas separadas para scale e fade)
- [ ] Testar manualmente em dispositivo/emulador Android (não disponível neste ambiente)

🤖 Generated with [Claude Code](https://claude.com/claude-code)