### PR TITLE
Restore missing MainActivity.kt to fix crash on launch

### DIFF
--- a/android/app/src/main/kotlin/com/example/cotacao_direta/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/cotacao_direta/MainActivity.kt
@@ -1,0 +1,5 @@
+package com.example.cotacao_direta
+
+import io.flutter.embedding.android.FlutterActivity
+
+class MainActivity : FlutterActivity()


### PR DESCRIPTION
## Summary
- Fixes the app crashing immediately on launch (reported on Android 12, but affects every Android version).
- `AndroidManifest.xml` declares the launcher activity as `.MainActivity` (`com.example.cotacao_direta.MainActivity`), but the Kotlin source file had been deleted in an earlier package-rename commit and never recreated under the new package path.
- Android resolves manifest-declared activity classes via reflection at launch time, not at build time, so the APK built and installed fine but threw `ClassNotFoundException: com.example.cotacao_direta.MainActivity` the instant the launcher started the activity — an immediate crash on open.
- Recreated `android/app/src/main/kotlin/com/example/cotacao_direta/MainActivity.kt` as a plain `FlutterActivity` subclass, matching the `namespace`/`applicationId` in `android/app/build.gradle`.

## Investigation notes
Also checked common Android 12 (API 31+) launch-crash causes — all were already fine in this codebase, so they were not the cause:
- `PendingIntent` mutability flags: no direct `PendingIntent.get*` calls in app code; `flutter_local_notifications` (^19.0.0) already sets flags internally.
- `android:exported`: `MainActivity`'s intent-filter already declares `android:exported="true"`.
- `targetSdk`/`compileSdk`: sourced from the Flutter SDK, already 31+.
- No foreground services declared.
- AGP/Kotlin/Gradle versions are current with no known Android 12 incompatibilities.

## Test plan
- [ ] Flutter was not available in this environment to build/run — please verify locally with `flutter run` (or a release build) on an Android 12 device/emulator that the launcher activity now starts without crashing.
- [ ] Confirm normal app navigation still works after the splash/launch screen.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ArZDQbb3ub5H6YxMLJuFnq


---
_Generated by [Claude Code](https://claude.ai/code/session_01ArZDQbb3ub5H6YxMLJuFnq)_