### PR TITLE
Aplica recomendações de design: contraste, Material 3 e UX

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -26,14 +26,22 @@ class MyApp extends StatelessWidget {
         GlobalCupertinoLocalizations.delegate,
         MyAppLocalizationsDelegate()
       ],
+      theme: ThemeData(
+        useMaterial3: true,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
+        fontFamily: "Roboto",
+      ),
       darkTheme: ThemeData(
+        useMaterial3: true,
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: Colors.blue,
           brightness: Brightness.dark,
-          floatingActionButtonTheme: FloatingActionButtonThemeData(
-              backgroundColor: Colors.blue, foregroundColor: Colors.white)),
+        ),
+        fontFamily: "Roboto",
+      ),
       themeMode: ThemeMode.system,
       supportedLocales: [const Locale("en"), const Locale("pt")],
       title: appName,
-      theme: ThemeData(primarySwatch: Colors.blue, fontFamily: "Roboto"),
       home: HomeBlocProvider(
         child: Home(appName),
       ),

--- a/lib/util/color_utils.dart
+++ b/lib/util/color_utils.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+/// Ajusta a cor-base de um círculo de cotação conforme o brilho do tema: no
+/// modo escuro reduzimos um pouco a luminosidade para a cor não "gritar"
+/// contra o fundo preto, mantendo a identidade visual de cada moeda.
+Color circleBackgroundColor(BuildContext context, Color baseColor) {
+  if (Theme.of(context).brightness != Brightness.dark) return baseColor;
+  final hsl = HSLColor.fromColor(baseColor);
+  return hsl.withLightness((hsl.lightness * 0.7).clamp(0.0, 1.0)).toColor();
+}
+
+/// Cor de texto (preto ou branco) com contraste adequado para ser usada
+/// sobre [background], calculada a partir do brilho estimado da cor.
+Color contrastingTextColor(Color background) {
+  return ThemeData.estimateBrightnessForColor(background) == Brightness.dark
+      ? Colors.white
+      : Colors.black87;
+}

