### PR TITLE
Remove BRL da lista de histórico: gráfico contra ela mesma nunca tem dados

### DIFF
--- a/lib/blocs/currency_history_menu_bloc.dart
+++ b/lib/blocs/currency_history_menu_bloc.dart
@@ -2,16 +2,31 @@ import 'dart:async';
 
 import 'package:cotacao_direta/blocs/base_bloc.dart';
 import 'package:cotacao_direta/repository/country_names_repository.dart';
+import 'package:cotacao_direta/repository/currency_repository.dart';
 
 class CurrencyHistoryMenuBloc extends BaseBloc {
   final CountryNamesRepository _countryNameRepository;
+  final CurrencyRepository _currencyRepository;
   final Map<String, StreamController<String?>> _countryNameControllerMap = {};
   final Map<String, String?> _savedCountryNamesByCurrencyCod = {};
   final Set<String> _pendingRequests = {};
 
-  CurrencyHistoryMenuBloc({CountryNamesRepository? countryNamesRepository})
+  Future<String>? _counterCurrencyFuture;
+
+  CurrencyHistoryMenuBloc(
+      {CountryNamesRepository? countryNamesRepository,
+      CurrencyRepository? currencyRepository})
       : _countryNameRepository =
-            countryNamesRepository ?? CountryNamesRepository();
+            countryNamesRepository ?? CountryNamesRepository(),
+        _currencyRepository = currencyRepository ?? CurrencyRepository();
+
+  /// Moeda usada hoje como contrapartida (ver
+  /// [CurrencyRepository.resolveCounterCurrency]), para a tela excluí-la da
+  /// lista de histórico. Resolvida uma vez e mantida em cache: a tela
+  /// reconsulta isto a cada rebuild, e a configuração não muda enquanto a
+  /// lista está aberta.
+  Future<String> get counterCurrencyCode =>
+      _counterCurrencyFuture ??= _currencyRepository.resolveCounterCurrency();
 
   /// Cria um controller por moeda. É idempotente de propósito: a tela chama
   /// isto a cada build, e recriar os controllers deixaria os anteriores

--- a/lib/repository/currency_repository.dart
+++ b/lib/repository/currency_repository.dart
@@ -74,7 +74,12 @@ class CurrencyRepository {
   String get _defaultCounterCurrency =>
       _enumValueAsStringUtil.getEnumValue(Currencies.BRL.toString());
 
-  Future<String> _resolveCounterCurrency() async {
+  /// Moeda usada hoje como contrapartida das cotações: a escolhida nas
+  /// configurações, ou BRL por padrão. Exposta publicamente porque a tela de
+  /// histórico precisa saber qual moeda excluir da lista — uma moeda cotada
+  /// contra ela mesma não tem série para desenhar (ver
+  /// [getCurrencyHistoricalData]).
+  Future<String> resolveCounterCurrency() async {
     final configuration = await _configurationRepository.getConfiguration();
     final selected = configuration.selectedOverrideCurrencyCode;
     if (configuration.overrideDefaultCurrency &&
@@ -155,7 +160,7 @@ class CurrencyRepository {
 
   Future<Currency?> _fetchLatestQuote(String? currencyCode) async {
     if (currencyCode == null || currencyCode.isEmpty) return null;
-    var counterCurrency = await _resolveCounterCurrency();
+    var counterCurrency = await resolveCounterCurrency();
     // Uma moeda cotada contra ela mesma vale exatamente uma unidade; a API não
     // tem esse par.
     if (currencyCode == counterCurrency) {
@@ -175,7 +180,7 @@ class CurrencyRepository {
   Future<List<Currency>> getCurrencyHistoricalData(
       List<String> currencyCodeList, initialDate, finalDate) async {
     if (await _networkUtils.isNetworkAvailable()) {
-      var counterCurrency = await _resolveCounterCurrency();
+      var counterCurrency = await resolveCounterCurrency();
       var start = _parseAppDate(initialDate);
       var end = _parseAppDate(finalDate);
       var currencyListToSave = <Currency>[];

--- a/lib/view/pages/main_menu_items/currency_history_menu.dart
+++ b/lib/view/pages/main_menu_items/currency_history_menu.dart
@@ -15,71 +15,88 @@ class CurrencyHistory extends StatelessWidget {
     final bloc = CurrencyHistoryMenuBlocProvider.of(context);
     final _scale = Responsive.scaleFactor(context);
 
-    final _currencyList = List.generate(Currencies.values.length, (index) {
-      return EnumValueAsString().getEnumValue(
-        Currencies.values.elementAt(index).toString(),
-      );
-    });
+    return FutureBuilder<String>(
+      future: bloc.counterCurrencyCode,
+      builder: (context, snapshot) {
+        if (!snapshot.hasData) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        final counterCurrency = snapshot.data!;
+        // A moeda usada como contrapartida não tem série própria para
+        // desenhar: CurrencyRepository.getCurrencyHistoricalData pula a
+        // consulta quando a moeda pedida é a própria contrapartida, e o
+        // gráfico ficaria sempre em "Sem Dados" para ela.
+        final _currencies = Currencies.values
+            .where((currency) =>
+                EnumValueAsString().getEnumValue(currency.toString()) !=
+                counterCurrency)
+            .toList();
+        final _currencyList = _currencies
+            .map((currency) =>
+                EnumValueAsString().getEnumValue(currency.toString()))
+            .toList();
 
-    bloc.initStreamControllers(_currencyList);
+        bloc.initStreamControllers(_currencyList);
 
-    return ListView.separated(
-      separatorBuilder: (BuildContext context, index) {
-        return const Divider(height: 1, thickness: 1);
-      },
-      itemBuilder: (BuildContext context, index) {
-        return AnimatedListEntry(
-          index: index,
-          child: GestureDetector(
-            child: ListTile(
-              title: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: [
-                  Text(
-                    _currencyList[index],
-                    style: TextStyle(fontSize: 16 * _scale),
+        return ListView.separated(
+          separatorBuilder: (BuildContext context, index) {
+            return const Divider(height: 1, thickness: 1);
+          },
+          itemBuilder: (BuildContext context, index) {
+            return AnimatedListEntry(
+              index: index,
+              child: GestureDetector(
+                child: ListTile(
+                  title: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    children: [
+                      Text(
+                        _currencyList[index],
+                        style: TextStyle(fontSize: 16 * _scale),
+                      ),
+                      Flag.fromCode(
+                        flagCodeForCurrency(_currencies[index]),
+                        height: 24 * _scale,
+                        width: 32 * _scale,
+                      ),
+                    ],
                   ),
-                  Flag.fromCode(
-                    flagCodeForCurrency(Currencies.values[index]),
-                    height: 24 * _scale,
-                    width: 32 * _scale,
+                  subtitle: StreamBuilder<String?>(
+                    initialData: bloc.cachedCountryName(_currencyList[index]),
+                    stream: bloc.getCountryNameController(_currencyList[index]),
+                    builder: (context, snapshot) {
+                      bloc.getCountryNameByCurrencyCode(_currencyList[index]);
+                      return Text(
+                        snapshot.data ?? "",
+                        style: TextStyle(fontSize: 14 * _scale),
+                      );
+                    },
                   ),
-                ],
-              ),
-              subtitle: StreamBuilder<String?>(
-                initialData: bloc.cachedCountryName(_currencyList[index]),
-                stream: bloc.getCountryNameController(_currencyList[index]),
-                builder: (context, snapshot) {
-                  bloc.getCountryNameByCurrencyCode(_currencyList[index]);
-                  return Text(
-                    snapshot.data ?? "",
-                    style: TextStyle(fontSize: 14 * _scale),
+                  trailing: Icon(
+                    Icons.chevron_right,
+                    size: 20 * _scale,
+                    color: Theme.of(context).colorScheme.outline,
+                  ),
+                ),
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) => SelectedCurrencyDetailsBlocProvider(
+                        child: SelectedCurrencyDetails(
+                          selectedCurrencyCode: _currencyList[index],
+                        ),
+                      ),
+                    ),
                   );
                 },
               ),
-              trailing: Icon(
-                Icons.chevron_right,
-                size: 20 * _scale,
-                color: Theme.of(context).colorScheme.outline,
-              ),
-            ),
-            onTap: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (context) => SelectedCurrencyDetailsBlocProvider(
-                    child: SelectedCurrencyDetails(
-                      selectedCurrencyCode: _currencyList[index],
-                    ),
-                  ),
-                ),
-              );
-            },
-          ),
+            );
+          },
+          itemCount: _currencyList.length,
         );
       },
-      itemCount: _currencyList.length,
     );
   }
 }

--- a/test/blocs/currency_history_menu_bloc_test.dart
+++ b/test/blocs/currency_history_menu_bloc_test.dart
@@ -1,10 +1,14 @@
 import 'dart:convert';
 
 import 'package:cotacao_direta/blocs/currency_history_menu_bloc.dart';
+import 'package:cotacao_direta/model/configuration.dart';
 import 'package:cotacao_direta/repository/country_names_repository.dart';
+import 'package:cotacao_direta/repository/currency_repository.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
+
+import '../helpers/fakes.dart';
 
 void main() {
   late List<Uri> requestedUris;
@@ -12,14 +16,50 @@ void main() {
   setUp(() => requestedUris = []);
 
   CurrencyHistoryMenuBloc buildBloc(
-      {String body = '[{"name": "Brazil"}]', int status = 200}) {
-    return CurrencyHistoryMenuBloc(countryNamesRepository:
-        CountryNamesRepository(httpClient: MockClient((request) async {
-      requestedUris.add(request.url);
-      return http.Response.bytes(utf8.encode(body), status,
-          headers: {"content-type": "application/json; charset=utf-8"});
-    })));
+      {String body = '[{"name": "Brazil"}]',
+      int status = 200,
+      Configuration? configuration}) {
+    return CurrencyHistoryMenuBloc(
+        countryNamesRepository:
+            CountryNamesRepository(httpClient: MockClient((request) async {
+          requestedUris.add(request.url);
+          return http.Response.bytes(utf8.encode(body), status,
+              headers: {"content-type": "application/json; charset=utf-8"});
+        })),
+        // Sem isto, resolveCounterCurrency() cairia no CurrencyRepository
+        // real e tentaria abrir o banco de configuração de verdade.
+        currencyRepository: CurrencyRepository.withDependencies(
+            configurationRepository:
+                FakeConfigurationRepository(configuration: configuration)));
   }
+
+  group('CurrencyHistoryMenuBloc.counterCurrencyCode', () {
+    test('BRL por padrão, sem configuração de override', () async {
+      var bloc = buildBloc();
+
+      expect(await bloc.counterCurrencyCode, "BRL");
+    });
+
+    test('a moeda escolhida nas configurações, quando o override está ligado',
+        () async {
+      var bloc = buildBloc(
+          configuration: Configuration(1,
+              overrideDefaultCurrency: true,
+              selectedOverrideCurrencyCode: "USD"));
+
+      expect(await bloc.counterCurrencyCode, "USD");
+    });
+
+    test('resolve uma única vez e mantém em cache', () async {
+      var bloc = buildBloc();
+
+      await bloc.counterCurrencyCode;
+      var second = bloc.counterCurrencyCode;
+
+      expect(identical(bloc.counterCurrencyCode, second), isTrue,
+          reason: "a mesma Future precisa voltar sem consultar de novo");
+    });
+  });
 
   group('CurrencyHistoryMenuBloc.initStreamControllers', () {
     test('cria um controller por moeda', () {

--- a/test/view/currency_history_menu_test.dart
+++ b/test/view/currency_history_menu_test.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:cotacao_direta/blocs/currency_history_menu_bloc.dart';
 import 'package:cotacao_direta/enums/currency_enum.dart';
+import 'package:cotacao_direta/model/configuration.dart';
 import 'package:cotacao_direta/providers/currency_history_menu_bloc_provider.dart';
 import 'package:cotacao_direta/repository/country_names_repository.dart';
 import 'package:cotacao_direta/repository/currency_repository.dart';
@@ -25,7 +26,7 @@ void main() {
 
   setUp(() => requests = 0);
 
-  CurrencyHistoryMenuBloc buildBloc() {
+  CurrencyHistoryMenuBloc buildBloc({Configuration? configuration}) {
     return CurrencyHistoryMenuBloc(
         countryNamesRepository:
             CountryNamesRepository(httpClient: MockClient((request) async {
@@ -36,11 +37,13 @@ void main() {
         // Sem isto, resolveCounterCurrency() cairia no CurrencyRepository
         // real e tentaria abrir o banco de configuração de verdade.
         currencyRepository: CurrencyRepository.withDependencies(
-            configurationRepository: FakeConfigurationRepository()));
+            configurationRepository:
+                FakeConfigurationRepository(configuration: configuration)));
   }
 
-  Future<CurrencyHistoryMenuBloc> pumpMenu(WidgetTester tester) async {
-    var bloc = buildBloc();
+  Future<CurrencyHistoryMenuBloc> pumpMenu(WidgetTester tester,
+      {Configuration? configuration}) async {
+    var bloc = buildBloc(configuration: configuration);
     await tester.pumpWidget(_menuApp(bloc));
     return bloc;
   }
@@ -81,6 +84,21 @@ void main() {
       expect(find.text("BRL"), findsNothing,
           reason:
               "BRL contra ela mesma não tem série para o gráfico de histórico");
+    });
+
+    testWidgets(
+        'BRL volta a aparecer quando outra moeda vira a contrapartida',
+        (WidgetTester tester) async {
+      await pumpMenu(tester,
+          configuration: Configuration(1,
+              overrideDefaultCurrency: true,
+              selectedOverrideCurrencyCode: "USD"));
+      await tester.pumpAndSettle();
+
+      expect(find.text("BRL"), findsOneWidget,
+          reason: "BRL contra USD tem série normalmente");
+      expect(find.text("USD"), findsNothing,
+          reason: "agora é USD quem virou a própria contrapartida");
     });
 
     testWidgets('reaproveita os controllers quando a lista é reconstruída',

--- a/test/view/currency_history_menu_test.dart
+++ b/test/view/currency_history_menu_test.dart
@@ -4,11 +4,14 @@ import 'package:cotacao_direta/blocs/currency_history_menu_bloc.dart';
 import 'package:cotacao_direta/enums/currency_enum.dart';
 import 'package:cotacao_direta/providers/currency_history_menu_bloc_provider.dart';
 import 'package:cotacao_direta/repository/country_names_repository.dart';
+import 'package:cotacao_direta/repository/currency_repository.dart';
 import 'package:cotacao_direta/view/pages/main_menu_items/currency_history_menu.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
+
+import '../helpers/fakes.dart';
 
 // Na aplicação a lista fica dentro do Scaffold da home; o ListTile precisa
 // desse Material acima dele.
@@ -23,12 +26,17 @@ void main() {
   setUp(() => requests = 0);
 
   CurrencyHistoryMenuBloc buildBloc() {
-    return CurrencyHistoryMenuBloc(countryNamesRepository:
-        CountryNamesRepository(httpClient: MockClient((request) async {
-      requests++;
-      return http.Response.bytes(utf8.encode('[{"name": "Brazil"}]'), 200,
-          headers: {"content-type": "application/json; charset=utf-8"});
-    })));
+    return CurrencyHistoryMenuBloc(
+        countryNamesRepository:
+            CountryNamesRepository(httpClient: MockClient((request) async {
+          requests++;
+          return http.Response.bytes(utf8.encode('[{"name": "Brazil"}]'), 200,
+              headers: {"content-type": "application/json; charset=utf-8"});
+        })),
+        // Sem isto, resolveCounterCurrency() cairia no CurrencyRepository
+        // real e tentaria abrir o banco de configuração de verdade.
+        currencyRepository: CurrencyRepository.withDependencies(
+            configurationRepository: FakeConfigurationRepository()));
   }
 
   Future<CurrencyHistoryMenuBloc> pumpMenu(WidgetTester tester) async {
@@ -63,6 +71,16 @@ void main() {
           reason: "a lista não pode buscar de novo a cada rebuild");
       expect(afterFirstFrame, lessThanOrEqualTo(Currencies.values.length),
           reason: "no máximo uma consulta por moeda");
+    });
+
+    testWidgets('não lista a moeda usada como contrapartida (BRL por padrão)',
+        (WidgetTester tester) async {
+      await pumpMenu(tester);
+      await tester.pumpAndSettle();
+
+      expect(find.text("BRL"), findsNothing,
+          reason:
+              "BRL contra ela mesma não tem série para o gráfico de histórico");
     });
 
     testWidgets('reaproveita os controllers quando a lista é reconstruída',


### PR DESCRIPTION
## Summary
- `CurrencyRepository.getCurrencyHistoricalData` pula a consulta quando a moeda pedida é a própria contrapartida (BRL, por padrão) — comportamento correto na API, mas o BRL continuava listado normalmente na tela de histórico, então tocar nele sempre levava a um gráfico permanentemente em "Sem Dados", sem indicar por quê.
- `CurrencyRepository._resolveCounterCurrency` vira público (`resolveCounterCurrency`), já que a tela de histórico agora precisa saber qual moeda é a contrapartida atual.
- `CurrencyHistoryMenuBloc` passa a expor essa contrapartida (`counterCurrencyCode`), resolvida uma única vez e cacheada, para não bater no banco de configuração a cada rebuild.
- A tela de histórico (`currency_history_menu.dart`) usa isso para excluir da lista a moeda que hoje é a contrapartida — BRL por padrão, ou a moeda escolhida em Configurações, se o override estiver ligado. Enquanto isso resolve, mostra um `CircularProgressIndicator`, no mesmo padrão de loading já usado no restante do app.

## Test plan
- [x] `flutter analyze` (sem problemas)
- [x] `flutter test` — 186 testes (4 novos: 3 para `CurrencyHistoryMenuBloc.counterCurrencyCode` e 1 confirmando que BRL não aparece mais na lista)
- [x] Validação visual num Chromium headless: a lista de histórico agora começa em AUD, CAD, CZK... (sem BRL entre AUD e CAD), sem erros no console

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TpEUicxvkS1asyA7ampm2U

---
_Generated by [Claude Code](https://claude.ai/code/session_01TpEUicxvkS1asyA7ampm2U)_