### PR TITLE
CI: publica a versão web no GitHub Pages

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,60 @@
+name: Deploy Web no GitHub Pages
+
+on:
+  push:
+    branches: [master]
+  # Permite disparar manualmente pela aba Actions, sem precisar de um push novo.
+  workflow_dispatch:
+
+env:
+  # Deve acompanhar o FLUTTER_VERSION do ci.yml.
+  FLUTTER_VERSION: 3.44.8
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Publicações concorrentes no Pages não fazem sentido: a mais recente sempre
+# vence. Diferente do `cancel-in-progress` do ci.yml, aqui uma publicação em
+# andamento não é cancelada por uma nova (evita deixar o site pela metade).
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Build e publica no GitHub Pages
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+          cache: true
+
+      - name: Baixa as dependências
+        run: flutter pub get
+
+      # --base-href precisa bater com o caminho do site de projeto no GitHub
+      # Pages (https://<usuário>.github.io/<repositório>/); sem isso os
+      # assets carregam com o caminho errado e a página fica em branco.
+      - name: Compila o app Web (release)
+        run: flutter build web --release --base-href /cotacao_direta/
+
+      - name: Configura o GitHub Pages
+        uses: actions/configure-pages@v5
+
+      - name: Publica os arquivos como artefato do Pages
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: build/web
+
+      - name: Publica no GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Problema

O app não tinha nenhuma versão web hospedada para testar — o CI só compila o build web (`ci.yml`, job `Build Web`) como verificação, em modo debug, sem publicar o resultado em lugar nenhum.

## Mudança

Novo workflow `.github/workflows/deploy-pages.yml`, que roda a cada push no `master` (ou manualmente pela aba Actions):

1. Compila o app em modo **release** com `--base-href /cotacao_direta/` — necessário porque um site de projeto no GitHub Pages fica em `https://hhldiniz.github.io/cotacao_direta/`, um subcaminho, não na raiz do domínio. O `web/index.html` já tem o placeholder `$FLUTTER_BASE_HREF` pronto para isso.
2. Publica o resultado usando o fluxo oficial do GitHub (`actions/configure-pages` + `actions/upload-pages-artifact` + `actions/deploy-pages`), sem depender de uma branch `gh-pages`.

Não mexi no job `Build Web` existente do `ci.yml` — ele continua rodando em toda PR como verificação rápida (build debug), independente deste deploy.

## ⚠️ Ação manual necessária (uma única vez)

O GitHub exige que a fonte do Pages seja selecionada manualmente antes da primeira publicação via Actions — não há API/token com permissão para isso a partir do workflow. Antes deste PR ser mergeado (ou logo depois), acesse:

**Settings → Pages → Build and deployment → Source → selecione "GitHub Actions"**

Sem isso, o job `deploy` vai falhar no primeiro push ao `master` com um erro do tipo "Get Pages site failed". Depois de configurado uma vez, todo push ao `master` publica automaticamente em `https://hhldiniz.github.io/cotacao_direta/`.

## Test plan

- [ ] Configurar Settings → Pages → Source → GitHub Actions (manual, uma vez)
- [ ] Confirmar que o job `deploy` do workflow roda e publica com sucesso após o merge
- [ ] Abrir `https://hhldiniz.github.io/cotacao_direta/` e confirmar que o app carrega (sem tela branca, o que indicaria `--base-href` incorreto)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WUaTjGPAxkgfz13hvwmrkm)_