--- a/lib/util/localizations.dart
+++ b/lib/util/localizations.dart
@@ -28,7 +28,10 @@ class MyAppLocalizations {
       'currencyHistoryToDateLabel': 'Until',
       'noDataLabel': 'No Data',
       'getCurrencyHistoryBtnLabel': 'Get history',
+      'chartUnavailableLabel':
+          'The chart for this period is temporarily unavailable.',
       'overrideDefaultCurrencySwitchLabel': 'Override default currency',
+      'selectedOverrideCurrencyLabel': 'Currency',
       'appConfigurationsSectionLabel': 'App Configurations',
       'aboutAppDescription': 'A simple app that shows the exchange rate of '
           'the main currencies against the Brazilian real.',
@@ -53,7 +56,10 @@ class MyAppLocalizations {
       'currencyHistoryToDateLabel': 'Até',
       'noDataLabel': 'Sem Dados',
       'getCurrencyHistoryBtnLabel': 'Obter histórico',
+      'chartUnavailableLabel':
+          'O gráfico para este período está temporariamente indisponível.',
       'overrideDefaultCurrencySwitchLabel': 'Sobrescrever moeda padrão',
+      'selectedOverrideCurrencyLabel': 'Moeda',
       'appConfigurationsSectionLabel': 'Configurações do Aplicativo',
       'aboutAppDescription': 'Um aplicativo simples que mostra a cotação das '
           'principais moedas frente ao real.',
@@ -119,6 +125,10 @@ class MyAppLocalizations {
     return _localizedValues[locale.languageCode]!['getCurrencyHistoryBtnLabel'];
   }
 
+  String? get chartUnavailableLabel {
+    return _localizedValues[locale.languageCode]!['chartUnavailableLabel'];
+  }
+
   String? get getConfigBottomNavItemLabel {
     return _localizedValues[locale.languageCode]!['configBottomNavItemLabel'];
   }
@@ -126,6 +136,11 @@ class MyAppLocalizations {
   String? get overrideDefaultCurrencySwitchLabel {
     return _localizedValues[locale.languageCode]!
         ['overrideDefaultCurrencySwitchLabel'];
+  }
+
+  String? get selectedOverrideCurrencyLabel {
+    return _localizedValues[locale.languageCode]!
+        ['selectedOverrideCurrencyLabel'];
   }
 
   String? get appConfigurationsSectionLabel {

--- a/lib/view/pages/home.dart
+++ b/lib/view/pages/home.dart
@@ -4,6 +4,7 @@ import 'package:cotacao_direta/providers/configurations_page_bloc_provider.dart'
 import 'package:cotacao_direta/providers/conversion_page_bloc_provider.dart';
 import 'package:cotacao_direta/providers/currency_history_menu_bloc_provider.dart';
 import 'package:cotacao_direta/providers/home_bloc_provider.dart';
+import 'package:cotacao_direta/util/color_utils.dart';
 import 'package:cotacao_direta/util/localizations.dart';
 import 'package:cotacao_direta/util/responsive.dart';
 import 'package:cotacao_direta/view/pages/conversion_page.dart';
@@ -28,10 +29,6 @@ class Home extends StatefulWidget {
 }
 
 class HomeState extends State<Home> with SingleTickerProviderStateMixin {
-  final dollarExchangeRate = DollarExchangeRate();
-  final euroExchangeRate = EuroExchangeRate();
-  final canadianDollarExchangeRate = CanadianDollarExchangeRate();
-  final yenExchangeRate = YenExchangeRate();
   var _selectedIndex = 0;
   late HomeBloc _bloc;
 
@@ -92,6 +89,41 @@ class HomeState extends State<Home> with SingleTickerProviderStateMixin {
     );
   }
 
+  /// Círculo de cotação com sombra (para dar profundidade) e cor de fundo
+  /// já ajustada ao tema claro/escuro.
+  Widget _currencyCircle(
+    BuildContext context, {
+    required int index,
+    required Color baseColor,
+    required double padding,
+    required Widget child,
+  }) {
+    return _animatedCircle(
+      index,
+      Container(
+        padding: EdgeInsets.all(padding),
+        decoration: BoxDecoration(
+          shape: BoxShape.circle,
+          color: circleBackgroundColor(context, baseColor),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withValues(alpha: 0.25),
+              blurRadius: 10,
+              offset: const Offset(0, 4),
+            ),
+          ],
+        ),
+        child: child,
+      ),
+    );
+  }
+
+  Future<void> _refreshRates(BuildContext context) async {
+    _bloc.getSelectedOverrideCurrency();
+    UpdateCurrencyValueNotification().dispatch(context);
+    await Future.delayed(const Duration(milliseconds: 400));
+  }
+
   @override
   Widget build(BuildContext context) {
     final orientation = MediaQuery.of(context).orientation;
@@ -123,172 +155,161 @@ class HomeState extends State<Home> with SingleTickerProviderStateMixin {
       stream: _bloc.getNextStreamController(),
     );
 
+    final dollarExchangeRate = DollarExchangeRate(
+      color: contrastingTextColor(circleBackgroundColor(context, Colors.amber)),
+    );
+    final euroExchangeRate = EuroExchangeRate(
+      color: contrastingTextColor(
+        circleBackgroundColor(context, Colors.blueAccent),
+      ),
+    );
+    final canadianDollarExchangeRate = CanadianDollarExchangeRate(
+      color: contrastingTextColor(
+        circleBackgroundColor(context, Colors.deepOrange),
+      ),
+    );
+    final yenExchangeRate = YenExchangeRate(
+      color: contrastingTextColor(circleBackgroundColor(context, Colors.pink)),
+    );
+
     final List<Widget> _widgetOptions = <Widget>[
-      Container(
-        child: orientation == Orientation.portrait
-            ? Column(
-                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                children: <Widget>[
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: <Widget>[
-                      Column(children: <Widget>[pageHeader]),
-                    ],
-                  ),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                    children: <Widget>[
-                      Column(
-                        children: <Widget>[
-                          _animatedCircle(
-                            0,
-                            Container(
-                              padding: EdgeInsets.all(40.0 * _scale),
-                              decoration: BoxDecoration(
-                                shape: BoxShape.circle,
-                                color: Colors.amber,
-                              ),
+      RefreshIndicator(
+        onRefresh: () => _refreshRates(context),
+        child: SingleChildScrollView(
+          physics: const AlwaysScrollableScrollPhysics(),
+          child: orientation == Orientation.portrait
+              ? Column(
+                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                  children: <Widget>[
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: <Widget>[
+                        Column(children: <Widget>[pageHeader]),
+                      ],
+                    ),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                      children: <Widget>[
+                        Column(
+                          children: <Widget>[
+                            _currencyCircle(
+                              context,
+                              index: 0,
+                              baseColor: Colors.amber,
+                              padding: 40.0 * _scale,
                               child: dollarExchangeRate,
                             ),
-                          ),
-                        ],
-                      ),
-                      Column(
-                        children: <Widget>[
-                          _animatedCircle(
-                            1,
-                            Container(
-                              padding: EdgeInsets.all(40.0 * _scale),
-                              decoration: BoxDecoration(
-                                shape: BoxShape.circle,
-                                color: Colors.blueAccent,
-                              ),
+                          ],
+                        ),
+                        Column(
+                          children: <Widget>[
+                            _currencyCircle(
+                              context,
+                              index: 1,
+                              baseColor: Colors.blueAccent,
+                              padding: 40.0 * _scale,
                               child: euroExchangeRate,
                             ),
-                          ),
-                        ],
-                      ),
-                    ],
-                  ),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: <Widget>[
-                      Column(
-                        children: <Widget>[
-                          _animatedCircle(
-                            2,
-                            Container(
-                              padding: EdgeInsets.all(60.0 * _scale),
-                              decoration: BoxDecoration(
-                                shape: BoxShape.circle,
-                                color: Colors.deepOrange,
-                              ),
+                          ],
+                        ),
+                      ],
+                    ),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: <Widget>[
+                        Column(
+                          children: <Widget>[
+                            _currencyCircle(
+                              context,
+                              index: 2,
+                              baseColor: Colors.deepOrange,
+                              padding: 60.0 * _scale,
                               child: canadianDollarExchangeRate,
                             ),
-                          ),
-                        ],
-                      ),
-                    ],
-                  ),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: <Widget>[
-                      _animatedCircle(
-                        3,
-                        Container(
-                          padding: EdgeInsets.all(33.0 * _scale),
-                          decoration: BoxDecoration(
-                            shape: BoxShape.circle,
-                            color: Colors.pink,
-                          ),
+                          ],
+                        ),
+                      ],
+                    ),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: <Widget>[
+                        _currencyCircle(
+                          context,
+                          index: 3,
+                          baseColor: Colors.pink,
+                          padding: 33.0 * _scale,
                           child: yenExchangeRate,
                         ),
-                      ),
-                    ],
-                  ),
-                ],
-              )
-            : Column(
-                children: <Widget>[
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                    children: <Widget>[
-                      Column(children: <Widget>[pageHeader]),
-                    ],
-                  ),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                    children: <Widget>[
-                      Column(
-                        children: <Widget>[
-                          _animatedCircle(
-                            0,
-                            Container(
-                              padding: EdgeInsets.all(40.0 * _scale),
-                              decoration: BoxDecoration(
-                                shape: BoxShape.circle,
-                                color: Colors.amber,
-                              ),
+                      ],
+                    ),
+                  ],
+                )
+              : Column(
+                  children: <Widget>[
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                      children: <Widget>[
+                        Column(children: <Widget>[pageHeader]),
+                      ],
+                    ),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                      children: <Widget>[
+                        Column(
+                          children: <Widget>[
+                            _currencyCircle(
+                              context,
+                              index: 0,
+                              baseColor: Colors.amber,
+                              padding: 40.0 * _scale,
                               child: dollarExchangeRate,
                             ),
-                          ),
-                        ],
-                      ),
-                      Column(
-                        children: <Widget>[
-                          Padding(
-                            padding: EdgeInsets.only(top: 100.0 * _scale),
-                            child: _animatedCircle(
-                              1,
-                              Container(
-                                padding: EdgeInsets.all(40.0 * _scale),
-                                decoration: BoxDecoration(
-                                  shape: BoxShape.circle,
-                                  color: Colors.blueAccent,
-                                ),
+                          ],
+                        ),
+                        Column(
+                          children: <Widget>[
+                            Padding(
+                              padding: EdgeInsets.only(top: 100.0 * _scale),
+                              child: _currencyCircle(
+                                context,
+                                index: 1,
+                                baseColor: Colors.blueAccent,
+                                padding: 40.0 * _scale,
                                 child: euroExchangeRate,
                               ),
                             ),
-                          ),
-                        ],
-                      ),
-                      Column(
-                        children: <Widget>[
-                          _animatedCircle(
-                            2,
-                            Container(
-                              padding: EdgeInsets.all(40.0 * _scale),
-                              decoration: BoxDecoration(
-                                shape: BoxShape.circle,
-                                color: Colors.deepOrange,
-                              ),
+                          ],
+                        ),
+                        Column(
+                          children: <Widget>[
+                            _currencyCircle(
+                              context,
+                              index: 2,
+                              baseColor: Colors.deepOrange,
+                              padding: 40.0 * _scale,
                               child: canadianDollarExchangeRate,
                             ),
-                          ),
-                        ],
-                      ),
-                      Column(
-                        children: <Widget>[
-                          Padding(
-                            padding: EdgeInsets.only(top: 100 * _scale),
-                            child: _animatedCircle(
-                              3,
-                              Container(
-                                padding: EdgeInsets.all(35.0 * _scale),
-                                decoration: BoxDecoration(
-                                  shape: BoxShape.circle,
-                                  color: Colors.pink,
-                                ),
+                          ],
+                        ),
+                        Column(
+                          children: <Widget>[
+                            Padding(
+                              padding: EdgeInsets.only(top: 100 * _scale),
+                              child: _currencyCircle(
+                                context,
+                                index: 3,
+                                baseColor: Colors.pink,
+                                padding: 35.0 * _scale,
                                 child: yenExchangeRate,
                               ),
                             ),
-                          ),
-                        ],
-                      ),
-                    ],
-                  ),
-                ],
-              ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+        ),
       ),
       Container(
         child: CurrencyHistoryMenuBlocProvider(child: CurrencyHistory()),
@@ -316,7 +337,7 @@ class HomeState extends State<Home> with SingleTickerProviderStateMixin {
             label: _localization.getConfigBottomNavItemLabel,
           ),
           BottomNavigationBarItem(
-            icon: Icon(Icons.short_text),
+            icon: Icon(Icons.info_outline),
             label: _localization.aboutBottomNavItemLabel,
           ),
         ],

--- a/lib/view/pages/main_menu_items/about_page.dart
+++ b/lib/view/pages/main_menu_items/about_page.dart
@@ -2,6 +2,7 @@ import 'package:cotacao_direta/util/localizations.dart';
 import 'package:cotacao_direta/util/responsive.dart';
 import 'package:flutter/material.dart';
 import 'package:package_info_plus/package_info_plus.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 class AboutPage extends StatelessWidget {
   static const String _sourceCodeUrl =
@@ -59,9 +60,24 @@ class AboutPage extends StatelessWidget {
               ),
               SizedBox(height: 8 * scale),
               Text(
-                '${localization.aboutSourceCodeLabel}: $_sourceCodeUrl',
+                '${localization.aboutSourceCodeLabel}:',
                 textAlign: TextAlign.center,
                 style: TextStyle(fontSize: 14 * scale),
+              ),
+              InkWell(
+                onTap: () => launchUrl(
+                  Uri.parse(_sourceCodeUrl),
+                  mode: LaunchMode.externalApplication,
+                ),
+                child: Text(
+                  _sourceCodeUrl,
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    fontSize: 14 * scale,
+                    color: Theme.of(context).colorScheme.primary,
+                    decoration: TextDecoration.underline,
+                  ),
+                ),
               ),
             ],
           ),

--- a/lib/view/pages/main_menu_items/configurations_page.dart
+++ b/lib/view/pages/main_menu_items/configurations_page.dart
@@ -26,66 +26,80 @@ class ConfigurationsPage extends StatelessWidget {
         constraints: BoxConstraints(
           maxWidth: Responsive.contentMaxWidth(context),
         ),
-        child: Column(
+        child: ListView(
+          padding: EdgeInsets.symmetric(vertical: 16 * _scale),
           children: [
-            Expanded(
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceAround,
+            Padding(
+              padding: EdgeInsets.symmetric(horizontal: 24 * _scale),
+              child: Text(
+                _localization.appConfigurationsSectionLabel!,
+                style: TextStyle(
+                  fontSize: 14 * _scale,
+                  fontWeight: FontWeight.bold,
+                  color: Theme.of(context).colorScheme.primary,
+                ),
+              ),
+            ),
+            SizedBox(height: 8 * _scale),
+            Card(
+              margin: EdgeInsets.symmetric(horizontal: 12 * _scale),
+              child: Column(
                 children: [
-                  Container(
-                    child: Row(
-                      children: [
-                        StreamBuilder<OverrideCurrencyStateHelper>(
-                          builder: (BuildContext context, snapshot) {
-                            return Transform.scale(
-                              scale: _scale,
-                              child: Switch(
-                                value: snapshot.data!.enableCurrencyOverride,
-                                onChanged: (bool checked) {
-                                  _bloc.updateOverrideCurrencySwitch(checked);
-                                },
-                              ),
-                            );
-                          },
-                          stream:
-                              _bloc.overrideDefaultCurrencyValueStream
-                                  as Stream<OverrideCurrencyStateHelper>?,
-                          initialData: _bloc.overrideCurrencyStateHelper,
-                        ),
-                        Text(
+                  StreamBuilder<OverrideCurrencyStateHelper>(
+                    builder: (BuildContext context, snapshot) {
+                      return SwitchListTile(
+                        value: snapshot.data!.enableCurrencyOverride,
+                        onChanged: (bool checked) {
+                          _bloc.updateOverrideCurrencySwitch(checked);
+                        },
+                        title: Text(
                           _localization.overrideDefaultCurrencySwitchLabel!,
                           style: TextStyle(fontSize: 16 * _scale),
                         ),
-                      ],
-                    ),
+                      );
+                    },
+                    stream:
+                        _bloc.overrideDefaultCurrencyValueStream
+                            as Stream<OverrideCurrencyStateHelper>?,
+                    initialData: _bloc.overrideCurrencyStateHelper,
                   ),
+                  const Divider(height: 1),
                   StreamBuilder<OverrideCurrencyStateHelper>(
                     builder: (BuildContext context, switchSnapshot) {
-                      return DropdownButton(
-                        items: List.generate(
-                          _currencyList.length,
-                          (index) => DropdownMenuItem(
-                            value: _currencyList[index],
-                            child: Text(
-                              _currencyList[index],
-                              style: TextStyle(fontSize: 16 * _scale),
+                      final _enabled =
+                          switchSnapshot.data!.enableCurrencyOverride == true;
+                      return ListTile(
+                        enabled: _enabled,
+                        leading: const Icon(Icons.attach_money),
+                        title: Text(
+                          _localization.selectedOverrideCurrencyLabel!,
+                          style: TextStyle(fontSize: 16 * _scale),
+                        ),
+                        trailing: DropdownButton(
+                          items: List.generate(
+                            _currencyList.length,
+                            (index) => DropdownMenuItem(
+                              value: _currencyList[index],
+                              child: Text(
+                                _currencyList[index],
+                                style: TextStyle(fontSize: 16 * _scale),
+                              ),
                             ),
                           ),
+                          onChanged: _enabled
+                              ? (dynamic value) {
+                                  _bloc.updateSelectedOverrideCurrency(value);
+                                }
+                              : null,
+                          value:
+                              switchSnapshot
+                                  .data!
+                                  .selectedCurrencyOverride!
+                                  .isEmpty
+                              ? _currencyList[0]
+                              : switchSnapshot.data!.selectedCurrencyOverride,
+                          iconSize: 24 * _scale,
                         ),
-                        onChanged:
-                            switchSnapshot.data!.enableCurrencyOverride == true
-                            ? (dynamic value) {
-                                _bloc.updateSelectedOverrideCurrency(value);
-                              }
-                            : null,
-                        value:
-                            switchSnapshot
-                                .data!
-                                .selectedCurrencyOverride!
-                                .isEmpty
-                            ? _currencyList[0]
-                            : switchSnapshot.data!.selectedCurrencyOverride,
-                        iconSize: 24 * _scale,
                       );
                     },
                     stream:
@@ -95,7 +109,6 @@ class ConfigurationsPage extends StatelessWidget {
                   ),
                 ],
               ),
-              flex: 1,
             ),
           ],
         ),

--- a/lib/view/pages/main_menu_items/currency_history_menu.dart
+++ b/lib/view/pages/main_menu_items/currency_history_menu.dart
@@ -58,6 +58,11 @@ class CurrencyHistory extends StatelessWidget {
                   );
                 },
               ),
+              trailing: Icon(
+                Icons.chevron_right,
+                size: 20 * _scale,
+                color: Theme.of(context).colorScheme.outline,
+              ),
             ),
             onTap: () {
               Navigator.push(

--- a/lib/view/pages/selected_currency_details.dart
+++ b/lib/view/pages/selected_currency_details.dart
@@ -92,25 +92,29 @@ class SelectedCurrencyDetails extends StatelessWidget {
                 ],
               ),
               Expanded(
-                child: Row(
-                  children: [
-                    // TODO Substitute this block with the class from another chart library
-                    /*StreamBuilder<List<Series<dynamic, dynamic>>>(
-                    builder: (context, snapshot) {
-                      return Expanded(
-                          child: Container(
-                        child: snapshot.data != null
-                            ? SimpleLineChart(
-                                seriesList: snapshot.data,
-                              )
-                            : Text(
-                                localizations.noDataLabel!,
-                                textAlign: TextAlign.center,
-                              ),
-                      ));
-                    },
-                    stream: bloc.currencyHistoryStream)*/
-                  ],
+                // TODO Substitute this block with the class from another chart library
+                child: Center(
+                  child: Padding(
+                    padding: const EdgeInsets.all(24.0),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Icon(
+                          Icons.show_chart,
+                          size: 48,
+                          color: Theme.of(context).colorScheme.outline,
+                        ),
+                        const SizedBox(height: 12),
+                        Text(
+                          localizations.chartUnavailableLabel!,
+                          textAlign: TextAlign.center,
+                          style: TextStyle(
+                            color: Theme.of(context).colorScheme.outline,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
                 ),
               ),
             ],

--- a/lib/view/widgets/canadian_dollar_exchange_rate.dart
+++ b/lib/view/widgets/canadian_dollar_exchange_rate.dart
@@ -5,7 +5,9 @@ import 'package:flutter/material.dart';
 import 'exchange_rate_value.dart';
 
 class CanadianDollarExchangeRate extends StatelessWidget {
-  final exchangeRateValue = ExchangeRateValue(Currencies.CAD);
+  final Color color;
+
+  CanadianDollarExchangeRate({this.color = Colors.white});
 
   @override
   Widget build(BuildContext context) {
@@ -17,14 +19,16 @@ class CanadianDollarExchangeRate extends StatelessWidget {
               "CAD ",
               style: TextStyle(
                 fontSize: 18 * Responsive.scaleFactor(context),
-                color: Colors.white,
+                color: color,
               ),
             ),
           ],
         ),
         Column(
           children: <Widget>[
-            ExchangeValueBlocProvider(child: exchangeRateValue),
+            ExchangeValueBlocProvider(
+              child: ExchangeRateValue(Currencies.CAD, color: color),
+            ),
           ],
         ),
       ],

--- a/lib/view/widgets/dollar_exchange_rate.dart
+++ b/lib/view/widgets/dollar_exchange_rate.dart
@@ -5,7 +5,9 @@ import 'package:cotacao_direta/view/widgets/exchange_rate_value.dart';
 import 'package:flutter/material.dart';
 
 class DollarExchangeRate extends StatelessWidget {
-  final exchangeRateValue = ExchangeRateValue(Currencies.USD);
+  final Color color;
+
+  DollarExchangeRate({this.color = Colors.white});
 
   @override
   Widget build(BuildContext context) {
@@ -17,14 +19,16 @@ class DollarExchangeRate extends StatelessWidget {
               "USD ",
               style: TextStyle(
                 fontSize: 18 * Responsive.scaleFactor(context),
-                color: Colors.white,
+                color: color,
               ),
             ),
           ],
         ),
         Column(
           children: <Widget>[
-            ExchangeValueBlocProvider(child: exchangeRateValue),
+            ExchangeValueBlocProvider(
+              child: ExchangeRateValue(Currencies.USD, color: color),
+            ),
           ],
         ),
       ],

--- a/lib/view/widgets/euro_exchange_rate.dart
+++ b/lib/view/widgets/euro_exchange_rate.dart
@@ -5,7 +5,9 @@ import 'package:cotacao_direta/view/widgets/exchange_rate_value.dart';
 import 'package:flutter/material.dart';
 
 class EuroExchangeRate extends StatelessWidget {
-  final exchangeRateValue = ExchangeRateValue(Currencies.EUR);
+  final Color color;
+
+  EuroExchangeRate({this.color = Colors.white});
 
   @override
   Widget build(BuildContext context) {
@@ -17,14 +19,16 @@ class EuroExchangeRate extends StatelessWidget {
               "EUR ",
               style: TextStyle(
                 fontSize: 18 * Responsive.scaleFactor(context),
-                color: Colors.white,
+                color: color,
               ),
             ),
           ],
         ),
         Column(
           children: <Widget>[
-            ExchangeValueBlocProvider(child: exchangeRateValue),
+            ExchangeValueBlocProvider(
+              child: ExchangeRateValue(Currencies.EUR, color: color),
+            ),
           ],
         ),
       ],

--- a/lib/view/widgets/exchange_rate_value.dart
+++ b/lib/view/widgets/exchange_rate_value.dart
@@ -9,8 +9,9 @@ import 'package:intl/intl.dart';
 
 class ExchangeRateValue extends StatefulWidget {
   final Currencies currency;
+  final Color color;
 
-  ExchangeRateValue(this.currency);
+  ExchangeRateValue(this.currency, {this.color = Colors.white});
 
   @override
   State<StatefulWidget> createState() {
@@ -65,11 +66,14 @@ class ExchangeRateValueState extends State<ExchangeRateValue> {
               didChangeDependencies();
               return true;
             },
-            child: Text(
-              _exchangeRateLabel(context, snapshot),
-              style: TextStyle(
-                fontSize: 18 * Responsive.scaleFactor(context),
-                color: Colors.white,
+            child: Semantics(
+              label: _exchangeRateLabel(context, snapshot),
+              child: Text(
+                _exchangeRateLabel(context, snapshot),
+                style: TextStyle(
+                  fontSize: 18 * Responsive.scaleFactor(context),
+                  color: widget.color,
+                ),
               ),
             ),
           ),

--- a/lib/view/widgets/yen_exchange_rate.dart
+++ b/lib/view/widgets/yen_exchange_rate.dart
@@ -5,7 +5,9 @@ import 'package:cotacao_direta/view/widgets/exchange_rate_value.dart';
 import 'package:flutter/material.dart';
 
 class YenExchangeRate extends StatelessWidget {
-  final exchangeRateValue = ExchangeRateValue(Currencies.JPY);
+  final Color color;
+
+  YenExchangeRate({this.color = Colors.white});
 
   @override
   Widget build(BuildContext context) {
@@ -17,14 +19,16 @@ class YenExchangeRate extends StatelessWidget {
               "JPY ",
               style: TextStyle(
                 fontSize: 18 * Responsive.scaleFactor(context),
-                color: Colors.white,
+                color: color,
               ),
             ),
           ],
         ),
         Column(
           children: <Widget>[
-            ExchangeValueBlocProvider(child: exchangeRateValue),
+            ExchangeValueBlocProvider(
+              child: ExchangeRateValue(Currencies.JPY, color: color),
+            ),
           ],
         ),
       ],

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,10 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
+  url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
 }

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  url_launcher_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -506,6 +506,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.2"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: b413d49b73867ac08dd2f9890efd3cc11f2a0e577618d50843440a1fb3776c32
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.32"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: "580fe5dfb51671ae38191d316e027f6b76272b026370708c2d898799750a02b0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.4.1"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: d5e14138b3bc193a0f63c10a53c94b91d399df0512b1f29b94a043db7482384a
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: "368adf46f71ad3c21b8f06614adb38346f193f3a59ba8fe9a2fd74133070ba18"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.5"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: "85c81589622fbc87c1c683aaea164d3604a7777495a79d91e39ffcdec39ddb34"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "712c70ab1b99744ff066053cbe3e80c73332b38d46e5e945c98689b2e66fc15f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.5"
   vector_graphics:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   sqflite_common_ffi: ^2.3.3
   flag: ^7.0.2
   package_info_plus: ^8.1.2
+  url_launcher: ^6.3.1
 
 dev_dependencies:
   flutter_launcher_icons: ^0.14.4


### PR DESCRIPTION
## Resumo

Implementa uma leva de recomendações de design levantadas ao revisar as telas do app (Home, Configurações, Histórico, Detalhes da moeda, Sobre):

- **Contraste/acessibilidade**: a cor do texto sobre os círculos de cotação (Home) agora é calculada dinamicamente a partir do brilho do fundo (`lib/util/color_utils.dart`), corrigindo o texto branco pouco legível sobre o círculo âmbar.
- **Tema Material 3**: `main.dart` passa a usar `ColorScheme.fromSeed` para os temas claro e escuro, em vez do `darkTheme` incompleto anterior (que só definia a cor do FAB).
- **Home**: círculos ganham sombra (profundidade) via um helper único (`_currencyCircle`), reduzindo a duplicação de código entre portrait/landscape; a aba de moedas ganhou pull-to-refresh reaproveitando o mecanismo de notificação já existente.
- **Configurações**: reestruturada com `Card` + `SwitchListTile` + `ListTile`, agrupando visualmente o switch e o dropdown de moeda de override.
- **Histórico de moedas**: cada item da lista ganhou um `chevron_right` indicando que é navegável.
- **Detalhes da moeda**: como o gráfico está temporariamente indisponível (TODO já existente no código), a tela agora mostra um estado vazio explícito em vez de um espaço em branco.
- **Sobre**: o link do repositório agora é clicável (nova dependência `url_launcher`); ícone da aba "Sobre" na bottom nav trocado de `short_text` para `info_outline` (mais reconhecível).

Novas chaves de localização (`selectedOverrideCurrencyLabel`, `chartUnavailableLabel`) adicionadas em `pt` e `en`.

## Test plan

- [x] `flutter analyze` — sem problemas
- [x] `flutter test` — 182 testes, todos passando
- [ ] Conferir visualmente no dispositivo/emulador (não foi possível tirar screenshot no sandbox usado nesta sessão — sem ferramenta de captura instalada e sem target web configurado no projeto)

🤖 Generated with [Claude Code](https://claude.com/claude-code)