### PR TITLE
Perf: elimina buscas de rede/banco redundantes no ciclo de atualização

### DIFF
--- a/lib/blocs/currency_alerts_bloc.dart
+++ b/lib/blocs/currency_alerts_bloc.dart
@@ -54,11 +54,21 @@ class CurrencyAlertsBloc extends BaseBloc {
     var alerts = await _currencyAlertRepository.getAll();
     var pendingAlerts =
         alerts.where((alert) => alert.active && !alert.triggered).toList();
+    if (pendingAlerts.isEmpty) return;
+
+    // Vários alertas costumam ser da mesma moeda: busca cada código uma única
+    // vez, e em paralelo, em vez de uma consulta sequencial por alerta.
+    var currencyCodes = pendingAlerts.map((alert) => alert.currencyCode).toSet();
+    var latestValueByCode = Map.fromEntries(
+      await Future.wait(currencyCodes.map((code) async {
+        var currency = await _currencyRepository.getLatestDataByCurrencyCode(code);
+        return MapEntry(code, currency?.value);
+      })),
+    );
+
     var triggeredAny = false;
     for (var alert in pendingAlerts) {
-      var currency = await _currencyRepository
-          .getLatestDataByCurrencyCode(alert.currencyCode);
-      var value = currency?.value;
+      var value = latestValueByCode[alert.currencyCode];
       if (value == null || !alert.isMetBy(value)) continue;
       alert.triggered = true;
       await _currencyAlertRepository.update(alert);

--- a/lib/repository/configuration_repository.dart
+++ b/lib/repository/configuration_repository.dart
@@ -4,14 +4,34 @@ import 'package:cotacao_direta/model/configuration.dart';
 class ConfigurationRepository {
   final ConfigurationDao _configurationDao;
 
+  // A configuração é lida do banco várias vezes no mesmo ciclo de atualização
+  // (uma por moeda na tela inicial, mais alertas, mais histórico); um cache
+  // curto evita essas leituras repetidas sem arriscar ficar desatualizado por
+  // muito tempo caso o usuário altere as configurações.
+  static const _cacheTtl = Duration(seconds: 2);
+  Configuration? _cachedConfiguration;
+  DateTime? _cachedAt;
+
   ConfigurationRepository({ConfigurationDao? configurationDao})
       : _configurationDao = configurationDao ?? ConfigurationDao();
 
   Future<void> insert(Configuration configuration) async {
-    return _configurationDao.insert(configuration);
+    await _configurationDao.insert(configuration);
+    _cachedConfiguration = configuration;
+    _cachedAt = DateTime.now();
   }
 
   Future<Configuration> getConfiguration() async {
-    return _configurationDao.getConfiguration();
+    final cached = _cachedConfiguration;
+    final cachedAt = _cachedAt;
+    if (cached != null &&
+        cachedAt != null &&
+        DateTime.now().difference(cachedAt) < _cacheTtl) {
+      return cached;
+    }
+    final configuration = await _configurationDao.getConfiguration();
+    _cachedConfiguration = configuration;
+    _cachedAt = DateTime.now();
+    return configuration;
   }
 }

--- a/lib/repository/currency_repository.dart
+++ b/lib/repository/currency_repository.dart
@@ -191,24 +191,22 @@ class CurrencyRepository {
             .get(_historyUri(currencyCode, counterCurrency, start, end));
         currencyListToSave.addAll(_parseHistory(response.body, currencyCode));
       }
-      await _currencyDao.insertMany(currencyListToSave
-          .where((currency) =>
-              (DateTime.now().year -
-                  DateTime.parse(currency.historicalDate!).year) <
-              10)
+
+      // Cada registro carrega sua data já convertida uma única vez, em vez de
+      // reparsear a mesma string repetidamente no filtro e no comparador do
+      // sort.
+      var dated = currencyListToSave
+          .map((currency) =>
+              (currency: currency, date: DateTime.parse(currency.historicalDate!)))
+          .toList();
+
+      await _currencyDao.insertMany(dated
+          .where((entry) => (DateTime.now().year - entry.date.year) < 10)
+          .map((entry) => entry.currency)
           .toList());
-      currencyListToSave.sort((a, b) {
-        DateTime dateCurrencyA = DateTime.parse(a.historicalDate!);
-        DateTime dateCurrencyB = DateTime.parse(b.historicalDate!);
-        if (dateCurrencyA.isBefore(dateCurrencyB)) {
-          return -1;
-        } else if (dateCurrencyA.isAfter(dateCurrencyB)) {
-          return 1;
-        } else {
-          return 0;
-        }
-      });
-      return currencyListToSave;
+
+      dated.sort((a, b) => a.date.compareTo(b.date));
+      return dated.map((entry) => entry.currency).toList();
     } else
       return await _currencyDao.getHistoricalData(
           currencyCodeList, initialDate, finalDate);

--- a/lib/util/network_util.dart
+++ b/lib/util/network_util.dart
@@ -8,9 +8,36 @@ typedef AddressLookup = Future<List<InternetAddress>> Function(String host);
 class NetworkUtils {
   final AddressLookup? _lookup;
 
+  // Cada moeda buscada (as 4 da tela inicial, mais alertas, mais histórico)
+  // checa a rede antes de tudo; sem isto, um único ciclo de atualização
+  // dispara várias consultas de DNS/HTTP idênticas em sequência. O cache é
+  // curto o bastante para não mascarar uma queda de conexão por muito tempo.
+  static const _cacheTtl = Duration(seconds: 5);
+  bool? _cachedResult;
+  DateTime? _cachedAt;
+  Future<bool>? _pendingCheck;
+
   NetworkUtils({AddressLookup? lookup}) : _lookup = lookup;
 
-  Future<bool> isNetworkAvailable() async {
+  Future<bool> isNetworkAvailable() {
+    final cachedResult = _cachedResult;
+    final cachedAt = _cachedAt;
+    if (cachedResult != null &&
+        cachedAt != null &&
+        DateTime.now().difference(cachedAt) < _cacheTtl) {
+      return Future.value(cachedResult);
+    }
+    // Concorrência: várias chamadas quase simultâneas compartilham a mesma
+    // checagem em andamento em vez de disparar uma para cada uma.
+    return _pendingCheck ??= _checkNetworkAvailable().then((result) {
+      _cachedResult = result;
+      _cachedAt = DateTime.now();
+      _pendingCheck = null;
+      return result;
+    });
+  }
+
+  Future<bool> _checkNetworkAvailable() async {
     if (_lookup != null) {
       try {
         final result = await _lookup("google.com");

--- a/lib/view/pages/home.dart
+++ b/lib/view/pages/home.dart
@@ -40,6 +40,11 @@ class HomeState extends State<Home> with SingleTickerProviderStateMixin {
 
   var fabVisibility = true;
 
+  // Garante que a busca inicial de cotação/alertas rode uma única vez: como
+  // ela depende do context (localizations), não pode ir para initState, mas
+  // build() roda de novo a cada troca de aba e não deve refazer a busca.
+  var _initialFetchScheduled = false;
+
   late final AnimationController _circlesAnimationController;
   late final List<Animation<double>> _circleScaleAnimations;
   late final List<Animation<double>> _circleFadeAnimations;
@@ -151,12 +156,15 @@ class HomeState extends State<Home> with SingleTickerProviderStateMixin {
     _bloc = HomeBlocProvider.of(context);
     _alertsBloc = CurrencyAlertsBlocProvider.of(context);
 
-    WidgetsBinding.instance.addPostFrameCallback(
-      (_) => _bloc.getSelectedOverrideCurrency(),
-    );
-    WidgetsBinding.instance.addPostFrameCallback(
-      (_) => _checkCurrencyAlerts(context),
-    );
+    if (!_initialFetchScheduled) {
+      _initialFetchScheduled = true;
+      WidgetsBinding.instance.addPostFrameCallback(
+        (_) => _bloc.getSelectedOverrideCurrency(),
+      );
+      WidgetsBinding.instance.addPostFrameCallback(
+        (_) => _checkCurrencyAlerts(context),
+      );
+    }
 
     final pageHeader = StreamBuilder(
       builder: (BuildContext context, snapshot) {
@@ -394,7 +402,12 @@ class HomeState extends State<Home> with SingleTickerProviderStateMixin {
           icon: Icon(Icons.compare_arrows),
         ),
       ),
-      body: _widgetOptions.elementAt(_selectedIndex),
+      // IndexedStack mantém as 5 abas montadas o tempo todo, só alternando
+      // qual fica visível. Isso evita que trocar de aba destrua e recrie o
+      // estado da anterior (cotações já buscadas, animações etc.), o que
+      // forçaria buscas repetidas de rede/banco toda vez que o usuário volta
+      // para uma aba já visitada.
+      body: IndexedStack(index: _selectedIndex, children: _widgetOptions),
     );
   }
 }

--- a/lib/view/pages/main_menu_items/currency_alerts_page.dart
+++ b/lib/view/pages/main_menu_items/currency_alerts_page.dart
@@ -8,11 +8,21 @@ import 'package:cotacao_direta/util/responsive.dart';
 import 'package:cotacao_direta/util/string_utils.dart';
 import 'package:flutter/material.dart';
 
-class CurrencyAlertsPage extends StatelessWidget {
+class CurrencyAlertsPage extends StatefulWidget {
+  @override
+  State<CurrencyAlertsPage> createState() => _CurrencyAlertsPageState();
+}
+
+class _CurrencyAlertsPageState extends State<CurrencyAlertsPage> {
+  var _alertsLoaded = false;
+
   @override
   Widget build(BuildContext context) {
     final _bloc = CurrencyAlertsBlocProvider.of(context);
-    WidgetsBinding.instance.addPostFrameCallback((_) => _bloc.loadAlerts());
+    if (!_alertsLoaded) {
+      _alertsLoaded = true;
+      WidgetsBinding.instance.addPostFrameCallback((_) => _bloc.loadAlerts());
+    }
     final _localization = MyAppLocalizations.of(context)!;
     final _scale = Responsive.scaleFactor(context);
     final _currencyList = List.generate(Currencies.values.length, (index) {


### PR DESCRIPTION
## Problema

Um levantamento de desempenho no app encontrou vários pontos onde a mesma leitura de rede/banco era repetida sem necessidade dentro do mesmo ciclo de atualização, principalmente por causa de código de busca de dados disparado a cada `build()` em vez de uma vez por visita à tela.

## Mudanças

- **`Home.build()`** reagendava a busca da moeda de destaque e a checagem de todos os alertas a cada rebuild — inclusive ao trocar para as abas de Configurações/Sobre/etc. Agora roda uma única vez por montagem da tela (guardado por uma flag).
- **Troca de aba na Home** usava `elementAt(_selectedIndex)`, o que destruía e recriava a página anterior inteira a cada troca (perdendo cotações já buscadas e forçando refetch ao voltar). Trocado por `IndexedStack`, que mantém as 5 abas montadas e só alterna a visibilidade.
- **`CurrencyAlertsPage`** tinha o mesmo problema: recarregava a lista de alertas a cada rebuild. Convertida para `StatefulWidget` para carregar uma única vez.
- **`CurrencyAlertsBloc.checkAlerts`** buscava a cotação de cada alerta em série (um `await` por alerta), sem aproveitar quando dois alertas eram da mesma moeda. Agora busca cada código de moeda uma única vez, em paralelo.
- **`ConfigurationRepository.getConfiguration()`** era lido do banco a cada chamada — e é chamado uma vez por cada uma das 4 moedas da tela inicial, mais alertas, mais histórico, no mesmo ciclo. Ganhou um cache curto (2s) que não compromete refletir mudanças do usuário nas configurações.
- **`NetworkUtils.isNetworkAvailable()`** fazia uma nova checagem de DNS/rede a cada busca de moeda (o mesmo padrão de repetição). Ganhou cache curto (5s) e deduplicação de chamadas concorrentes (chamadas simultâneas compartilham a mesma checagem em andamento).
- **`CurrencyRepository.getCurrencyHistoricalData`** parseava a mesma string de data duas vezes por registro durante o `sort` (uma vez no filtro, outra no comparador). Agora cada data é parseada uma única vez.

Uma otimização adicional considerada — paralelizar a busca de histórico quando várias moedas são pedidas de uma vez — foi deixada de fora: hoje o app só pede uma moeda por vez nesse fluxo, então não haveria ganho real, e a mudança arriscaria a ordem das requisições que um teste existente verifica.

## Test plan

- [x] Revisão manual de cada mudança e dos testes existentes que exercitam os arquivos alterados (`ConfigurationRepository`, `NetworkUtils`, `CurrencyAlertsBloc`, `CurrencyRepository`) para confirmar que continuam passando com o novo comportamento
- [ ] Validação manual em dispositivo/emulador (não foi possível rodar `flutter` neste ambiente)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WUaTjGPAxkgfz13hvwmrkm)_