### PR TITLE
fix: valores da tela de bolhas somem ao trocar de aba e voltar

### DIFF
--- a/lib/view/pages/home.dart
+++ b/lib/view/pages/home.dart
@@ -49,6 +49,14 @@ class HomeState extends State<Home> with SingleTickerProviderStateMixin {
   late final List<Animation<double>> _circleScaleAnimations;
   late final List<Animation<double>> _circleFadeAnimations;
 
+  // getNextStreamController() fecha e recria o StreamController se já houver
+  // um listener; chamá-la a cada build (o que acontece ao trocar de aba, já
+  // que dispara setState) descartaria o stream em uso e o cabeçalho pararia
+  // de receber atualizações. Por isso a stream é obtida uma única vez por
+  // bloc, aqui em cache.
+  Stream<String?>? _headerStream;
+  HomeBloc? _headerStreamBloc;
+
   HomeState(this._pageTitle);
 
   @override
@@ -155,6 +163,10 @@ class HomeState extends State<Home> with SingleTickerProviderStateMixin {
     final _scale = Responsive.scaleFactor(context);
     _bloc = HomeBlocProvider.of(context);
     _alertsBloc = CurrencyAlertsBlocProvider.of(context);
+    if (!identical(_headerStreamBloc, _bloc)) {
+      _headerStreamBloc = _bloc;
+      _headerStream = _bloc.getNextStreamController();
+    }
 
     if (!_initialFetchScheduled) {
       _initialFetchScheduled = true;
@@ -182,7 +194,7 @@ class HomeState extends State<Home> with SingleTickerProviderStateMixin {
           );
         }
       },
-      stream: _bloc.getNextStreamController(),
+      stream: _headerStream,
     );
 
     final dollarExchangeRate = DollarExchangeRate(

--- a/lib/view/widgets/exchange_rate_value.dart
+++ b/lib/view/widgets/exchange_rate_value.dart
@@ -26,11 +26,23 @@ class ExchangeRateValueState extends State<ExchangeRateValue> {
   final _formatter = NumberFormat("#.###");
   final Currencies _currency;
 
+  // A stream só pode ser obtida uma vez por bloc: getNextStreamController()
+  // fecha e recria o StreamController se já houver um listener, então
+  // chamá-la de novo a cada build (o que acontece ao trocar de aba e voltar,
+  // já que o Home reconstrói a árvore) descartaria o stream em uso e
+  // deixaria a tela sem receber novos valores.
+  Stream<num?>? _stream;
+  ExchangeValueBloc? _streamBloc;
+
   ExchangeRateValueState(this._currency);
 
   @override
   void didChangeDependencies() {
     bloc = ExchangeValueBlocProvider.of(context);
+    if (!identical(_streamBloc, bloc)) {
+      _streamBloc = bloc;
+      _stream = bloc.getNextStreamController();
+    }
     bloc
         .retrieveCurrencyValue(_currency)
         .then((value) {
@@ -59,7 +71,7 @@ class ExchangeRateValueState extends State<ExchangeRateValue> {
   @override
   Widget build(BuildContext context) {
     return StreamBuilder<num?>(
-      stream: bloc.getNextStreamController(),
+      stream: _stream,
       builder: (context, snapshot) =>
           NotificationListener<UpdateCurrencyValueNotification>(
             onNotification: (UpdateCurrencyValueNotification notification) {

--- a/test/view/exchange_rate_value_test.dart
+++ b/test/view/exchange_rate_value_test.dart
@@ -69,6 +69,52 @@ void main() {
       expect(find.text("5.42"), findsOneWidget);
     });
 
+    testWidgets(
+        'mantém o valor após um rebuild da árvore (troca de aba e volta)',
+        (WidgetTester tester) async {
+      late StateSetter rebuild;
+
+      // O StatefulBuilder por cima do ExchangeValueBlocProvider reproduz o
+      // que o Home faz ao trocar de aba: chama setState, o que reconstrói a
+      // subárvore inteira (novas instâncias de ExchangeValueBlocProvider e
+      // ExchangeRateValue) sem que nenhum InheritedWidget do qual o widget
+      // dependa realmente mude — então didChangeDependencies não é chamado
+      // de novo, só build().
+      await tester.pumpWidget(MaterialApp(
+        locale: const Locale("pt"),
+        localizationsDelegates: [
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+          MyAppLocalizationsDelegate()
+        ],
+        supportedLocales: const [Locale("pt"), Locale("en")],
+        home: StatefulBuilder(
+          builder: (context, setState) {
+            rebuild = setState;
+            return ExchangeValueBlocProvider(
+              bloc: _FakeExchangeValueBloc(0.2),
+              child: ExchangeRateValue(Currencies.USD),
+            );
+          },
+        ),
+      ));
+      await tester.pump();
+
+      expect(find.text("5"), findsOneWidget);
+
+      // Antes da correção, esse rebuild descartava o StreamController em uso
+      // (getNextStreamController fechava e recriava o stream porque já
+      // havia um listener) e nada mais empurrava um novo valor para ele, já
+      // que nenhuma busca é refeita nesse tipo de rebuild.
+      rebuild(() {});
+      await tester.pump();
+
+      expect(find.text("5"), findsOneWidget);
+      expect(find.text(""), findsNothing);
+      expect(find.text("Sem Dados"), findsNothing);
+    });
+
     testWidgets('não mostra nada enquanto a cotação não chega',
         (WidgetTester tester) async {
       await tester.pumpWidget(MaterialApp(


### PR DESCRIPTION
## Summary

- Corrige o bug em que os valores das cotações na tela de bolhas (dólar, euro, dólar canadense, iene) carregam corretamente na primeira vez, mas somem para sempre ao trocar de aba e voltar.
- Causa raiz: `getNextStreamController()` (em `ExchangeValueBloc` e `HomeBloc`) fecha e recria o `StreamController` sempre que já existe um listener. Ela era chamada diretamente dentro de `build()`, então qualquer rebuild da árvore — como o `setState` disparado ao trocar de aba no `IndexedStack` da `Home` — descartava o stream em uso e colocava um vazio no lugar. Como nenhuma nova busca é refeita nesse tipo de rebuild, o novo stream nunca recebia um valor e a cotação ficava em branco permanentemente.
- Correção: a stream agora é obtida uma única vez por instância de bloc e mantida em cache, tanto em `ExchangeRateValueState` (valores das bolhas) quanto em `HomeState` (texto de cabeçalho, que tinha o mesmo problema).

## Test plan

- [x] Adicionado teste de regressão em `test/view/exchange_rate_value_test.dart` que reproduz o rebuild de árvore sem mudança de dependência (o mesmo padrão do `setState` ao trocar de aba) e confirma que o valor permanece visível.
- [x] Confirmado manualmente que o novo teste falha sem a correção (o texto some) e passa com ela.
- [x] `flutter analyze` sem problemas nos arquivos alterados.
- [x] `flutter test` — todos os 220 testes passando.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BUuVvqjxWQr4HJQ7HntXa5)_