### PR TITLE
Adiciona workflow manual para build e publicação do APK debug

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -1,0 +1,42 @@
+name: Build APK
+
+# Sem gatilhos de push/pull_request de propósito: este workflow só roda
+# quando disparado manualmente (aba Actions > Run workflow).
+on:
+  workflow_dispatch:
+
+env:
+  # Deve acompanhar o FLUTTER_VERSION do ci.yml.
+  FLUTTER_VERSION: 3.44.8
+
+jobs:
+  build-apk:
+    name: Build e publica APK (debug)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+          cache: true
+
+      - name: Baixa as dependências
+        run: flutter pub get
+
+      # Build de debug: não depende de chave de assinatura.
+      - name: Compila o APK de debug
+        run: flutter build apk --debug
+
+      - name: Publica o APK como artefato
+        uses: actions/upload-artifact@v4
+        with:
+          name: cotacao_direta-debug-apk
+          path: build/app/outputs/flutter-apk/app-debug.apk
+          if-no-files-found: error


### PR DESCRIPTION
## Summary
- Adiciona `.github/workflows/build-apk.yml`, um novo workflow disparado apenas manualmente (`workflow_dispatch`), sem gatilhos de push/pull_request/branch.
- O workflow compila o app Android em modo debug (`flutter build apk --debug`) e publica o APK gerado como artefato do workflow run (`cotacao_direta-debug-apk`).
- Reaproveita a mesma versão do Flutter (`FLUTTER_VERSION: 3.44.8`) e o setup de Java 17 já usados no job `build-android` do `ci.yml`.

## Test plan
- [ ] Rodar o workflow manualmente na aba Actions ("Run workflow") e confirmar que o job conclui com sucesso.
- [ ] Verificar que o artefato `cotacao_direta-debug-apk` é publicado no run e contém um `app-debug.apk` válido.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YVUWMyvi5k2RcRv2nLRRC4)_