### PR TITLE
Adiciona indicador de carregamento no histórico de moeda

### DIFF
--- a/lib/blocs/selected_currency_details_bloc.dart
+++ b/lib/blocs/selected_currency_details_bloc.dart
@@ -8,7 +8,10 @@ import 'package:intl/intl.dart';
 
 class SelectedCurrencyDetailsBloc extends BaseBloc {
   StreamController<List<Currency>> _selectedCurrencyHistoryDataStreamController =
-      StreamController<List<Currency>>();
+      StreamController<List<Currency>>.broadcast();
+
+  StreamController<bool> _isLoadingStreamController =
+      StreamController<bool>.broadcast();
 
   final DateFormat _viewDateFormatter = DateFormat("dd/MM/yyyy");
   final DateFormat _apiDateFormatter = DateFormat("yyyy-MM-dd");
@@ -26,14 +29,21 @@ class SelectedCurrencyDetailsBloc extends BaseBloc {
   Stream<List<Currency>> get currencyHistoryStream =>
       _selectedCurrencyHistoryDataStreamController.stream;
 
+  Stream<bool> get isLoadingStream => _isLoadingStreamController.stream;
+
   TextEditingController get initialDateController => _initialDateController;
 
   TextEditingController get endDateController => _endDateController;
 
   getCurrencyHistoryData(String selectedCurrencyCod) async {
-    var currencyList = await _currencyRepository.getCurrencyHistoricalData(
-        [selectedCurrencyCod], _initialDate, _finalDate);
-    _selectedCurrencyHistoryDataStreamController.sink.add(currencyList);
+    _isLoadingStreamController.sink.add(true);
+    try {
+      var currencyList = await _currencyRepository.getCurrencyHistoricalData(
+          [selectedCurrencyCod], _initialDate, _finalDate);
+      _selectedCurrencyHistoryDataStreamController.sink.add(currencyList);
+    } finally {
+      _isLoadingStreamController.sink.add(false);
+    }
   }
 
   updateInitialDate(dateValue){
@@ -49,6 +59,7 @@ class SelectedCurrencyDetailsBloc extends BaseBloc {
   @override
   void dispose() {
     _selectedCurrencyHistoryDataStreamController.close();
+    _isLoadingStreamController.close();
     // Os campos de data são ChangeNotifier: sem dispose, os ouvintes ficam
     // presos ao bloc depois que a tela sai.
     _initialDateController.dispose();

--- a/lib/view/pages/selected_currency_details.dart
+++ b/lib/view/pages/selected_currency_details.dart
@@ -94,38 +94,51 @@ class SelectedCurrencyDetails extends StatelessWidget {
                 ],
               ),
               Expanded(
-                child: StreamBuilder<List<Currency>>(
-                  stream: bloc.currencyHistoryStream,
-                  builder: (context, snapshot) {
-                    final currencyList = snapshot.data;
-                    if (currencyList == null || currencyList.isEmpty) {
-                      return Center(
-                        child: Padding(
-                          padding: const EdgeInsets.all(24.0),
-                          child: Column(
-                            mainAxisSize: MainAxisSize.min,
-                            children: [
-                              Icon(
-                                Icons.show_chart,
-                                size: 48,
-                                color: Theme.of(context).colorScheme.outline,
-                              ),
-                              const SizedBox(height: 12),
-                              Text(
-                                localizations.noDataLabel!,
-                                textAlign: TextAlign.center,
-                                style: TextStyle(
-                                  color: Theme.of(context).colorScheme.outline,
-                                ),
-                              ),
-                            ],
-                          ),
-                        ),
-                      );
+                child: StreamBuilder<bool>(
+                  stream: bloc.isLoadingStream,
+                  initialData: false,
+                  builder: (context, loadingSnapshot) {
+                    if (loadingSnapshot.data == true) {
+                      return const Center(child: CircularProgressIndicator());
                     }
-                    return Padding(
-                      padding: const EdgeInsets.fromLTRB(8, 24, 24, 8),
-                      child: SimpleLineChart(currencyList: currencyList),
+                    return StreamBuilder<List<Currency>>(
+                      stream: bloc.currencyHistoryStream,
+                      builder: (context, snapshot) {
+                        final currencyList = snapshot.data;
+                        if (currencyList == null || currencyList.isEmpty) {
+                          return Center(
+                            child: Padding(
+                              padding: const EdgeInsets.all(24.0),
+                              child: Column(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  Icon(
+                                    Icons.show_chart,
+                                    size: 48,
+                                    color: Theme.of(
+                                      context,
+                                    ).colorScheme.outline,
+                                  ),
+                                  const SizedBox(height: 12),
+                                  Text(
+                                    localizations.noDataLabel!,
+                                    textAlign: TextAlign.center,
+                                    style: TextStyle(
+                                      color: Theme.of(
+                                        context,
+                                      ).colorScheme.outline,
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ),
+                          );
+                        }
+                        return Padding(
+                          padding: const EdgeInsets.fromLTRB(8, 24, 24, 8),
+                          child: SimpleLineChart(currencyList: currencyList),
+                        );
+                      },
                     );
                   },
                 ),


### PR DESCRIPTION
## Summary
- Adiciona um stream de loading (`isLoadingStream`) ao `SelectedCurrencyDetailsBloc`, emitido em `true`/`false` ao redor da chamada de `getCurrencyHistoryData`.
- A tela `SelectedCurrencyDetails` agora mostra um `CircularProgressIndicator` centralizado enquanto os dados históricos são buscados, em vez de deixar a área do gráfico vazia após tocar no FAB.
- O `StreamController` de dados do histórico virou `broadcast` (era single-subscription), necessário porque o `StreamBuilder` de loading desmonta/remonta o `StreamBuilder` de dados, e um stream single-subscription não pode ser ouvido novamente após o cancelamento do primeiro listener (causava `Bad state: Stream has already been listened to`).

## Test plan
- [x] `flutter analyze` nos arquivos alterados (sem problemas)
- [ ] Testar manualmente no app: abrir detalhes de uma moeda, tocar no FAB e confirmar que o spinner aparece durante o carregamento e o gráfico/estado vazio aparece corretamente depois, inclusive em buscas repetidas

🤖 Generated with [Claude Code](https://claude.com/claude-code)