### PR TITLE
fix: texto das bolhas mostrava dólar em vez da moeda das cotações

### DIFF
--- a/lib/blocs/home_bloc.dart
+++ b/lib/blocs/home_bloc.dart
@@ -1,17 +1,16 @@
 import 'dart:async';
 
 import 'package:cotacao_direta/blocs/base_bloc.dart';
-import 'package:cotacao_direta/enums/currency_enum.dart';
-import 'package:cotacao_direta/model/configuration.dart';
-import 'package:cotacao_direta/model/currency.dart';
-import 'package:cotacao_direta/repository/configuration_repository.dart';
 import 'package:cotacao_direta/repository/currency_repository.dart';
-import 'package:cotacao_direta/util/string_utils.dart';
+import 'package:cotacao_direta/util/currency_name.dart';
+import 'package:flutter/widgets.dart';
 
 class HomeBloc extends BaseBloc {
-  ConfigurationRepository _configurationRepository = ConfigurationRepository();
-  CurrencyRepository _currencyRepository = CurrencyRepository();
+  final CurrencyRepository _currencyRepository;
   StreamController<String?>? _headsUpTextStreamController;
+
+  HomeBloc({CurrencyRepository? currencyRepository})
+      : _currencyRepository = currencyRepository ?? CurrencyRepository();
 
   Stream<String?> getNextStreamController() {
     if (_headsUpTextStreamController == null) {
@@ -26,29 +25,23 @@ class HomeBloc extends BaseBloc {
     }
   }
 
-  getSelectedOverrideCurrency() {
-    _configurationRepository
-        .getConfiguration()
-        .then((Configuration configuration) {
-      if (configuration.overrideDefaultCurrency) {
-        _currencyRepository
-            .getLatestDataByCurrencyCode(configuration.selectedOverrideCurrencyCode)
-            .then((Currency? currency) {
-          _headsUpTextStreamController!.sink.add(currency != null
-              ? currency.friendlyName
-              : configuration.selectedOverrideCurrencyCode);
-        });
-      } else {
-        _currencyRepository
-            .getLatestDataByCurrencyCode(
-                EnumValueAsString().getEnumValue(Currencies.USD.toString()))
-            .then((Currency? currency) {
-          _headsUpTextStreamController!.sink.add(currency != null
-              ? currency.friendlyName
-              : EnumValueAsString().getEnumValue(Currencies.USD.toString()));
-        });
-      }
-    });
+  /// Publica o nome da moeda em que as cotações das bolhas estão expressas:
+  /// cada bolha mostra quanto vale uma unidade da sua moeda na contrapartida
+  /// usada hoje (ver [CurrencyRepository.resolveCounterCurrency]), que é o real
+  /// ou a moeda escolhida nas configurações — e não o dólar, que é só mais uma
+  /// das moedas cotadas.
+  ///
+  /// O nome vem do mapa local de nomes, e não do `friendlyName` gravado com a
+  /// cotação: a contrapartida não é cotada contra ela mesma, então não existe
+  /// registro com o nome dela vindo da API.
+  Future<void> loadCounterCurrencyName(Locale locale) async {
+    var counterCurrencyCode =
+        await _currencyRepository.resolveCounterCurrency();
+    // A stream pode ter sido fechada enquanto a configuração era lida, se a
+    // tela saiu da árvore nesse meio-tempo.
+    var controller = _headsUpTextStreamController;
+    if (controller == null || controller.isClosed) return;
+    controller.sink.add(currencyNameForCode(counterCurrencyCode, locale));
   }
 
   @override

--- a/lib/util/currency_name.dart
+++ b/lib/util/currency_name.dart
@@ -57,3 +57,22 @@ String currencyName(Currencies currency, Locale locale) {
 
 /// Código ISO 4217 da moeda, que é o próprio nome do valor do enum.
 String currencyCode(Currencies currency) => currency.name;
+
+/// Moeda correspondente a um código ISO 4217, ou nulo para um código que o app
+/// não conhece.
+Currencies? currencyForCode(String? code) {
+  if (code == null || code.isEmpty) return null;
+  var upperCaseCode = code.toUpperCase();
+  for (var currency in Currencies.values) {
+    if (currency.name == upperCaseCode) return currency;
+  }
+  return null;
+}
+
+/// Nome da moeda de [code] no idioma de [locale]. Um código desconhecido fica
+/// com o próprio código como nome: é o que o app tem para mostrar, e ainda
+/// identifica a moeda.
+String currencyNameForCode(String? code, Locale locale) {
+  var currency = currencyForCode(code);
+  return currency == null ? (code ?? "") : currencyName(currency, locale);
+}

--- a/lib/util/localizations.dart
+++ b/lib/util/localizations.dart
@@ -14,7 +14,7 @@ class MyAppLocalizations {
     'en': {
       'conversionButtonLabel': 'Conversions',
       'conversionPageTitle': "Currency Conversion",
-      'homePageHeadsUpText': 'The %s today is worth',
+      'homePageHeadsUpText': 'Exchange rates in %s',
       'convertActionBtnLabel': 'Convert',
       'conversionMultiplierHint': 'Amount',
       'conversionPageExplanationText': 'Insert the amount value of the currency '
@@ -72,7 +72,7 @@ class MyAppLocalizations {
     'pt': {
       'conversionButtonLabel': "Conversões",
       'conversionPageTitle': "Conversão de Moedas",
-      'homePageHeadsUpText': "O %s vale hoje",
+      'homePageHeadsUpText': "Cotações em %s",
       'convertActionBtnLabel': "Converter",
       'conversionMultiplierHint': 'Quantidade',
       'conversionPageExplanationText': 'Insira a quantidade da moeda que será '

--- a/lib/view/pages/home.dart
+++ b/lib/view/pages/home.dart
@@ -136,10 +136,16 @@ class HomeState extends State<Home> with SingleTickerProviderStateMixin {
   }
 
   Future<void> _refreshRates(BuildContext context) async {
-    _bloc.getSelectedOverrideCurrency();
+    _loadCounterCurrencyName(context);
     _checkCurrencyAlerts(context);
     UpdateCurrencyValueNotification().dispatch(context);
     await Future.delayed(const Duration(milliseconds: 400));
+  }
+
+  /// Pede ao bloc o nome da moeda em que as cotações estão expressas, no idioma
+  /// da tela, para o texto acima das bolhas.
+  void _loadCounterCurrencyName(BuildContext context) {
+    _bloc.loadCounterCurrencyName(MyAppLocalizations.of(context)!.locale);
   }
 
   /// Confere os alertas de câmbio cadastrados contra a cotação mais recente.
@@ -171,7 +177,7 @@ class HomeState extends State<Home> with SingleTickerProviderStateMixin {
     if (!_initialFetchScheduled) {
       _initialFetchScheduled = true;
       WidgetsBinding.instance.addPostFrameCallback(
-        (_) => _bloc.getSelectedOverrideCurrency(),
+        (_) => _loadCounterCurrencyName(context),
       );
       WidgetsBinding.instance.addPostFrameCallback(
         (_) => _checkCurrencyAlerts(context),
@@ -394,6 +400,10 @@ class HomeState extends State<Home> with SingleTickerProviderStateMixin {
             fabVisibility = index == 0;
             _selectedIndex = index;
           });
+          // A moeda de contrapartida pode ter mudado na aba de opções: ao
+          // voltar para as bolhas, o texto do cabeçalho precisa acompanhar a
+          // moeda em que as cotações passam a ser mostradas.
+          if (index == 0) _loadCounterCurrencyName(context);
         },
       ),
       floatingActionButton: Visibility(

--- a/test/blocs/home_bloc_test.dart
+++ b/test/blocs/home_bloc_test.dart
@@ -1,0 +1,58 @@
+import 'package:cotacao_direta/blocs/home_bloc.dart';
+import 'package:cotacao_direta/model/configuration.dart';
+import 'package:cotacao_direta/repository/currency_repository.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../helpers/fakes.dart';
+
+void main() {
+  // Sem repositório injetado, resolveCounterCurrency() cairia no
+  // CurrencyRepository real e tentaria abrir o banco de verdade.
+  HomeBloc buildBloc({Configuration? configuration}) => HomeBloc(
+      currencyRepository: CurrencyRepository.withDependencies(
+          configurationRepository:
+              FakeConfigurationRepository(configuration: configuration)));
+
+  group('HomeBloc.loadCounterCurrencyName', () {
+    test('publica o real quando não há moeda sobrescrita', () async {
+      var bloc = buildBloc();
+      var stream = bloc.getNextStreamController();
+
+      await bloc.loadCounterCurrencyName(const Locale("pt"));
+
+      expect(await stream.first, "Real Brasileiro");
+    });
+
+    test('publica a moeda escolhida nas configurações, e não o dólar',
+        () async {
+      var bloc = buildBloc(
+          configuration: Configuration(1,
+              overrideDefaultCurrency: true,
+              selectedOverrideCurrencyCode: "JPY"));
+      var stream = bloc.getNextStreamController();
+
+      await bloc.loadCounterCurrencyName(const Locale("pt"));
+
+      expect(await stream.first, "Iene Japonês");
+    });
+
+    test('traduz o nome para o idioma da tela', () async {
+      var bloc = buildBloc();
+      var stream = bloc.getNextStreamController();
+
+      await bloc.loadCounterCurrencyName(const Locale("en"));
+
+      expect(await stream.first, "Brazilian Real");
+    });
+
+    test('não quebra se a stream já foi fechada', () async {
+      var bloc = buildBloc();
+      bloc.getNextStreamController();
+      bloc.dispose();
+
+      await expectLater(
+          bloc.loadCounterCurrencyName(const Locale("pt")), completes);
+    });
+  });
+}

--- a/test/util/currency_name_test.dart
+++ b/test/util/currency_name_test.dart
@@ -25,6 +25,31 @@ void main() {
     });
   });
 
+  group('currencyForCode', () {
+    test('encontra a moeda pelo código', () {
+      expect(currencyForCode("BRL"), Currencies.BRL);
+      expect(currencyForCode("jpy"), Currencies.JPY);
+    });
+
+    test('devolve nulo para um código desconhecido ou vazio', () {
+      expect(currencyForCode("XXX"), isNull);
+      expect(currencyForCode(""), isNull);
+      expect(currencyForCode(null), isNull);
+    });
+  });
+
+  group('currencyNameForCode', () {
+    test('traduz o nome da moeda do código', () {
+      expect(currencyNameForCode("BRL", const Locale("pt")), "Real Brasileiro");
+      expect(currencyNameForCode("BRL", const Locale("en")), "Brazilian Real");
+    });
+
+    test('usa o próprio código quando a moeda é desconhecida', () {
+      expect(currencyNameForCode("XXX", const Locale("pt")), "XXX");
+      expect(currencyNameForCode(null, const Locale("pt")), "");
+    });
+  });
+
   group('currencyCode', () {
     test('usa o próprio nome do valor do enum', () {
       expect(currencyCode(Currencies.BRL), "BRL");


### PR DESCRIPTION
## Problema

O texto acima das bolhas da tela inicial dizia sempre "O Dólar Americano vale hoje", mesmo quando as cotações mostradas nas bolhas não tinham o dólar como contrapartida.

O `HomeBloc.getSelectedOverrideCurrency()` buscava o `friendlyName` de **USD** sempre que o override de moeda estava desligado — mas nesse caso a contrapartida das cotações é o **real** (`CurrencyRepository.resolveCounterCurrency()`), e cada bolha mostra quanto vale uma unidade da sua moeda em reais. O dólar ali é só mais uma das moedas cotadas.

Com o override ligado o texto também não se resolvia: o bloc lia o registro salvo da moeda escolhida, e a contrapartida não é cotada contra ela mesma, então esse registro não tem nome vindo da API.

## Mudanças

- `HomeBloc` agora publica o nome da moeda que as bolhas realmente usam como contrapartida, resolvida por `CurrencyRepository.resolveCounterCurrency()` (real por padrão, ou a moeda escolhida nas configurações). O bloc passou a receber o repositório pelo construtor, como os demais.
- O nome sai do mapa local de `currency_name.dart`, no idioma da tela, e não do `friendlyName` gravado com a cotação — que não existe para a contrapartida. Para isso foram adicionados `currencyForCode` e `currencyNameForCode`.
- O texto localizado mudou de forma junto com o conteúdo: `"O %s vale hoje"` → `"Cotações em %s"` (`"The %s today is worth"` → `"Exchange rates in %s"`). As bolhas mostram o valor de uma unidade de cada moeda **na** contrapartida, então a frase antiga ficaria invertida ao nomeá-la ("O Real Brasileiro vale hoje / USD 5,4").
- O nome é recarregado ao voltar para a aba das bolhas, para acompanhar uma troca de moeda feita na aba de opções (a tela fica montada dentro do `IndexedStack` e não refazia essa leitura).

## Testes

- Novo `test/blocs/home_bloc_test.dart`: publica o real sem override, publica a moeda escolhida (e não o dólar) com override, traduz para o idioma da tela e não quebra com a stream já fechada.
- `test/util/currency_name_test.dart` cobre `currencyForCode` e `currencyNameForCode`.
- `flutter analyze` sem apontamentos e `flutter test` com os 268 testes passando (Flutter 3.44.8, a versão fixada no CI).

## Fora do escopo

A cotação salva é chaveada só pelo código da moeda, sem a contrapartida, e vale por uma hora: ao trocar a moeda nas configurações as bolhas podem seguir mostrando por até uma hora valores calculados contra a contrapartida anterior, até um "puxar para atualizar". Corrigir isso exige mudar o esquema do banco, então ficou de fora daqui.

---
_Generated by [Claude Code](https://claude.ai/code/session_013qBZCjsrfLYvWjbqEesFsi)_