### PR TITLE
Substitui lib de gráfico na tela de histórico de moedas

### DIFF
--- a/lib/blocs/selected_currency_details_bloc.dart
+++ b/lib/blocs/selected_currency_details_bloc.dart
@@ -1,13 +1,14 @@
 import 'dart:async';
 
 import 'package:cotacao_direta/blocs/base_bloc.dart';
+import 'package:cotacao_direta/model/currency.dart';
 import 'package:cotacao_direta/repository/currency_repository.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
 class SelectedCurrencyDetailsBloc extends BaseBloc {
-  StreamController _selectedCurrencyHistoryDataStreamController =
-  StreamController();
+  StreamController<List<Currency>> _selectedCurrencyHistoryDataStreamController =
+      StreamController<List<Currency>>();
 
   final DateFormat _viewDateFormatter = DateFormat("dd/MM/yyyy");
   final DateFormat _apiDateFormatter = DateFormat("yyyy-MM-dd");
@@ -22,7 +23,7 @@ class SelectedCurrencyDetailsBloc extends BaseBloc {
 
   final _currencyRepository = CurrencyRepository();
 
-  get currencyHistoryStream =>
+  Stream<List<Currency>> get currencyHistoryStream =>
       _selectedCurrencyHistoryDataStreamController.stream;
 
   TextEditingController get initialDateController => _initialDateController;
@@ -30,23 +31,9 @@ class SelectedCurrencyDetailsBloc extends BaseBloc {
   TextEditingController get endDateController => _endDateController;
 
   getCurrencyHistoryData(String selectedCurrencyCod) async {
-    // O resultado é descartado por enquanto: o bloco que montava a série do
-    // gráfico está comentado abaixo, esperando a troca da biblioteca. A busca
-    // continua valendo porque guarda o histórico no banco.
-    await _currencyRepository.getCurrencyHistoricalData(
+    var currencyList = await _currencyRepository.getCurrencyHistoricalData(
         [selectedCurrencyCod], _initialDate, _finalDate);
-    // TODO Replace this block when the chart library gets replaced. O valor
-    // devolvido pela chamada acima volta a ser usado como `currencyList`.
-    // var dataToAdd = <Series<dynamic, DateTime>>[];
-    /*dataToAdd.add(
-        Series<Currency, DateTime>(
-            id: selectedCurrencyCod,
-            data: currencyList,
-            domainFn: (Currency currency, _) =>
-                DateFormat("yyyy-MM-dd").parse(currency.historicalDate!),
-            measureFn: (Currency currency, _) => currency.value)
-    );*/
-    // _selectedCurrencyHistoryDataStreamController.sink.add(dataToAdd);
+    _selectedCurrencyHistoryDataStreamController.sink.add(currencyList);
   }
 
   updateInitialDate(dateValue){

--- a/lib/util/localizations.dart
+++ b/lib/util/localizations.dart
@@ -28,8 +28,6 @@ class MyAppLocalizations {
       'currencyHistoryToDateLabel': 'Until',
       'noDataLabel': 'No Data',
       'getCurrencyHistoryBtnLabel': 'Get history',
-      'chartUnavailableLabel':
-          'The chart for this period is temporarily unavailable.',
       'overrideDefaultCurrencySwitchLabel': 'Override default currency',
       'selectedOverrideCurrencyLabel': 'Currency',
       'appConfigurationsSectionLabel': 'App Configurations',
@@ -56,8 +54,6 @@ class MyAppLocalizations {
       'currencyHistoryToDateLabel': 'Até',
       'noDataLabel': 'Sem Dados',
       'getCurrencyHistoryBtnLabel': 'Obter histórico',
-      'chartUnavailableLabel':
-          'O gráfico para este período está temporariamente indisponível.',
       'overrideDefaultCurrencySwitchLabel': 'Sobrescrever moeda padrão',
       'selectedOverrideCurrencyLabel': 'Moeda',
       'appConfigurationsSectionLabel': 'Configurações do Aplicativo',
@@ -123,10 +119,6 @@ class MyAppLocalizations {
 
   String? get getCurrencyHistoryBtnLabel {
     return _localizedValues[locale.languageCode]!['getCurrencyHistoryBtnLabel'];
-  }
-
-  String? get chartUnavailableLabel {
-    return _localizedValues[locale.languageCode]!['chartUnavailableLabel'];
   }
 
   String? get getConfigBottomNavItemLabel {

--- a/lib/view/pages/selected_currency_details.dart
+++ b/lib/view/pages/selected_currency_details.dart
@@ -1,6 +1,8 @@
+import 'package:cotacao_direta/model/currency.dart';
 import 'package:cotacao_direta/providers/selected_currency_details_bloc_provider.dart';
 import 'package:cotacao_direta/util/localizations.dart';
 import 'package:cotacao_direta/util/responsive.dart';
+import 'package:cotacao_direta/view/widgets/charts.dart';
 import 'package:flutter/material.dart';
 
 class SelectedCurrencyDetails extends StatelessWidget {
@@ -92,29 +94,40 @@ class SelectedCurrencyDetails extends StatelessWidget {
                 ],
               ),
               Expanded(
-                // TODO Substitute this block with the class from another chart library
-                child: Center(
-                  child: Padding(
-                    padding: const EdgeInsets.all(24.0),
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Icon(
-                          Icons.show_chart,
-                          size: 48,
-                          color: Theme.of(context).colorScheme.outline,
-                        ),
-                        const SizedBox(height: 12),
-                        Text(
-                          localizations.chartUnavailableLabel!,
-                          textAlign: TextAlign.center,
-                          style: TextStyle(
-                            color: Theme.of(context).colorScheme.outline,
+                child: StreamBuilder<List<Currency>>(
+                  stream: bloc.currencyHistoryStream,
+                  builder: (context, snapshot) {
+                    final currencyList = snapshot.data;
+                    if (currencyList == null || currencyList.isEmpty) {
+                      return Center(
+                        child: Padding(
+                          padding: const EdgeInsets.all(24.0),
+                          child: Column(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              Icon(
+                                Icons.show_chart,
+                                size: 48,
+                                color: Theme.of(context).colorScheme.outline,
+                              ),
+                              const SizedBox(height: 12),
+                              Text(
+                                localizations.noDataLabel!,
+                                textAlign: TextAlign.center,
+                                style: TextStyle(
+                                  color: Theme.of(context).colorScheme.outline,
+                                ),
+                              ),
+                            ],
                           ),
                         ),
-                      ],
-                    ),
-                  ),
+                      );
+                    }
+                    return Padding(
+                      padding: const EdgeInsets.fromLTRB(8, 24, 24, 8),
+                      child: SimpleLineChart(currencyList: currencyList),
+                    );
+                  },
                 ),
               ),
             ],

--- a/lib/view/widgets/charts.dart
+++ b/lib/view/widgets/charts.dart
@@ -1,31 +1,92 @@
-import 'package:flutter/widgets.dart';
+import 'package:cotacao_direta/model/currency.dart';
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 
+/// Gráfico de linha simples com o histórico de valores de uma moeda ao longo
+/// do tempo, uma [Currency] por dia.
 class SimpleLineChart extends StatelessWidget {
-  // final List<Series>? seriesList;
-  final bool? animate;
+  final List<Currency> currencyList;
 
-  SimpleLineChart({/*this.seriesList,*/ this.animate});
+  SimpleLineChart({required this.currencyList});
+
+  final DateFormat _axisDateFormatter = DateFormat("dd/MM");
 
   @override
   Widget build(BuildContext context) {
-    // TODO Replace this with a chart from another library
-    /*return TimeSeriesChart(
-      seriesList as List<Series<dynamic, DateTime>>,
-      animate: animate,
-      primaryMeasureAxis: NumericAxisSpec(
-          tickFormatterSpec: BasicNumericTickFormatterSpec.fromNumberFormat(
-              NumberFormat.compactSimpleCurrency())),
-      domainAxis: DateTimeAxisSpec(
-          tickFormatterSpec: AutoDateTimeTickFormatterSpec(
-              day: TimeFormatterSpec(
-                  format: 'dd', transitionFormat: 'yyyy-MM-dd'),
-              month: TimeFormatterSpec(
-                  format: 'MM', transitionFormat: 'yyyy-MM-dd'),
-              year: TimeFormatterSpec(
-                  format: 'yyyy', transitionFormat: 'yyyy-MM-dd'))),
-    );*/
-    return Container(
-      child: Text("TODO"),
+    final dates = currencyList
+        .map((currency) => DateTime.parse(currency.historicalDate!))
+        .toList();
+    final spots = List.generate(
+      currencyList.length,
+      (index) => FlSpot(index.toDouble(), currencyList[index].value ?? 0),
+    );
+    final color = Theme.of(context).colorScheme.primary;
+
+    return LineChart(
+      LineChartData(
+        lineTouchData: LineTouchData(
+          touchTooltipData: LineTouchTooltipData(
+            getTooltipItems: (touchedSpots) => touchedSpots.map((spot) {
+              final date = dates[spot.x.toInt()];
+              return LineTooltipItem(
+                "${_axisDateFormatter.format(date)}\n${spot.y.toStringAsFixed(4)}",
+                TextStyle(color: Theme.of(context).colorScheme.onInverseSurface),
+              );
+            }).toList(),
+          ),
+        ),
+        titlesData: FlTitlesData(
+          topTitles: const AxisTitles(
+            sideTitles: SideTitles(showTitles: false),
+          ),
+          rightTitles: const AxisTitles(
+            sideTitles: SideTitles(showTitles: false),
+          ),
+          bottomTitles: AxisTitles(
+            sideTitles: SideTitles(
+              showTitles: true,
+              reservedSize: 28,
+              interval: dates.length > 1 ? (dates.length - 1) / 4 : 1,
+              getTitlesWidget: (value, meta) {
+                final index = value.round();
+                if (index < 0 || index >= dates.length) {
+                  return const SizedBox.shrink();
+                }
+                return Padding(
+                  padding: const EdgeInsets.only(top: 8.0),
+                  child: Text(
+                    _axisDateFormatter.format(dates[index]),
+                    style: const TextStyle(fontSize: 10),
+                  ),
+                );
+              },
+            ),
+          ),
+          leftTitles: AxisTitles(
+            sideTitles: SideTitles(
+              showTitles: true,
+              reservedSize: 48,
+              getTitlesWidget: (value, meta) => Text(
+                value.toStringAsFixed(2),
+                style: const TextStyle(fontSize: 10),
+              ),
+            ),
+          ),
+        ),
+        gridData: const FlGridData(show: true),
+        borderData: FlBorderData(show: true),
+        lineBarsData: [
+          LineChartBarData(
+            spots: spots,
+            isCurved: true,
+            color: color,
+            barWidth: 2,
+            dotData: const FlDotData(show: false),
+            belowBarData: BarAreaData(show: true, color: color.withValues(alpha: 0.15)),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -105,6 +105,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.1"
+  equatable:
+    dependency: transitive
+    description:
+      name: equatable
+      sha256: "3bce007a596ff8b3119c45d68aaef631272537c03d30e5d4534dd24bf4c5eaa2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   fake_async:
     dependency: transitive
     description:
@@ -129,6 +137,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  fl_chart:
+    dependency: "direct main"
+    description:
+      name: fl_chart
+      sha256: b938f77d042cbcd822936a7a359a7235bad8bd72070de1f827efc2cc297ac888
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.0"
   flag:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,6 +25,7 @@ dependencies:
   flag: ^7.0.2
   package_info_plus: ^8.1.2
   url_launcher: ^6.3.1
+  fl_chart: ^1.1.1
 
 dev_dependencies:
   flutter_launcher_icons: ^0.14.4


### PR DESCRIPTION
## Summary
- `charts_flutter` foi removido em [667cdab](https://github.com/hhldiniz/cotacao_direta/commit/667cdab0165b96e6f81ba8311b32012de5f95161) por não funcionar mais com as dependências atuais, deixando a tela de detalhes/histórico da moeda com um aviso fixo de "gráfico indisponível" no lugar do gráfico.
- Troca a lib por [`fl_chart`](https://pub.dev/packages/fl_chart) (ativamente mantida), mantendo a mesma funcionalidade: linha do valor da moeda ao longo do tempo, eixo de datas, tooltip ao tocar nos pontos e estado de "sem dados" quando a consulta não retorna registros.
- `SelectedCurrencyDetailsBloc.getCurrencyHistoryData` volta a alimentar o stream do histórico com os dados reais retornados pelo repositório (antes eram descartados).
- Remove o texto `chartUnavailableLabel`, que não é mais usado.

## Test plan
- [x] `flutter analyze` sem apontamentos
- [x] `flutter test` — 182 testes passando
- [x] Renderização visual conferida via teste com golden file (dados de exemplo), confirmando linha, preenchimento de área e grid do gráfico

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>