### PR TITLE
Fix: gráfico de histórico não aparecia após buscar dados

### DIFF
--- a/lib/view/pages/selected_currency_details.dart
+++ b/lib/view/pages/selected_currency_details.dart
@@ -94,14 +94,9 @@ class SelectedCurrencyDetails extends StatelessWidget {
                 ],
               ),
               Expanded(
-                child: StreamBuilder<bool>(
-                  stream: bloc.isLoadingStream,
-                  initialData: false,
-                  builder: (context, loadingSnapshot) {
-                    if (loadingSnapshot.data == true) {
-                      return const Center(child: CircularProgressIndicator());
-                    }
-                    return StreamBuilder<List<Currency>>(
+                child: Stack(
+                  children: [
+                    StreamBuilder<List<Currency>>(
                       stream: bloc.currencyHistoryStream,
                       builder: (context, snapshot) {
                         final currencyList = snapshot.data;
@@ -139,8 +134,20 @@ class SelectedCurrencyDetails extends StatelessWidget {
                           child: SimpleLineChart(currencyList: currencyList),
                         );
                       },
-                    );
-                  },
+                    ),
+                    StreamBuilder<bool>(
+                      stream: bloc.isLoadingStream,
+                      initialData: false,
+                      builder: (context, loadingSnapshot) {
+                        if (loadingSnapshot.data == true) {
+                          return const Center(
+                            child: CircularProgressIndicator(),
+                          );
+                        }
+                        return const SizedBox.shrink();
+                      },
+                    ),
+                  ],
                 ),
               ),
             ],


### PR DESCRIPTION
## Problema

Na tela de detalhes/histórico da moeda, após selecionar as datas e tocar em "buscar histórico", o gráfico não aparecia na maioria das vezes, mesmo quando a API retornava dados válidos.

## Causa raiz

Em `lib/view/pages/selected_currency_details.dart`, o `StreamBuilder<List<Currency>>` (que renderiza o gráfico) estava aninhado **dentro** do `builder` do `StreamBuilder<bool>` (que controla o loading).

Ambos os streams no bloc são `.broadcast()`, ou seja, não reenviam eventos passados para novos assinantes. A sequência do bug:

1. `getCurrencyHistoryData` emite `isLoading = true` → o `StreamBuilder` externo reconstrói e mostra o spinner, **desmontando** o `StreamBuilder<List<Currency>>` interno (cancelando sua inscrição no stream de dados).
2. A requisição termina e o bloc emite a lista de moedas em `currencyHistoryStream` — mas nesse exato momento não há nenhum assinante (foi desmontado no passo 1), então o evento é **perdido** para sempre.
3. Em seguida `isLoading = false` é emitido → o `StreamBuilder` externo reconstrói de novo, criando um **novo** `StreamBuilder<List<Currency>>` que se inscreve do zero — mas o evento com os dados já passou e não é reenviado.
4. Resultado: `snapshot.data` fica `null`, cai no branch de "sem dados" e o gráfico nunca aparece.

Isso é uma corrida estrutural (a desmontagem sempre ocorre exatamente na janela em que o dado é emitido), por isso o problema acontecia "na maioria das vezes".

## Correção

Os dois `StreamBuilder`s passam a ser irmãos dentro de uma `Stack` (o de loading como um overlay por cima), em vez de um aninhado dentro do outro. Assim a inscrição no `currencyHistoryStream` permanece ativa durante todo o ciclo de loading e o evento com os dados nunca é perdido.

## Test plan

- [x] Revisão manual do fluxo de streams/subscrições
- [x] Testes existentes de `SelectedCurrencyDetailsBloc` continuam válidos (não foram alterados, cobrem apenas o bloc)
- [ ] Validação manual em dispositivo/emulador (não foi possível rodar `flutter` neste ambiente)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WUaTjGPAxkgfz13hvwmrkm)_