### PR TITLE
On-device AI financial analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,63 @@ selecionado em tempo de execução por `lib/util/database.dart`:
   `dart run sqflite_common_ffi_web:setup --force`, se a versão do pacote
   mudar.
 
+## IA local: insights e projeções
+
+A aba **IA** analisa um ativo (moeda ou criptomoeda) e mostra um resumo de
+mercado, uma projeção com faixa de confiança e observações em texto. Tudo é
+calculado no próprio aparelho: não há modelo para baixar, plugin nativo,
+chamada a serviço de IA nem envio de dados para fora. A única requisição de
+rede é a busca de cotações que o app já fazia.
+
+O modelo tem duas peças, que se cobrem:
+
+- uma **rede neural** de uma camada escondida (perceptron multicamada) escrita
+  em Dart puro (`lib/ai/neural/neural_network.dart`), treinada na hora com o
+  histórico do próprio ativo. Ela recebe uma janela de log-retornos recentes
+  mais quatro indicadores derivados (momento, IFR, distância da média em
+  desvios padrão e aceleração da volatilidade) e prevê o retorno do dia
+  seguinte; a projeção de vários dias sai da aplicação repetida dessa previsão;
+- uma **deriva estatística**, a média exponencial dos log-retornos, amortecida
+  ao longo do horizonte para não extrapolar uma tendência em linha reta.
+
+O peso de cada peça na projeção final não é arbitrário. Um trecho do fim da
+série é separado do treino e nele a rede é comparada com o passeio aleatório
+("amanhã é igual a hoje"); o peso da rede é proporcional à vantagem obtida e
+tem teto de 60%. Quando a rede não supera o passeio aleatório — o caso comum,
+já que preço de ativo é quase um passeio aleatório —, o peso vai a zero e a
+projeção passa a ser a base estatística. Esse número aparece na tela, em
+"Vantagem sobre o passeio aleatório", para a projeção ser lida pelo que ela é.
+
+A faixa de confiança vem do modelo de caminhada aleatória em log-preço: o
+desvio acumulado cresce com `sigma * sqrt(dias)` e o multiplicador é o quantil
+da normal para o nível pedido (80% por padrão).
+
+O treino é semeado com um valor fixo, então a mesma série produz sempre a mesma
+projeção. Uma análise completa (indicadores, treino e projeção) leva de 5 a 20
+ms sobre 90 a 360 pontos numa máquina de desenvolvimento, e algumas dezenas de
+milissegundos em celular — daí rodar na própria isolate da interface, sem
+precisar de isolate separado (o que também mantém o recurso funcionando na
+web).
+
+Onde fica o código:
+
+- `lib/ai/math/` — estatística e indicadores técnicos (Dart puro);
+- `lib/ai/neural/` — a rede neural e o treino;
+- `lib/ai/local_financial_model.dart` — características, projeção e faixa de
+  confiança;
+- `lib/ai/insight_engine.dart` — quais observações fazer e com que tom (o texto
+  em si vem das traduções, em `lib/util/localizations.dart`);
+- `lib/ai/financial_ai_service.dart` — porta de entrada usada pelo bloc;
+- `lib/blocs/ai_insights_bloc.dart` e
+  `lib/view/pages/main_menu_items/ai_insights_page.dart` — estado e tela.
+
+Limites, ditos com todas as letras: são estimativas estatísticas sobre cotações
+passadas, e a tela traz esse aviso — não é recomendação de investimento. O
+motor já trabalha com ações (`AssetKind.stock`, com limiares de volatilidade
+próprios), mas a fonte de cotações usada pelo app (AwesomeAPI) só serve moeda
+fiduciária e criptomoeda; basta alimentar um `AssetSeries` com preços de ação
+para analisar uma.
+
 ## Getting Started
 
 This project is a starting point for a Flutter application.

--- a/lib/ai/financial_ai_service.dart
+++ b/lib/ai/financial_ai_service.dart
@@ -1,0 +1,97 @@
+import 'dart:math';
+
+import 'package:cotacao_direta/ai/insight_engine.dart';
+import 'package:cotacao_direta/ai/local_financial_model.dart';
+import 'package:cotacao_direta/ai/math/indicators.dart';
+import 'package:cotacao_direta/ai/math/statistics.dart';
+import 'package:cotacao_direta/model/asset_series.dart';
+import 'package:cotacao_direta/model/financial_analysis.dart';
+
+/// Porta de entrada da análise local: recebe a série de preços, roda os
+/// indicadores, treina e consulta o modelo, e devolve tudo junto com as
+/// observações em texto.
+///
+/// Tudo acontece no aparelho e sem rede: a única coisa que sai do celular é a
+/// consulta de cotação que o app já fazia antes.
+class FinancialAiService {
+  final LocalFinancialModel model;
+
+  FinancialAiService({LocalFinancialModel? model})
+      : model = model ?? LocalFinancialModel();
+
+  /// Abaixo disto não há série a analisar: nem os indicadores mais curtos
+  /// (média de 7 dias, variação semanal) teriam pontos suficientes.
+  static const int minimumPoints = 10;
+
+  /// Dias de negociação num ano, para anualizar a volatilidade. Cripto negocia
+  /// todo dia; moeda e ação, só em pregão.
+  static double _periodsPerYear(AssetKind kind) =>
+      kind == AssetKind.cryptocurrency ? 365 : 252;
+
+  /// Analisa [series] e projeta [horizonInDays] dias à frente.
+  ///
+  /// [languageCode] só afeta a formatação dos números embutidos nas
+  /// observações ("3,2%" ou "3.2%").
+  FinancialAnalysis analyze(
+    AssetSeries series, {
+    int horizonInDays = 15,
+    String languageCode = "pt",
+  }) {
+    if (series.length < minimumPoints)
+      throw ArgumentError("série com menos de $minimumPoints pontos");
+
+    final statistics = computeStatistics(series);
+    final forecast = model.forecast(series, horizonInDays: horizonInDays);
+    final insights = InsightEngine(languageCode: languageCode).generate(
+      series: series,
+      statistics: statistics,
+      forecast: forecast,
+    );
+
+    return FinancialAnalysis(
+      series: series,
+      statistics: statistics,
+      forecast: forecast,
+      insights: insights,
+    );
+  }
+
+  /// Retrato estatístico da série. É o que alimenta o resumo de mercado da tela
+  /// e os limiares dos insights.
+  MarketStatistics computeStatistics(AssetSeries series) {
+    if (series.isEmpty)
+      throw ArgumentError("computeStatistics de uma série vazia");
+
+    final prices = series.prices;
+    final returns = logReturns(prices);
+
+    // Tendência ajustada sobre o log do preço, e não sobre o preço: em log, um
+    // crescimento percentual constante vira uma reta, que é o que o R² mede
+    // bem.
+    final logPrices = prices.map(log).toList(growable: false);
+    final positions = List<double>.generate(
+        logPrices.length, (index) => index.toDouble(),
+        growable: false);
+    final trend = linearFit(positions, logPrices);
+
+    return MarketStatistics(
+      lastPrice: series.lastPrice,
+      weeklyChange: momentum(prices, 7),
+      monthlyChange: momentum(prices, 30),
+      annualizedVolatility: annualizedVolatility(returns,
+          periodsPerYear: _periodsPerYear(series.kind)),
+      relativeStrengthIndex: relativeStrengthIndex(prices),
+      shortMovingAverage: simpleMovingAverage(prices, 7),
+      longMovingAverage: simpleMovingAverage(prices, 30),
+      maxDrawdown: maxDrawdown(prices),
+      compoundAnnualGrowthRate: compoundAnnualGrowthRate(
+        initialPrice: prices.first,
+        finalPrice: prices.last,
+        spanInDays: series.spanInDays,
+      ),
+      trendSlopePerDay: trend.slope,
+      trendRSquared: trend.rSquared,
+      sampleCount: series.length,
+    );
+  }
+}

--- a/lib/ai/financial_ai_service.dart
+++ b/lib/ai/financial_ai_service.dart
@@ -7,38 +7,38 @@ import 'package:cotacao_direta/ai/math/statistics.dart';
 import 'package:cotacao_direta/model/asset_series.dart';
 import 'package:cotacao_direta/model/financial_analysis.dart';
 
-/// Porta de entrada da análise local: recebe a série de preços, roda os
-/// indicadores, treina e consulta o modelo, e devolve tudo junto com as
-/// observações em texto.
+/// Entry point of the local analysis: it takes the price series, runs the
+/// indicators, trains and queries the model, and returns everything together
+/// with the remarks in text form.
 ///
-/// Tudo acontece no aparelho e sem rede: a única coisa que sai do celular é a
-/// consulta de cotação que o app já fazia antes.
+/// It all happens on the device and offline: the only thing that leaves the
+/// phone is the quote request the app already made before.
 class FinancialAiService {
   final LocalFinancialModel model;
 
   FinancialAiService({LocalFinancialModel? model})
       : model = model ?? LocalFinancialModel();
 
-  /// Abaixo disto não há série a analisar: nem os indicadores mais curtos
-  /// (média de 7 dias, variação semanal) teriam pontos suficientes.
+  /// Below this there is no series to analyse: not even the shortest
+  /// indicators (7-day average, weekly change) would have enough points.
   static const int minimumPoints = 10;
 
-  /// Dias de negociação num ano, para anualizar a volatilidade. Cripto negocia
-  /// todo dia; moeda e ação, só em pregão.
+  /// Trading days in a year, to annualise volatility. Crypto trades every day;
+  /// currencies and stocks, only on trading days.
   static double _periodsPerYear(AssetKind kind) =>
       kind == AssetKind.cryptocurrency ? 365 : 252;
 
-  /// Analisa [series] e projeta [horizonInDays] dias à frente.
+  /// Analyses [series] and projects [horizonInDays] days ahead.
   ///
-  /// [languageCode] só afeta a formatação dos números embutidos nas
-  /// observações ("3,2%" ou "3.2%").
+  /// [languageCode] only affects the formatting of the numbers embedded in the
+  /// remarks ("3,2%" or "3.2%").
   FinancialAnalysis analyze(
     AssetSeries series, {
     int horizonInDays = 15,
     String languageCode = "pt",
   }) {
     if (series.length < minimumPoints)
-      throw ArgumentError("série com menos de $minimumPoints pontos");
+      throw ArgumentError("series with fewer than $minimumPoints points");
 
     final statistics = computeStatistics(series);
     final forecast = model.forecast(series, horizonInDays: horizonInDays);
@@ -56,18 +56,18 @@ class FinancialAiService {
     );
   }
 
-  /// Retrato estatístico da série. É o que alimenta o resumo de mercado da tela
-  /// e os limiares dos insights.
+  /// Statistical portrait of the series. It feeds the market summary on screen
+  /// and the thresholds of the insights.
   MarketStatistics computeStatistics(AssetSeries series) {
     if (series.isEmpty)
-      throw ArgumentError("computeStatistics de uma série vazia");
+      throw ArgumentError("computeStatistics of an empty series");
 
     final prices = series.prices;
     final returns = logReturns(prices);
 
-    // Tendência ajustada sobre o log do preço, e não sobre o preço: em log, um
-    // crescimento percentual constante vira uma reta, que é o que o R² mede
-    // bem.
+    // The trend is fitted over the log of the price rather than the price
+    // itself: in log space, constant percentage growth becomes a straight
+    // line, which is what R² measures well.
     final logPrices = prices.map(log).toList(growable: false);
     final positions = List<double>.generate(
         logPrices.length, (index) => index.toDouble(),

--- a/lib/ai/insight_engine.dart
+++ b/lib/ai/insight_engine.dart
@@ -3,34 +3,34 @@ import 'package:cotacao_direta/model/financial_analysis.dart';
 import 'package:cotacao_direta/util/quote_format.dart';
 import 'package:intl/intl.dart';
 
-/// Traduz os números da análise em observações curtas.
+/// Turns the numbers of the analysis into short remarks.
 ///
-/// A camada de linguagem do recurso mora aqui: o modelo produz estatísticas e
-/// uma projeção, e esta classe decide o que merece ser dito e com que tom. O
-/// texto final não sai daqui — sai do arquivo de traduções, que a tela preenche
-/// com [FinancialInsight.arguments]. Assim o motor continua sendo Dart puro,
-/// sem depender de Flutter, e os dois idiomas do app são atendidos pelo mesmo
-/// código.
+/// The language layer of the feature lives here: the model produces statistics
+/// and a projection, and this class decides what is worth saying and in what
+/// tone. The final text does not come from here — it comes from the
+/// translations file, which the screen fills in with
+/// [FinancialInsight.arguments]. That keeps the engine in pure Dart, free of
+/// Flutter, while both app languages are served by the same code.
 class InsightEngine {
-  /// Idioma em que os números são formatados ("pt" ou "en"): muda a vírgula
-  /// decimal e o separador de milhar.
+  /// Language the numbers are formatted in ("pt" or "en"): it changes the
+  /// decimal comma and the thousands separator.
   final String languageCode;
 
   const InsightEngine({this.languageCode = "pt"});
 
-  /// Acima disto a variação do período deixa de ser ruído e vira tendência.
+  /// Above this the period's change stops being noise and becomes a trend.
   static const double _trendThreshold = 0.025;
 
-  /// Faixa em que a projeção é considerada estável.
+  /// Range within which the projection counts as stable.
   static const double _projectionThreshold = 0.01;
 
   static const double _overboughtLevel = 70;
   static const double _oversoldLevel = 30;
 
-  /// A partir daqui a queda do topo merece aviso.
+  /// From here on the drop from the peak deserves a warning.
   static const double _drawdownThreshold = 0.15;
 
-  /// Vantagem mínima sobre o passeio aleatório para a rede ser digna de nota.
+  /// Minimum edge over the random walk for the network to be worth mentioning.
   static const double _meaningfulSkill = 0.05;
 
   List<FinancialInsight> generate({
@@ -73,7 +73,8 @@ class InsightEngine {
   List<FinancialInsight> _trendInsights(MarketStatistics statistics) {
     final change = statistics.referenceChange;
     if (change == null) return const [];
-    // A variação de referência é a de 30 dias quando existe; senão, a de 7.
+    // The reference change is the 30-day one when it exists; otherwise the
+    // 7-day one.
     final days = statistics.monthlyChange != null ? "30" : "7";
     final arguments = [_percent(change.abs()), days];
     if (change > _trendThreshold) {
@@ -152,9 +153,9 @@ class InsightEngine {
     return const [];
   }
 
-  /// Cripto oscila numa ordem de grandeza acima de moeda fiduciária: 40% ao ano
-  /// é rotina para bitcoin e seria um susto para o euro. Por isso os limiares
-  /// dependem do tipo de ativo.
+  /// Crypto swings an order of magnitude more than fiat currency: 40% a year
+  /// is routine for bitcoin and would be alarming for the euro. Hence the
+  /// thresholds depend on the kind of asset.
   double _highVolatilityLevel(AssetKind kind) => switch (kind) {
         AssetKind.currency => 0.15,
         AssetKind.stock => 0.35,
@@ -203,9 +204,9 @@ class InsightEngine {
               locale: languageCode, decimalDigits: decimalDigits)
           .format(value);
 
-  /// Cotação com casas decimais suficientes para o preço não virar "0,00":
-  /// cripto cotada em real anda na casa das centenas de milhares, e a mesma
-  /// tela mostra pares de moeda na casa das unidades.
+  /// Quote with enough decimal places for the price not to turn into "0.00":
+  /// crypto quoted in reais runs in the hundreds of thousands, and the same
+  /// screen shows currency pairs in the units.
   String _price(double value) => _number(value,
       decimalDigits:
           quoteDecimalDigits(value, minimumDigits: 2, significantDigits: 4));

--- a/lib/ai/insight_engine.dart
+++ b/lib/ai/insight_engine.dart
@@ -1,0 +1,212 @@
+import 'package:cotacao_direta/model/asset_series.dart';
+import 'package:cotacao_direta/model/financial_analysis.dart';
+import 'package:cotacao_direta/util/quote_format.dart';
+import 'package:intl/intl.dart';
+
+/// Traduz os números da análise em observações curtas.
+///
+/// A camada de linguagem do recurso mora aqui: o modelo produz estatísticas e
+/// uma projeção, e esta classe decide o que merece ser dito e com que tom. O
+/// texto final não sai daqui — sai do arquivo de traduções, que a tela preenche
+/// com [FinancialInsight.arguments]. Assim o motor continua sendo Dart puro,
+/// sem depender de Flutter, e os dois idiomas do app são atendidos pelo mesmo
+/// código.
+class InsightEngine {
+  /// Idioma em que os números são formatados ("pt" ou "en"): muda a vírgula
+  /// decimal e o separador de milhar.
+  final String languageCode;
+
+  const InsightEngine({this.languageCode = "pt"});
+
+  /// Acima disto a variação do período deixa de ser ruído e vira tendência.
+  static const double _trendThreshold = 0.025;
+
+  /// Faixa em que a projeção é considerada estável.
+  static const double _projectionThreshold = 0.01;
+
+  static const double _overboughtLevel = 70;
+  static const double _oversoldLevel = 30;
+
+  /// A partir daqui a queda do topo merece aviso.
+  static const double _drawdownThreshold = 0.15;
+
+  /// Vantagem mínima sobre o passeio aleatório para a rede ser digna de nota.
+  static const double _meaningfulSkill = 0.05;
+
+  List<FinancialInsight> generate({
+    required AssetSeries series,
+    required MarketStatistics statistics,
+    required AssetForecast forecast,
+  }) {
+    return [
+      _projectionInsight(forecast),
+      ..._trendInsights(statistics),
+      ..._momentumInsights(statistics),
+      ..._volatilityInsights(series.kind, statistics),
+      ..._riskInsights(statistics),
+      _confidenceInsight(forecast.diagnostics),
+    ];
+  }
+
+  FinancialInsight _projectionInsight(AssetForecast forecast) {
+    final change = forecast.projectedChange;
+    final days = "${forecast.horizonInDays}";
+    final price = _price(forecast.projectedPrice);
+    if (change > _projectionThreshold) {
+      return FinancialInsight(
+          code: InsightCode.projectionUp,
+          sentiment: InsightSentiment.positive,
+          arguments: [_percent(change.abs()), days, price]);
+    }
+    if (change < -_projectionThreshold) {
+      return FinancialInsight(
+          code: InsightCode.projectionDown,
+          sentiment: InsightSentiment.negative,
+          arguments: [_percent(change.abs()), days, price]);
+    }
+    return FinancialInsight(
+        code: InsightCode.projectionStable,
+        sentiment: InsightSentiment.neutral,
+        arguments: [days, price]);
+  }
+
+  List<FinancialInsight> _trendInsights(MarketStatistics statistics) {
+    final change = statistics.referenceChange;
+    if (change == null) return const [];
+    // A variação de referência é a de 30 dias quando existe; senão, a de 7.
+    final days = statistics.monthlyChange != null ? "30" : "7";
+    final arguments = [_percent(change.abs()), days];
+    if (change > _trendThreshold) {
+      return [
+        FinancialInsight(
+            code: InsightCode.trendUp,
+            sentiment: InsightSentiment.positive,
+            arguments: arguments)
+      ];
+    }
+    if (change < -_trendThreshold) {
+      return [
+        FinancialInsight(
+            code: InsightCode.trendDown,
+            sentiment: InsightSentiment.negative,
+            arguments: arguments)
+      ];
+    }
+    return [
+      FinancialInsight(
+          code: InsightCode.trendSideways,
+          sentiment: InsightSentiment.neutral,
+          arguments: arguments)
+    ];
+  }
+
+  List<FinancialInsight> _momentumInsights(MarketStatistics statistics) {
+    final rsi = statistics.relativeStrengthIndex;
+    if (rsi == null) return const [];
+    final arguments = [_number(rsi, decimalDigits: 0)];
+    if (rsi >= _overboughtLevel) {
+      return [
+        FinancialInsight(
+            code: InsightCode.momentumOverbought,
+            sentiment: InsightSentiment.caution,
+            arguments: arguments)
+      ];
+    }
+    if (rsi <= _oversoldLevel) {
+      return [
+        FinancialInsight(
+            code: InsightCode.momentumOversold,
+            sentiment: InsightSentiment.caution,
+            arguments: arguments)
+      ];
+    }
+    return [
+      FinancialInsight(
+          code: InsightCode.momentumNeutral,
+          sentiment: InsightSentiment.neutral,
+          arguments: arguments)
+    ];
+  }
+
+  List<FinancialInsight> _volatilityInsights(
+      AssetKind kind, MarketStatistics statistics) {
+    final volatility = statistics.annualizedVolatility;
+    if (volatility <= 0) return const [];
+    final arguments = [_percent(volatility)];
+    if (volatility >= _highVolatilityLevel(kind)) {
+      return [
+        FinancialInsight(
+            code: InsightCode.volatilityHigh,
+            sentiment: InsightSentiment.caution,
+            arguments: arguments)
+      ];
+    }
+    if (volatility <= _lowVolatilityLevel(kind)) {
+      return [
+        FinancialInsight(
+            code: InsightCode.volatilityLow,
+            sentiment: InsightSentiment.positive,
+            arguments: arguments)
+      ];
+    }
+    return const [];
+  }
+
+  /// Cripto oscila numa ordem de grandeza acima de moeda fiduciária: 40% ao ano
+  /// é rotina para bitcoin e seria um susto para o euro. Por isso os limiares
+  /// dependem do tipo de ativo.
+  double _highVolatilityLevel(AssetKind kind) => switch (kind) {
+        AssetKind.currency => 0.15,
+        AssetKind.stock => 0.35,
+        AssetKind.cryptocurrency => 0.60,
+      };
+
+  double _lowVolatilityLevel(AssetKind kind) => switch (kind) {
+        AssetKind.currency => 0.05,
+        AssetKind.stock => 0.12,
+        AssetKind.cryptocurrency => 0.25,
+      };
+
+  List<FinancialInsight> _riskInsights(MarketStatistics statistics) {
+    if (statistics.maxDrawdown < _drawdownThreshold) return const [];
+    return [
+      FinancialInsight(
+          code: InsightCode.drawdown,
+          sentiment: InsightSentiment.caution,
+          arguments: [_percent(statistics.maxDrawdown)])
+    ];
+  }
+
+  FinancialInsight _confidenceInsight(ModelDiagnostics diagnostics) {
+    if (!diagnostics.trained) {
+      return FinancialInsight(
+          code: InsightCode.dataLimited,
+          sentiment: InsightSentiment.caution,
+          arguments: ["${diagnostics.trainingSamples}"]);
+    }
+    if (diagnostics.skill >= _meaningfulSkill) {
+      return FinancialInsight(
+          code: InsightCode.confidenceGood,
+          sentiment: InsightSentiment.positive,
+          arguments: [_percent(diagnostics.skill)]);
+    }
+    return const FinancialInsight(
+        code: InsightCode.confidenceLow, sentiment: InsightSentiment.caution);
+  }
+
+  String _percent(double fraction) =>
+      NumberFormat.decimalPercentPattern(locale: languageCode, decimalDigits: 1)
+          .format(fraction);
+
+  String _number(double value, {int decimalDigits = 2}) =>
+      NumberFormat.decimalPatternDigits(
+              locale: languageCode, decimalDigits: decimalDigits)
+          .format(value);
+
+  /// Cotação com casas decimais suficientes para o preço não virar "0,00":
+  /// cripto cotada em real anda na casa das centenas de milhares, e a mesma
+  /// tela mostra pares de moeda na casa das unidades.
+  String _price(double value) => _number(value,
+      decimalDigits:
+          quoteDecimalDigits(value, minimumDigits: 2, significantDigits: 4));
+}

--- a/lib/ai/local_financial_model.dart
+++ b/lib/ai/local_financial_model.dart
@@ -6,31 +6,31 @@ import 'package:cotacao_direta/ai/neural/neural_network.dart';
 import 'package:cotacao_direta/model/asset_series.dart';
 import 'package:cotacao_direta/model/financial_analysis.dart';
 
-/// Modelo preditivo que roda inteiramente no aparelho.
+/// Predictive model that runs entirely on the device.
 ///
-/// Ele junta duas peças que se cobrem:
+/// It brings together two pieces that cover for each other:
 ///
-/// 1. uma rede neural pequena ([NeuralNetwork]) treinada na hora, com o próprio
-///    histórico do ativo que o usuário abriu — sem pesos baixados e sem
-///    servidor. Ela recebe uma janela de log-retornos recentes mais alguns
-///    indicadores (momento, IFR, distância da média, aceleração da
-///    volatilidade) e tenta prever o retorno do dia seguinte;
-/// 2. uma deriva estatística, que é a média exponencial dos log-retornos com
-///    amortecimento ao longo do horizonte.
+/// 1. a small neural network ([NeuralNetwork]) trained on the spot with the
+///    history of the very asset the user opened — no downloaded weights and no
+///    server. It receives a window of recent log-returns plus a few indicators
+///    (momentum, RSI, distance from the average, volatility acceleration) and
+///    tries to predict the next day's return;
+/// 2. a statistical drift, which is the exponentially weighted mean of the
+///    log-returns, damped along the horizon.
 ///
-/// A projeção final é a média ponderada das duas, e o peso da rede não é
-/// arbitrário: ele sai do quanto ela superou, num trecho de validação que não
-/// viu no treino, o passeio aleatório ("amanhã é igual a hoje"). Preço de ativo
-/// é quase um passeio aleatório, então esse rival é vencido por pouco quando é
-/// vencido; quando não é, o peso vai a zero e a projeção vira a base
-/// estatística. Isso mantém a tela honesta em vez de vender uma precisão que o
-/// modelo não tem.
+/// The final projection is the weighted average of the two, and the network's
+/// weight is not arbitrary: it comes from how much the network beat the random
+/// walk ("tomorrow equals today") on a validation slice it did not see while
+/// training. Asset prices are nearly a random walk, so that rival is beaten by
+/// a small margin when it is beaten at all; when it is not, the weight goes to
+/// zero and the projection becomes the statistical baseline. That keeps the
+/// screen honest instead of selling a precision the model does not have.
 ///
-/// A faixa de confiança vem do modelo de caminhada aleatória em log-preço: o
-/// desvio padrão acumulado cresce com `sigma * sqrt(dias)`, e o multiplicador
-/// sai do quantil da normal para o nível de confiança pedido.
+/// The confidence band comes from the random walk model in log-price: the
+/// accumulated standard deviation grows with `sigma * sqrt(days)`, and the
+/// multiplier is the normal quantile for the requested confidence level.
 class LocalFinancialModel {
-  /// Quantos log-retornos recentes entram no vetor de características.
+  /// How many recent log-returns go into the feature vector.
   final int window;
 
   final int hiddenUnits;
@@ -38,17 +38,17 @@ class LocalFinancialModel {
   final double learningRate;
   final double weightDecay;
 
-  /// Semente da aleatoriedade do treino. Fixa de propósito: a mesma série tem
-  /// que produzir sempre a mesma projeção, senão a tela mudaria de resposta a
-  /// cada toque no botão.
+  /// Seed of the training randomness. Fixed on purpose: the same series has to
+  /// produce the same projection every time, otherwise the screen would change
+  /// its answer on every tap of the button.
   final int seed;
 
-  /// Nível da faixa mostrada em volta da projeção (0,8 = 80%).
+  /// Level of the band drawn around the projection (0.8 = 80%).
   final double confidenceLevel;
 
-  /// Teto do peso da rede na mistura. Mesmo uma rede que se saia muito bem na
-  /// validação não passa daqui: a validação é curta e o excesso de confiança é
-  /// o erro clássico deste tipo de previsão.
+  /// Cap on the network's weight in the blend. Even a network that does very
+  /// well on validation does not go past this: the validation slice is short,
+  /// and overconfidence is the classic mistake in this kind of forecast.
   final double maximumNeuralWeight;
 
   static const int _rsiPeriod = 14;
@@ -57,16 +57,17 @@ class LocalFinancialModel {
   static const int _momentumPeriod = 5;
   static const int _volatilityPeriod = 5;
 
-  /// Abaixo disto não vale treinar: a rede decoraria as poucas janelas
-  /// existentes e a validação não diria nada.
+  /// Below this it is not worth training: the network would memorise the few
+  /// existing windows and validation would say nothing.
   static const int minimumTrainingSamples = 24;
 
-  /// Amortecimento da deriva a cada dia projetado. Sem ele, uma tendência
-  /// recente de alta seria extrapolada em linha reta até o fim do horizonte.
+  /// Damping applied to the drift on each projected day. Without it, a recent
+  /// uptrend would be extrapolated in a straight line to the end of the
+  /// horizon.
   static const double _driftDamping = 0.92;
 
-  /// Teto do movimento diário projetado, em desvios padrão. Segura a projeção
-  /// dentro do que a série costuma fazer.
+  /// Cap on the projected daily move, in standard deviations. It holds the
+  /// projection within what the series usually does.
   static const double _maximumDailyMove = 2.5;
 
   LocalFinancialModel({
@@ -83,32 +84,31 @@ class LocalFinancialModel {
         assert(confidenceLevel > 0 && confidenceLevel < 1),
         assert(maximumNeuralWeight >= 0 && maximumNeuralWeight <= 1);
 
-  /// Tamanho do vetor de características: a janela de retornos mais os quatro
-  /// indicadores derivados.
+  /// Size of the feature vector: the window of returns plus the four derived
+  /// indicators.
   int get featureCount => window + 4;
 
-  /// Primeiro índice da série que tem passado suficiente para virar amostra.
+  /// First index of the series with enough past behind it to become a sample.
   int get _firstUsableIndex =>
       max(window, max(_rsiPeriod + 1, _movingAveragePeriod));
 
-  /// Menor histórico que permite treinar a rede.
+  /// Shortest history that allows training the network.
   int get minimumHistoryForTraining =>
       _firstUsableIndex + minimumTrainingSamples + 1;
 
-  /// Projeta [horizonInDays] dias à frente do último ponto de [series].
+  /// Projects [horizonInDays] days beyond the last point of [series].
   AssetForecast forecast(AssetSeries series, {int horizonInDays = 15}) {
-    if (series.isEmpty) throw ArgumentError("forecast de uma série vazia");
+    if (series.isEmpty) throw ArgumentError("forecast of an empty series");
     if (horizonInDays <= 0)
-      throw ArgumentError("horizonte precisa ser positivo");
+      throw ArgumentError("horizon must be positive");
 
     final prices = series.prices.toList();
     final returns = logReturns(prices);
 
-    // Escala de referência da série. Todas as características e o alvo são
-    // divididos por ela, o que deixa a rede vendo números da ordem de 1 tanto
-    // para um par de moedas calmo quanto para uma cripto. O piso evita divisão
-    // por zero numa série sem variação (uma moeda cotada contra ela mesma, por
-    // exemplo).
+    // Reference scale of the series. Every feature and the target are divided
+    // by it, which keeps the network seeing numbers of order 1 for both a calm
+    // currency pair and a crypto. The floor avoids a division by zero on a
+    // series with no variation (a currency quoted against itself, say).
     final volatility =
         returns.length >= 2 ? standardDeviation(returns) : 0.0;
     final scale = max(volatility, 1e-6);
@@ -147,7 +147,8 @@ class LocalFinancialModel {
       final price = workingPrices.last * exp(expectedReturn);
       workingPrices.add(price);
 
-      // Incerteza da caminhada aleatória: cresce com a raiz do número de dias.
+      // Random walk uncertainty: it grows with the square root of the number
+      // of days.
       final horizonDeviation = scale * sqrt(step) * multiplier;
       points.add(ForecastPoint(
         step: step,
@@ -166,9 +167,8 @@ class LocalFinancialModel {
     );
   }
 
-  /// Janelas de treino montadas a partir da série: cada amostra são as
-  /// características no dia `index` e, como alvo, o log-retorno do dia
-  /// seguinte.
+  /// Training windows built from the series: each sample is the set of
+  /// features on day `index` and, as the target, the next day's log-return.
   _TrainingData _buildSamples(List<double> prices, double scale) {
     final inputs = <List<double>>[];
     final targets = <double>[];
@@ -184,14 +184,14 @@ class LocalFinancialModel {
     return _TrainingData(inputs, targets);
   }
 
-  /// Características do dia [index], todas em unidades de [scale] e limitadas a
-  /// [-4, 4] para que um dia excepcional não domine o treino.
+  /// Features of day [index], all in units of [scale] and clamped to [-4, 4]
+  /// so that one exceptional day cannot dominate training.
   List<double>? _features(List<double> prices, int index, double scale) {
     if (index < _firstUsableIndex || index >= prices.length) return null;
 
     final features = <double>[];
 
-    // Os log-retornos mais recentes, do dia [index] para trás.
+    // The most recent log-returns, from day [index] backwards.
     for (var lag = 0; lag < window; lag++) {
       final current = prices[index - lag];
       final previous = prices[index - lag - 1];
@@ -199,30 +199,31 @@ class LocalFinancialModel {
       features.add(log(current / previous) / scale);
     }
 
-    // Momento: o retorno acumulado da janela curta, normalizado pela
-    // volatilidade esperada nesse número de dias.
+    // Momentum: the return accumulated over the short window, normalised by
+    // the volatility expected over that number of days.
     final momentumBase = prices[index - _momentumPeriod];
     if (momentumBase <= 0 || prices[index] <= 0) return null;
     features.add(log(prices[index] / momentumBase) /
         (scale * sqrt(_momentumPeriod.toDouble())));
 
-    // IFR centrado em zero. A janela de apuração é fixa para que a
-    // característica signifique o mesmo no começo e no fim da série.
+    // RSI centred on zero. The lookback is fixed so that the feature means the
+    // same thing at the start and at the end of the series.
     final rsiWindow = prices.sublist(
         max(0, index + 1 - _rsiLookback), index + 1);
     final rsi = relativeStrengthIndex(rsiWindow, period: _rsiPeriod) ?? 50;
     features.add((rsi - 50) / 50);
 
-    // Distância da média móvel, em desvios padrão da janela (bandas de
-    // Bollinger), reduzida para a mesma ordem de grandeza das demais.
+    // Distance from the moving average, in standard deviations of the window
+    // (Bollinger bands), scaled down to the same order of magnitude as the
+    // rest.
     final zScore = bollingerZScore(
             prices.sublist(index + 1 - _movingAveragePeriod, index + 1),
             _movingAveragePeriod) ??
         0;
     features.add(zScore / 3);
 
-    // Aceleração da volatilidade: quanto a agitação dos últimos dias difere da
-    // agitação típica da série.
+    // Volatility acceleration: how much the agitation of the last few days
+    // differs from the series' typical agitation.
     final recentReturns =
         logReturns(prices.sublist(index - _volatilityPeriod, index + 1));
     final recentVolatility =
@@ -236,16 +237,16 @@ class LocalFinancialModel {
     return features;
   }
 
-  /// Treina a rede e mede o quanto ela superou o passeio aleatório.
+  /// Trains the network and measures how much it beat the random walk.
   _TrainedModel _train(_TrainingData data) {
     if (data.inputs.length < minimumTrainingSamples) {
       return _TrainedModel(
           null, ModelDiagnostics.untrained(trainingSamples: data.inputs.length));
     }
 
-    // A validação é o trecho final da série, e não uma amostra sorteada: prever
-    // um dia no meio de dias vizinhos já conhecidos é bem mais fácil do que
-    // prever o futuro, e daria uma nota inflada.
+    // Validation is the tail of the series, not a random sample: predicting a
+    // day surrounded by already known neighbours is far easier than predicting
+    // the future, and would hand out an inflated score.
     final validationCount =
         (data.inputs.length * 0.2).round().clamp(4, data.inputs.length - 12);
     final splitIndex = data.inputs.length - validationCount;
@@ -266,7 +267,7 @@ class LocalFinancialModel {
       weightDecay: weightDecay,
     );
 
-    // O passeio aleatório prevê retorno zero para o dia seguinte.
+    // The random walk predicts a zero return for the next day.
     final baselineError = meanSquaredError(
         List<double>.filled(validationTargets.length, 0), validationTargets);
     final validationError = report.validationError;
@@ -297,7 +298,7 @@ class _TrainingData {
 }
 
 class _TrainedModel {
-  /// Nulo quando não houve histórico suficiente para treinar.
+  /// Null when there was not enough history to train.
   final NeuralNetwork? network;
   final ModelDiagnostics diagnostics;
 

--- a/lib/ai/local_financial_model.dart
+++ b/lib/ai/local_financial_model.dart
@@ -1,0 +1,305 @@
+import 'dart:math';
+
+import 'package:cotacao_direta/ai/math/indicators.dart';
+import 'package:cotacao_direta/ai/math/statistics.dart';
+import 'package:cotacao_direta/ai/neural/neural_network.dart';
+import 'package:cotacao_direta/model/asset_series.dart';
+import 'package:cotacao_direta/model/financial_analysis.dart';
+
+/// Modelo preditivo que roda inteiramente no aparelho.
+///
+/// Ele junta duas peças que se cobrem:
+///
+/// 1. uma rede neural pequena ([NeuralNetwork]) treinada na hora, com o próprio
+///    histórico do ativo que o usuário abriu — sem pesos baixados e sem
+///    servidor. Ela recebe uma janela de log-retornos recentes mais alguns
+///    indicadores (momento, IFR, distância da média, aceleração da
+///    volatilidade) e tenta prever o retorno do dia seguinte;
+/// 2. uma deriva estatística, que é a média exponencial dos log-retornos com
+///    amortecimento ao longo do horizonte.
+///
+/// A projeção final é a média ponderada das duas, e o peso da rede não é
+/// arbitrário: ele sai do quanto ela superou, num trecho de validação que não
+/// viu no treino, o passeio aleatório ("amanhã é igual a hoje"). Preço de ativo
+/// é quase um passeio aleatório, então esse rival é vencido por pouco quando é
+/// vencido; quando não é, o peso vai a zero e a projeção vira a base
+/// estatística. Isso mantém a tela honesta em vez de vender uma precisão que o
+/// modelo não tem.
+///
+/// A faixa de confiança vem do modelo de caminhada aleatória em log-preço: o
+/// desvio padrão acumulado cresce com `sigma * sqrt(dias)`, e o multiplicador
+/// sai do quantil da normal para o nível de confiança pedido.
+class LocalFinancialModel {
+  /// Quantos log-retornos recentes entram no vetor de características.
+  final int window;
+
+  final int hiddenUnits;
+  final int epochs;
+  final double learningRate;
+  final double weightDecay;
+
+  /// Semente da aleatoriedade do treino. Fixa de propósito: a mesma série tem
+  /// que produzir sempre a mesma projeção, senão a tela mudaria de resposta a
+  /// cada toque no botão.
+  final int seed;
+
+  /// Nível da faixa mostrada em volta da projeção (0,8 = 80%).
+  final double confidenceLevel;
+
+  /// Teto do peso da rede na mistura. Mesmo uma rede que se saia muito bem na
+  /// validação não passa daqui: a validação é curta e o excesso de confiança é
+  /// o erro clássico deste tipo de previsão.
+  final double maximumNeuralWeight;
+
+  static const int _rsiPeriod = 14;
+  static const int _rsiLookback = 60;
+  static const int _movingAveragePeriod = 10;
+  static const int _momentumPeriod = 5;
+  static const int _volatilityPeriod = 5;
+
+  /// Abaixo disto não vale treinar: a rede decoraria as poucas janelas
+  /// existentes e a validação não diria nada.
+  static const int minimumTrainingSamples = 24;
+
+  /// Amortecimento da deriva a cada dia projetado. Sem ele, uma tendência
+  /// recente de alta seria extrapolada em linha reta até o fim do horizonte.
+  static const double _driftDamping = 0.92;
+
+  /// Teto do movimento diário projetado, em desvios padrão. Segura a projeção
+  /// dentro do que a série costuma fazer.
+  static const double _maximumDailyMove = 2.5;
+
+  LocalFinancialModel({
+    this.window = 5,
+    this.hiddenUnits = 6,
+    this.epochs = 300,
+    this.learningRate = 0.03,
+    this.weightDecay = 1e-4,
+    this.seed = 7,
+    this.confidenceLevel = 0.8,
+    this.maximumNeuralWeight = 0.6,
+  })  : assert(window > 0),
+        assert(hiddenUnits > 0),
+        assert(confidenceLevel > 0 && confidenceLevel < 1),
+        assert(maximumNeuralWeight >= 0 && maximumNeuralWeight <= 1);
+
+  /// Tamanho do vetor de características: a janela de retornos mais os quatro
+  /// indicadores derivados.
+  int get featureCount => window + 4;
+
+  /// Primeiro índice da série que tem passado suficiente para virar amostra.
+  int get _firstUsableIndex =>
+      max(window, max(_rsiPeriod + 1, _movingAveragePeriod));
+
+  /// Menor histórico que permite treinar a rede.
+  int get minimumHistoryForTraining =>
+      _firstUsableIndex + minimumTrainingSamples + 1;
+
+  /// Projeta [horizonInDays] dias à frente do último ponto de [series].
+  AssetForecast forecast(AssetSeries series, {int horizonInDays = 15}) {
+    if (series.isEmpty) throw ArgumentError("forecast de uma série vazia");
+    if (horizonInDays <= 0)
+      throw ArgumentError("horizonte precisa ser positivo");
+
+    final prices = series.prices.toList();
+    final returns = logReturns(prices);
+
+    // Escala de referência da série. Todas as características e o alvo são
+    // divididos por ela, o que deixa a rede vendo números da ordem de 1 tanto
+    // para um par de moedas calmo quanto para uma cripto. O piso evita divisão
+    // por zero numa série sem variação (uma moeda cotada contra ela mesma, por
+    // exemplo).
+    final volatility =
+        returns.length >= 2 ? standardDeviation(returns) : 0.0;
+    final scale = max(volatility, 1e-6);
+
+    final samples = _buildSamples(prices, scale);
+    final network = _train(samples);
+    final diagnostics = network.diagnostics;
+
+    final drift = returns.isEmpty
+        ? 0.0
+        : exponentiallyWeightedMean(returns, alpha: 0.15)
+            .clamp(-0.5 * scale, 0.5 * scale);
+
+    final multiplier = confidenceMultiplier(confidenceLevel);
+    final workingPrices = prices.toList();
+    final points = <ForecastPoint>[];
+
+    for (var step = 1; step <= horizonInDays; step++) {
+      final dampedDrift = drift * pow(_driftDamping, step - 1);
+
+      var expectedReturn = dampedDrift;
+      final model = network.network;
+      if (model != null) {
+        final features =
+            _features(workingPrices, workingPrices.length - 1, scale);
+        if (features != null) {
+          final neuralReturn =
+              model.predict(features).clamp(-4.0, 4.0) * scale;
+          expectedReturn = diagnostics.neuralWeight * neuralReturn +
+              (1 - diagnostics.neuralWeight) * dampedDrift;
+        }
+      }
+      expectedReturn = expectedReturn.clamp(
+          -_maximumDailyMove * scale, _maximumDailyMove * scale);
+
+      final price = workingPrices.last * exp(expectedReturn);
+      workingPrices.add(price);
+
+      // Incerteza da caminhada aleatória: cresce com a raiz do número de dias.
+      final horizonDeviation = scale * sqrt(step) * multiplier;
+      points.add(ForecastPoint(
+        step: step,
+        date: series.lastDate.add(Duration(days: step)),
+        price: price,
+        lowerBound: price * exp(-horizonDeviation),
+        upperBound: price * exp(horizonDeviation),
+      ));
+    }
+
+    return AssetForecast(
+      lastPrice: series.lastPrice,
+      points: List.unmodifiable(points),
+      diagnostics: diagnostics,
+      confidenceLevel: confidenceLevel,
+    );
+  }
+
+  /// Janelas de treino montadas a partir da série: cada amostra são as
+  /// características no dia `index` e, como alvo, o log-retorno do dia
+  /// seguinte.
+  _TrainingData _buildSamples(List<double> prices, double scale) {
+    final inputs = <List<double>>[];
+    final targets = <double>[];
+    for (var index = _firstUsableIndex; index < prices.length - 1; index++) {
+      final features = _features(prices, index, scale);
+      if (features == null) continue;
+      final previous = prices[index];
+      final next = prices[index + 1];
+      if (previous <= 0 || next <= 0) continue;
+      inputs.add(features);
+      targets.add((log(next / previous) / scale).clamp(-4.0, 4.0));
+    }
+    return _TrainingData(inputs, targets);
+  }
+
+  /// Características do dia [index], todas em unidades de [scale] e limitadas a
+  /// [-4, 4] para que um dia excepcional não domine o treino.
+  List<double>? _features(List<double> prices, int index, double scale) {
+    if (index < _firstUsableIndex || index >= prices.length) return null;
+
+    final features = <double>[];
+
+    // Os log-retornos mais recentes, do dia [index] para trás.
+    for (var lag = 0; lag < window; lag++) {
+      final current = prices[index - lag];
+      final previous = prices[index - lag - 1];
+      if (current <= 0 || previous <= 0) return null;
+      features.add(log(current / previous) / scale);
+    }
+
+    // Momento: o retorno acumulado da janela curta, normalizado pela
+    // volatilidade esperada nesse número de dias.
+    final momentumBase = prices[index - _momentumPeriod];
+    if (momentumBase <= 0 || prices[index] <= 0) return null;
+    features.add(log(prices[index] / momentumBase) /
+        (scale * sqrt(_momentumPeriod.toDouble())));
+
+    // IFR centrado em zero. A janela de apuração é fixa para que a
+    // característica signifique o mesmo no começo e no fim da série.
+    final rsiWindow = prices.sublist(
+        max(0, index + 1 - _rsiLookback), index + 1);
+    final rsi = relativeStrengthIndex(rsiWindow, period: _rsiPeriod) ?? 50;
+    features.add((rsi - 50) / 50);
+
+    // Distância da média móvel, em desvios padrão da janela (bandas de
+    // Bollinger), reduzida para a mesma ordem de grandeza das demais.
+    final zScore = bollingerZScore(
+            prices.sublist(index + 1 - _movingAveragePeriod, index + 1),
+            _movingAveragePeriod) ??
+        0;
+    features.add(zScore / 3);
+
+    // Aceleração da volatilidade: quanto a agitação dos últimos dias difere da
+    // agitação típica da série.
+    final recentReturns =
+        logReturns(prices.sublist(index - _volatilityPeriod, index + 1));
+    final recentVolatility =
+        recentReturns.length >= 2 ? standardDeviation(recentReturns) : scale;
+    features.add(recentVolatility / scale - 1);
+
+    for (var position = 0; position < features.length; position++) {
+      final value = features[position];
+      features[position] = value.isFinite ? value.clamp(-4.0, 4.0) : 0.0;
+    }
+    return features;
+  }
+
+  /// Treina a rede e mede o quanto ela superou o passeio aleatório.
+  _TrainedModel _train(_TrainingData data) {
+    if (data.inputs.length < minimumTrainingSamples) {
+      return _TrainedModel(
+          null, ModelDiagnostics.untrained(trainingSamples: data.inputs.length));
+    }
+
+    // A validação é o trecho final da série, e não uma amostra sorteada: prever
+    // um dia no meio de dias vizinhos já conhecidos é bem mais fácil do que
+    // prever o futuro, e daria uma nota inflada.
+    final validationCount =
+        (data.inputs.length * 0.2).round().clamp(4, data.inputs.length - 12);
+    final splitIndex = data.inputs.length - validationCount;
+    final trainingInputs = data.inputs.sublist(0, splitIndex);
+    final trainingTargets = data.targets.sublist(0, splitIndex);
+    final validationInputs = data.inputs.sublist(splitIndex);
+    final validationTargets = data.targets.sublist(splitIndex);
+
+    final network = NeuralNetwork(
+        inputSize: featureCount, hiddenSize: hiddenUnits, seed: seed);
+    final report = network.train(
+      trainingInputs,
+      trainingTargets,
+      validationInputs: validationInputs,
+      validationTargets: validationTargets,
+      epochs: epochs,
+      learningRate: learningRate,
+      weightDecay: weightDecay,
+    );
+
+    // O passeio aleatório prevê retorno zero para o dia seguinte.
+    final baselineError = meanSquaredError(
+        List<double>.filled(validationTargets.length, 0), validationTargets);
+    final validationError = report.validationError;
+    final skill = (baselineError <= 0 || validationError == null)
+        ? 0.0
+        : (1 - validationError / baselineError).clamp(0.0, 1.0);
+
+    return _TrainedModel(
+      network,
+      ModelDiagnostics(
+        trainingSamples: data.inputs.length,
+        validationError: validationError,
+        baselineError: baselineError,
+        skill: skill,
+        neuralWeight: skill * maximumNeuralWeight,
+        epochs: report.epochs,
+        trained: true,
+      ),
+    );
+  }
+}
+
+class _TrainingData {
+  final List<List<double>> inputs;
+  final List<double> targets;
+
+  const _TrainingData(this.inputs, this.targets);
+}
+
+class _TrainedModel {
+  /// Nulo quando não houve histórico suficiente para treinar.
+  final NeuralNetwork? network;
+  final ModelDiagnostics diagnostics;
+
+  const _TrainedModel(this.network, this.diagnostics);
+}

--- a/lib/ai/math/indicators.dart
+++ b/lib/ai/math/indicators.dart
@@ -1,0 +1,127 @@
+import 'dart:math';
+
+import 'package:cotacao_direta/ai/math/statistics.dart';
+
+/// Indicadores técnicos clássicos calculados sobre a série de preços. São as
+/// entradas que o modelo local recebe além dos retornos crus e, ao mesmo tempo,
+/// os números que aparecem no resumo de mercado da tela.
+
+/// Média móvel simples dos últimos [period] preços. Devolve nulo quando a série
+/// é mais curta que o período: uma média incompleta seria comparada com médias
+/// completas em outra escala.
+double? simpleMovingAverage(List<double> values, int period) {
+  if (period <= 0) throw ArgumentError("período precisa ser positivo");
+  if (values.length < period) return null;
+  return mean(values.sublist(values.length - period));
+}
+
+/// Média móvel exponencial de período [period], no formato usual do mercado
+/// (`alpha = 2 / (period + 1)`), semeada pela média simples do primeiro bloco.
+double? exponentialMovingAverage(List<double> values, int period) {
+  if (period <= 0) throw ArgumentError("período precisa ser positivo");
+  if (values.length < period) return null;
+  final alpha = 2 / (period + 1);
+  var estimate = mean(values.sublist(0, period));
+  for (var index = period; index < values.length; index++) {
+    estimate = alpha * values[index] + (1 - alpha) * estimate;
+  }
+  return estimate;
+}
+
+/// Índice de Força Relativa (IFR/RSI) de Wilder, entre 0 e 100.
+///
+/// Acima de 70 o ativo é lido como sobrecomprado; abaixo de 30, sobrevendido.
+/// Precisa de [period] variações, isto é, `period + 1` preços; com menos que
+/// isso devolve nulo.
+double? relativeStrengthIndex(List<double> prices, {int period = 14}) {
+  if (period <= 0) throw ArgumentError("período precisa ser positivo");
+  if (prices.length < period + 1) return null;
+
+  var averageGain = 0.0;
+  var averageLoss = 0.0;
+  for (var index = 1; index <= period; index++) {
+    final change = prices[index] - prices[index - 1];
+    if (change >= 0)
+      averageGain += change;
+    else
+      averageLoss -= change;
+  }
+  averageGain /= period;
+  averageLoss /= period;
+
+  // Suavização de Wilder: cada dia novo entra com peso 1/period, sem descartar
+  // de uma vez o dia que saiu da janela.
+  for (var index = period + 1; index < prices.length; index++) {
+    final change = prices[index] - prices[index - 1];
+    final gain = change > 0 ? change : 0.0;
+    final loss = change < 0 ? -change : 0.0;
+    averageGain = (averageGain * (period - 1) + gain) / period;
+    averageLoss = (averageLoss * (period - 1) + loss) / period;
+  }
+
+  // Sem nenhuma perda no período o índice satura em 100 (e a divisão por zero
+  // não chega a acontecer).
+  if (averageLoss == 0) return averageGain == 0 ? 50.0 : 100.0;
+  final relativeStrength = averageGain / averageLoss;
+  return 100 - 100 / (1 + relativeStrength);
+}
+
+/// Maior queda entre um topo e o vale seguinte, como fração positiva (0,2 =
+/// caiu 20% do topo). Zero quando a série só sobe.
+double maxDrawdown(List<double> prices) {
+  if (prices.isEmpty) return 0;
+  var peak = prices.first;
+  var worst = 0.0;
+  for (var price in prices) {
+    if (price > peak) peak = price;
+    if (peak <= 0) continue;
+    final drawdown = (peak - price) / peak;
+    if (drawdown > worst) worst = drawdown;
+  }
+  return worst;
+}
+
+/// Volatilidade anualizada a partir dos log-retornos diários: o desvio padrão
+/// diário multiplicado por `sqrt(dias no ano)`.
+///
+/// [periodsPerYear] é 252 por padrão (pregões de um ano) — a série da API vem
+/// em dias úteis. Para cripto, que negocia todo dia, o chamador passa 365.
+double annualizedVolatility(List<double> dailyLogReturns,
+    {double periodsPerYear = 252}) {
+  if (dailyLogReturns.length < 2) return 0;
+  return standardDeviation(dailyLogReturns) * sqrt(periodsPerYear);
+}
+
+/// Variação percentual acumulada nos últimos [period] pontos, como fração
+/// (0,05 = subiu 5%). Nulo quando não há pontos suficientes.
+double? momentum(List<double> prices, int period) {
+  if (period <= 0) throw ArgumentError("período precisa ser positivo");
+  if (prices.length < period + 1) return null;
+  final past = prices[prices.length - 1 - period];
+  if (past <= 0) return null;
+  return prices.last / past - 1;
+}
+
+/// Taxa de crescimento anual composta (CAGR) implícita entre o primeiro e o
+/// último preço, dado o intervalo em dias corridos.
+double compoundAnnualGrowthRate(
+    {required double initialPrice,
+    required double finalPrice,
+    required int spanInDays,
+    double daysPerYear = 365}) {
+  if (initialPrice <= 0 || finalPrice <= 0 || spanInDays <= 0) return 0;
+  final years = spanInDays / daysPerYear;
+  return pow(finalPrice / initialPrice, 1 / years).toDouble() - 1;
+}
+
+/// Distância do preço atual à média móvel de [period], medida em desvios
+/// padrão da própria janela (o "z-score" das bandas de Bollinger). Positivo
+/// quer dizer preço esticado acima da média.
+double? bollingerZScore(List<double> prices, int period) {
+  if (period <= 1) throw ArgumentError("período precisa ser maior que 1");
+  if (prices.length < period) return null;
+  final window = prices.sublist(prices.length - period);
+  final deviation = standardDeviation(window);
+  if (deviation == 0) return 0;
+  return (prices.last - mean(window)) / deviation;
+}

--- a/lib/ai/math/indicators.dart
+++ b/lib/ai/math/indicators.dart
@@ -2,23 +2,24 @@ import 'dart:math';
 
 import 'package:cotacao_direta/ai/math/statistics.dart';
 
-/// Indicadores técnicos clássicos calculados sobre a série de preços. São as
-/// entradas que o modelo local recebe além dos retornos crus e, ao mesmo tempo,
-/// os números que aparecem no resumo de mercado da tela.
+/// Classic technical indicators computed over the price series. They are both
+/// the inputs the local model receives besides the raw returns and the numbers
+/// shown in the market summary on screen.
 
-/// Média móvel simples dos últimos [period] preços. Devolve nulo quando a série
-/// é mais curta que o período: uma média incompleta seria comparada com médias
-/// completas em outra escala.
+/// Simple moving average of the last [period] prices. Returns null when the
+/// series is shorter than the period: an incomplete average would be compared
+/// against complete ones on a different scale.
 double? simpleMovingAverage(List<double> values, int period) {
-  if (period <= 0) throw ArgumentError("período precisa ser positivo");
+  if (period <= 0) throw ArgumentError("period must be positive");
   if (values.length < period) return null;
   return mean(values.sublist(values.length - period));
 }
 
-/// Média móvel exponencial de período [period], no formato usual do mercado
-/// (`alpha = 2 / (period + 1)`), semeada pela média simples do primeiro bloco.
+/// Exponential moving average of period [period], in the usual market form
+/// (`alpha = 2 / (period + 1)`), seeded by the simple average of the first
+/// block.
 double? exponentialMovingAverage(List<double> values, int period) {
-  if (period <= 0) throw ArgumentError("período precisa ser positivo");
+  if (period <= 0) throw ArgumentError("period must be positive");
   if (values.length < period) return null;
   final alpha = 2 / (period + 1);
   var estimate = mean(values.sublist(0, period));
@@ -28,13 +29,12 @@ double? exponentialMovingAverage(List<double> values, int period) {
   return estimate;
 }
 
-/// Índice de Força Relativa (IFR/RSI) de Wilder, entre 0 e 100.
+/// Wilder's Relative Strength Index (RSI), between 0 and 100.
 ///
-/// Acima de 70 o ativo é lido como sobrecomprado; abaixo de 30, sobrevendido.
-/// Precisa de [period] variações, isto é, `period + 1` preços; com menos que
-/// isso devolve nulo.
+/// Above 70 the asset reads as overbought; below 30, as oversold. It needs
+/// [period] changes, that is, `period + 1` prices; with fewer it returns null.
 double? relativeStrengthIndex(List<double> prices, {int period = 14}) {
-  if (period <= 0) throw ArgumentError("período precisa ser positivo");
+  if (period <= 0) throw ArgumentError("period must be positive");
   if (prices.length < period + 1) return null;
 
   var averageGain = 0.0;
@@ -49,8 +49,8 @@ double? relativeStrengthIndex(List<double> prices, {int period = 14}) {
   averageGain /= period;
   averageLoss /= period;
 
-  // Suavização de Wilder: cada dia novo entra com peso 1/period, sem descartar
-  // de uma vez o dia que saiu da janela.
+  // Wilder's smoothing: each new day enters with weight 1/period, without
+  // dropping in one go the day that left the window.
   for (var index = period + 1; index < prices.length; index++) {
     final change = prices[index] - prices[index - 1];
     final gain = change > 0 ? change : 0.0;
@@ -59,15 +59,15 @@ double? relativeStrengthIndex(List<double> prices, {int period = 14}) {
     averageLoss = (averageLoss * (period - 1) + loss) / period;
   }
 
-  // Sem nenhuma perda no período o índice satura em 100 (e a divisão por zero
-  // não chega a acontecer).
+  // With no losses in the period the index saturates at 100 (and the division
+  // by zero never happens).
   if (averageLoss == 0) return averageGain == 0 ? 50.0 : 100.0;
   final relativeStrength = averageGain / averageLoss;
   return 100 - 100 / (1 + relativeStrength);
 }
 
-/// Maior queda entre um topo e o vale seguinte, como fração positiva (0,2 =
-/// caiu 20% do topo). Zero quando a série só sobe.
+/// Largest drop from a peak to the following trough, as a positive fraction
+/// (0.2 = fell 20% from the peak). Zero when the series only rises.
 double maxDrawdown(List<double> prices) {
   if (prices.isEmpty) return 0;
   var peak = prices.first;
@@ -81,29 +81,30 @@ double maxDrawdown(List<double> prices) {
   return worst;
 }
 
-/// Volatilidade anualizada a partir dos log-retornos diários: o desvio padrão
-/// diário multiplicado por `sqrt(dias no ano)`.
+/// Annualised volatility from daily log-returns: the daily standard deviation
+/// times `sqrt(days in a year)`.
 ///
-/// [periodsPerYear] é 252 por padrão (pregões de um ano) — a série da API vem
-/// em dias úteis. Para cripto, que negocia todo dia, o chamador passa 365.
+/// [periodsPerYear] is 252 by default (trading days in a year) — the API
+/// series comes in business days. For crypto, which trades every day, the
+/// caller passes 365.
 double annualizedVolatility(List<double> dailyLogReturns,
     {double periodsPerYear = 252}) {
   if (dailyLogReturns.length < 2) return 0;
   return standardDeviation(dailyLogReturns) * sqrt(periodsPerYear);
 }
 
-/// Variação percentual acumulada nos últimos [period] pontos, como fração
-/// (0,05 = subiu 5%). Nulo quando não há pontos suficientes.
+/// Cumulative percentage change over the last [period] points, as a fraction
+/// (0.05 = up 5%). Null when there are not enough points.
 double? momentum(List<double> prices, int period) {
-  if (period <= 0) throw ArgumentError("período precisa ser positivo");
+  if (period <= 0) throw ArgumentError("period must be positive");
   if (prices.length < period + 1) return null;
   final past = prices[prices.length - 1 - period];
   if (past <= 0) return null;
   return prices.last / past - 1;
 }
 
-/// Taxa de crescimento anual composta (CAGR) implícita entre o primeiro e o
-/// último preço, dado o intervalo em dias corridos.
+/// Compound annual growth rate (CAGR) implied between the first and the last
+/// price, given the span in calendar days.
 double compoundAnnualGrowthRate(
     {required double initialPrice,
     required double finalPrice,
@@ -114,11 +115,11 @@ double compoundAnnualGrowthRate(
   return pow(finalPrice / initialPrice, 1 / years).toDouble() - 1;
 }
 
-/// Distância do preço atual à média móvel de [period], medida em desvios
-/// padrão da própria janela (o "z-score" das bandas de Bollinger). Positivo
-/// quer dizer preço esticado acima da média.
+/// Distance from the current price to the moving average of [period], measured
+/// in standard deviations of that same window (the Bollinger bands "z-score").
+/// Positive means the price is stretched above the average.
 double? bollingerZScore(List<double> prices, int period) {
-  if (period <= 1) throw ArgumentError("período precisa ser maior que 1");
+  if (period <= 1) throw ArgumentError("period must be greater than 1");
   if (prices.length < period) return null;
   final window = prices.sublist(prices.length - period);
   final deviation = standardDeviation(window);

--- a/lib/ai/math/statistics.dart
+++ b/lib/ai/math/statistics.dart
@@ -1,23 +1,24 @@
 import 'dart:math';
 
-/// Funções estatísticas usadas pelo modelo local. Ficam separadas do modelo por
-/// serem puras: entram números, saem números, sem depender de Flutter nem de
-/// rede — o que as deixa testáveis isoladamente e reaproveitáveis pelos
-/// indicadores.
+/// Statistical helpers used by the local model. They live apart from the model
+/// because they are pure: numbers in, numbers out, with no Flutter and no
+/// network — which keeps them testable in isolation and reusable by the
+/// indicators.
 
-/// Média aritmética. Lança se a lista estiver vazia: uma média de nada não tem
-/// valor neutro razoável, e todo chamador aqui já sabe quantos pontos tem.
+/// Arithmetic mean. Throws on an empty list: the mean of nothing has no
+/// sensible neutral value, and every caller here already knows how many points
+/// it has.
 double mean(List<double> values) {
-  if (values.isEmpty) throw ArgumentError("mean de uma lista vazia");
+  if (values.isEmpty) throw ArgumentError("mean of an empty list");
   var total = 0.0;
   for (var value in values) total += value;
   return total / values.length;
 }
 
-/// Variância amostral (divisor n-1) por padrão; com [sample] falso, a
-/// populacional. Com um único ponto não há dispersão a medir: devolve zero.
+/// Sample variance (divisor n-1) by default; with [sample] false, the
+/// population one. A single point has no dispersion to measure: returns zero.
 double variance(List<double> values, {bool sample = true}) {
-  if (values.isEmpty) throw ArgumentError("variance de uma lista vazia");
+  if (values.isEmpty) throw ArgumentError("variance of an empty list");
   if (values.length == 1) return 0;
   final average = mean(values);
   var accumulated = 0.0;
@@ -31,15 +32,15 @@ double variance(List<double> values, {bool sample = true}) {
 double standardDeviation(List<double> values, {bool sample = true}) =>
     sqrt(variance(values, sample: sample));
 
-/// Retornos logarítmicos da série de preços: `ln(p[i] / p[i-1])`.
+/// Logarithmic returns of the price series: `ln(p[i] / p[i-1])`.
 ///
-/// O modelo trabalha em log-retorno, e não em variação percentual, porque eles
-/// se somam ao longo do tempo (o retorno de 10 dias é a soma dos 10 diários).
-/// É isso que permite projetar vários dias à frente acumulando previsões e
-/// abrir a faixa de confiança por `sigma * sqrt(dias)`.
+/// The model works in log-returns rather than percentage changes because they
+/// add up over time (a 10-day return is the sum of the 10 daily ones). That is
+/// what allows projecting several days ahead by accumulating predictions, and
+/// widening the confidence band by `sigma * sqrt(days)`.
 ///
-/// Preço não positivo interrompe o cálculo naquele ponto: `ln` não existiria e
-/// um par de dias sem preço não representa retorno nenhum.
+/// A non-positive price interrupts the calculation at that point: `ln` would
+/// not exist, and a pair of days without a price is no return at all.
 List<double> logReturns(List<double> prices) {
   final returns = <double>[];
   for (var index = 1; index < prices.length; index++) {
@@ -51,13 +52,13 @@ List<double> logReturns(List<double> prices) {
   return returns;
 }
 
-/// Reta ajustada por mínimos quadrados, com o R² do ajuste.
+/// Least-squares fitted line, with the R² of the fit.
 class LinearFit {
   final double slope;
   final double intercept;
 
-  /// Fração da variação dos dados explicada pela reta, entre 0 e 1. Vale 0
-  /// quando os dados não variam (não há o que explicar).
+  /// Share of the data's variation explained by the line, between 0 and 1. It
+  /// is 0 when the data does not vary (there is nothing to explain).
   final double rSquared;
 
   const LinearFit(
@@ -66,10 +67,10 @@ class LinearFit {
   double predict(double x) => intercept + slope * x;
 }
 
-/// Ajusta `y = intercept + slope * x` por mínimos quadrados.
+/// Fits `y = intercept + slope * x` by least squares.
 LinearFit linearFit(List<double> xs, List<double> ys) {
   if (xs.length != ys.length)
-    throw ArgumentError("linearFit com listas de tamanhos diferentes");
+    throw ArgumentError("linearFit with lists of different lengths");
   if (xs.length < 2)
     return const LinearFit(slope: 0, intercept: 0, rSquared: 0);
 
@@ -101,11 +102,12 @@ LinearFit linearFit(List<double> xs, List<double> ys) {
   return LinearFit(slope: slope, intercept: intercept, rSquared: rSquared);
 }
 
-/// Média móvel exponencial de toda a lista, com peso [alpha] no ponto mais
-/// recente. É a estimativa de deriva usada como linha de base da projeção:
-/// dá mais peso ao passado recente sem descartar o restante da série.
+/// Exponentially weighted mean of the whole list, with weight [alpha] on the
+/// most recent point. This is the drift estimate used as the projection's
+/// baseline: it favours the recent past without discarding the rest of the
+/// series.
 double exponentiallyWeightedMean(List<double> values, {double alpha = 0.15}) {
-  if (values.isEmpty) throw ArgumentError("ewm de uma lista vazia");
+  if (values.isEmpty) throw ArgumentError("ewm of an empty list");
   var estimate = values.first;
   for (var index = 1; index < values.length; index++) {
     estimate = alpha * values[index] + (1 - alpha) * estimate;
@@ -113,10 +115,10 @@ double exponentiallyWeightedMean(List<double> values, {double alpha = 0.15}) {
   return estimate;
 }
 
-/// Erro quadrático médio entre previsões e alvos.
+/// Mean squared error between predictions and targets.
 double meanSquaredError(List<double> predictions, List<double> targets) {
   if (predictions.length != targets.length)
-    throw ArgumentError("meanSquaredError com listas de tamanhos diferentes");
+    throw ArgumentError("meanSquaredError with lists of different lengths");
   if (predictions.isEmpty) return 0;
   var accumulated = 0.0;
   for (var index = 0; index < predictions.length; index++) {
@@ -126,10 +128,10 @@ double meanSquaredError(List<double> predictions, List<double> targets) {
   return accumulated / predictions.length;
 }
 
-// Coeficientes da aproximação racional de Peter Acklam para o inverso da
-// normal padrão, com erro relativo abaixo de 1,15e-9 — folgado para o uso
-// aqui, que é converter um nível de confiança (80%, 95%) no multiplicador do
-// desvio padrão que abre a faixa da projeção.
+// Coefficients of Peter Acklam's rational approximation for the inverse of the
+// standard normal, with relative error below 1.15e-9 — plenty for the use here,
+// which is turning a confidence level (80%, 95%) into the standard deviation
+// multiplier that opens the projection band.
 const List<double> _lowerCoefficientsA = [
   -3.969683028665376e+01,
   2.209460984245205e+02,
@@ -160,10 +162,11 @@ const List<double> _tailCoefficientsD = [
   3.754408661907416e+00
 ];
 
-/// Quantil da normal padrão: o valor `z` tal que `P(Z <= z) = probability`.
+/// Quantile of the standard normal: the value `z` such that
+/// `P(Z <= z) = probability`.
 double normalQuantile(double probability) {
   if (probability <= 0 || probability >= 1)
-    throw ArgumentError("normalQuantile fora do intervalo (0, 1)");
+    throw ArgumentError("normalQuantile outside the (0, 1) range");
 
   const lowerBreak = 0.02425;
   const upperBreak = 1 - lowerBreak;
@@ -208,10 +211,10 @@ double normalQuantile(double probability) {
           1);
 }
 
-/// Multiplicador do desvio padrão que cobre [confidenceLevel] da distribuição
-/// em torno da média: 1,96 para 95%, 1,28 para 80%.
+/// Standard deviation multiplier covering [confidenceLevel] of the
+/// distribution around the mean: 1.96 for 95%, 1.28 for 80%.
 double confidenceMultiplier(double confidenceLevel) {
   if (confidenceLevel <= 0 || confidenceLevel >= 1)
-    throw ArgumentError("confidenceMultiplier fora do intervalo (0, 1)");
+    throw ArgumentError("confidenceMultiplier outside the (0, 1) range");
   return normalQuantile(0.5 + confidenceLevel / 2);
 }

--- a/lib/ai/math/statistics.dart
+++ b/lib/ai/math/statistics.dart
@@ -1,0 +1,217 @@
+import 'dart:math';
+
+/// Funções estatísticas usadas pelo modelo local. Ficam separadas do modelo por
+/// serem puras: entram números, saem números, sem depender de Flutter nem de
+/// rede — o que as deixa testáveis isoladamente e reaproveitáveis pelos
+/// indicadores.
+
+/// Média aritmética. Lança se a lista estiver vazia: uma média de nada não tem
+/// valor neutro razoável, e todo chamador aqui já sabe quantos pontos tem.
+double mean(List<double> values) {
+  if (values.isEmpty) throw ArgumentError("mean de uma lista vazia");
+  var total = 0.0;
+  for (var value in values) total += value;
+  return total / values.length;
+}
+
+/// Variância amostral (divisor n-1) por padrão; com [sample] falso, a
+/// populacional. Com um único ponto não há dispersão a medir: devolve zero.
+double variance(List<double> values, {bool sample = true}) {
+  if (values.isEmpty) throw ArgumentError("variance de uma lista vazia");
+  if (values.length == 1) return 0;
+  final average = mean(values);
+  var accumulated = 0.0;
+  for (var value in values) {
+    final deviation = value - average;
+    accumulated += deviation * deviation;
+  }
+  return accumulated / (sample ? values.length - 1 : values.length);
+}
+
+double standardDeviation(List<double> values, {bool sample = true}) =>
+    sqrt(variance(values, sample: sample));
+
+/// Retornos logarítmicos da série de preços: `ln(p[i] / p[i-1])`.
+///
+/// O modelo trabalha em log-retorno, e não em variação percentual, porque eles
+/// se somam ao longo do tempo (o retorno de 10 dias é a soma dos 10 diários).
+/// É isso que permite projetar vários dias à frente acumulando previsões e
+/// abrir a faixa de confiança por `sigma * sqrt(dias)`.
+///
+/// Preço não positivo interrompe o cálculo naquele ponto: `ln` não existiria e
+/// um par de dias sem preço não representa retorno nenhum.
+List<double> logReturns(List<double> prices) {
+  final returns = <double>[];
+  for (var index = 1; index < prices.length; index++) {
+    final previous = prices[index - 1];
+    final current = prices[index];
+    if (previous <= 0 || current <= 0) continue;
+    returns.add(log(current / previous));
+  }
+  return returns;
+}
+
+/// Reta ajustada por mínimos quadrados, com o R² do ajuste.
+class LinearFit {
+  final double slope;
+  final double intercept;
+
+  /// Fração da variação dos dados explicada pela reta, entre 0 e 1. Vale 0
+  /// quando os dados não variam (não há o que explicar).
+  final double rSquared;
+
+  const LinearFit(
+      {required this.slope, required this.intercept, required this.rSquared});
+
+  double predict(double x) => intercept + slope * x;
+}
+
+/// Ajusta `y = intercept + slope * x` por mínimos quadrados.
+LinearFit linearFit(List<double> xs, List<double> ys) {
+  if (xs.length != ys.length)
+    throw ArgumentError("linearFit com listas de tamanhos diferentes");
+  if (xs.length < 2)
+    return const LinearFit(slope: 0, intercept: 0, rSquared: 0);
+
+  final meanX = mean(xs);
+  final meanY = mean(ys);
+  var covariance = 0.0;
+  var varianceX = 0.0;
+  for (var index = 0; index < xs.length; index++) {
+    final deviationX = xs[index] - meanX;
+    covariance += deviationX * (ys[index] - meanY);
+    varianceX += deviationX * deviationX;
+  }
+  if (varianceX == 0)
+    return LinearFit(slope: 0, intercept: meanY, rSquared: 0);
+
+  final slope = covariance / varianceX;
+  final intercept = meanY - slope * meanX;
+
+  var residualSum = 0.0;
+  var totalSum = 0.0;
+  for (var index = 0; index < xs.length; index++) {
+    final residual = ys[index] - (intercept + slope * xs[index]);
+    final deviationY = ys[index] - meanY;
+    residualSum += residual * residual;
+    totalSum += deviationY * deviationY;
+  }
+  final rSquared =
+      totalSum == 0 ? 0.0 : (1 - residualSum / totalSum).clamp(0.0, 1.0);
+  return LinearFit(slope: slope, intercept: intercept, rSquared: rSquared);
+}
+
+/// Média móvel exponencial de toda a lista, com peso [alpha] no ponto mais
+/// recente. É a estimativa de deriva usada como linha de base da projeção:
+/// dá mais peso ao passado recente sem descartar o restante da série.
+double exponentiallyWeightedMean(List<double> values, {double alpha = 0.15}) {
+  if (values.isEmpty) throw ArgumentError("ewm de uma lista vazia");
+  var estimate = values.first;
+  for (var index = 1; index < values.length; index++) {
+    estimate = alpha * values[index] + (1 - alpha) * estimate;
+  }
+  return estimate;
+}
+
+/// Erro quadrático médio entre previsões e alvos.
+double meanSquaredError(List<double> predictions, List<double> targets) {
+  if (predictions.length != targets.length)
+    throw ArgumentError("meanSquaredError com listas de tamanhos diferentes");
+  if (predictions.isEmpty) return 0;
+  var accumulated = 0.0;
+  for (var index = 0; index < predictions.length; index++) {
+    final error = predictions[index] - targets[index];
+    accumulated += error * error;
+  }
+  return accumulated / predictions.length;
+}
+
+// Coeficientes da aproximação racional de Peter Acklam para o inverso da
+// normal padrão, com erro relativo abaixo de 1,15e-9 — folgado para o uso
+// aqui, que é converter um nível de confiança (80%, 95%) no multiplicador do
+// desvio padrão que abre a faixa da projeção.
+const List<double> _lowerCoefficientsA = [
+  -3.969683028665376e+01,
+  2.209460984245205e+02,
+  -2.759285104469687e+02,
+  1.383577518672690e+02,
+  -3.066479806614716e+01,
+  2.506628277459239e+00
+];
+const List<double> _lowerCoefficientsB = [
+  -5.447609879822406e+01,
+  1.615858368580409e+02,
+  -1.556989798598866e+02,
+  6.680131188771972e+01,
+  -1.328068155288572e+01
+];
+const List<double> _tailCoefficientsC = [
+  -7.784894002430293e-03,
+  -3.223964580411365e-01,
+  -2.400758277161838e+00,
+  -2.549732539343734e+00,
+  4.374664141464968e+00,
+  2.938163982698783e+00
+];
+const List<double> _tailCoefficientsD = [
+  7.784695709041462e-03,
+  3.224671290700398e-01,
+  2.445134137142996e+00,
+  3.754408661907416e+00
+];
+
+/// Quantil da normal padrão: o valor `z` tal que `P(Z <= z) = probability`.
+double normalQuantile(double probability) {
+  if (probability <= 0 || probability >= 1)
+    throw ArgumentError("normalQuantile fora do intervalo (0, 1)");
+
+  const lowerBreak = 0.02425;
+  const upperBreak = 1 - lowerBreak;
+
+  double tail(double q) =>
+      (((((_tailCoefficientsC[0] * q + _tailCoefficientsC[1]) * q +
+                                  _tailCoefficientsC[2]) *
+                              q +
+                          _tailCoefficientsC[3]) *
+                      q +
+                  _tailCoefficientsC[4]) *
+              q +
+          _tailCoefficientsC[5]) /
+      ((((_tailCoefficientsD[0] * q + _tailCoefficientsD[1]) * q +
+                      _tailCoefficientsD[2]) *
+                  q +
+              _tailCoefficientsD[3]) *
+          q +
+          1);
+
+  if (probability < lowerBreak) return tail(sqrt(-2 * log(probability)));
+  if (probability > upperBreak) return -tail(sqrt(-2 * log(1 - probability)));
+
+  final q = probability - 0.5;
+  final r = q * q;
+  return (((((_lowerCoefficientsA[0] * r + _lowerCoefficientsA[1]) * r +
+                              _lowerCoefficientsA[2]) *
+                          r +
+                      _lowerCoefficientsA[3]) *
+                  r +
+              _lowerCoefficientsA[4]) *
+          r +
+          _lowerCoefficientsA[5]) *
+      q /
+      (((((_lowerCoefficientsB[0] * r + _lowerCoefficientsB[1]) * r +
+                          _lowerCoefficientsB[2]) *
+                      r +
+                  _lowerCoefficientsB[3]) *
+              r +
+          _lowerCoefficientsB[4]) *
+          r +
+          1);
+}
+
+/// Multiplicador do desvio padrão que cobre [confidenceLevel] da distribuição
+/// em torno da média: 1,96 para 95%, 1,28 para 80%.
+double confidenceMultiplier(double confidenceLevel) {
+  if (confidenceLevel <= 0 || confidenceLevel >= 1)
+    throw ArgumentError("confidenceMultiplier fora do intervalo (0, 1)");
+  return normalQuantile(0.5 + confidenceLevel / 2);
+}

--- a/lib/ai/neural/neural_network.dart
+++ b/lib/ai/neural/neural_network.dart
@@ -2,17 +2,18 @@ import 'dart:math';
 
 import 'package:cotacao_direta/ai/math/statistics.dart';
 
-/// Resultado de um treino, para o modelo decidir o quanto confiar na rede.
+/// Outcome of a training run, for the model to decide how much to trust the
+/// network.
 class TrainingReport {
-  /// Erro quadrático médio no conjunto de treino, na última época rodada.
+  /// Mean squared error on the training set, on the last epoch run.
   final double trainingError;
 
-  /// Erro quadrático médio no conjunto de validação (o trecho final da série,
-  /// que a rede não viu no treino). É nulo quando não houve validação.
+  /// Mean squared error on the validation set (the tail of the series, which
+  /// the network did not see while training). Null when there was no
+  /// validation.
   final double? validationError;
 
-  /// Épocas efetivamente rodadas — menos que o teto quando a parada antecipada
-  /// entrou em ação.
+  /// Epochs actually run — fewer than the cap when early stopping kicked in.
   final int epochs;
 
   const TrainingReport(
@@ -21,31 +22,31 @@ class TrainingReport {
       required this.epochs});
 }
 
-/// Rede neural densa de uma camada escondida (perceptron multicamada) escrita
-/// em Dart puro, para regressão de uma saída.
+/// Dense neural network with a single hidden layer (multilayer perceptron)
+/// written in pure Dart, for single-output regression.
 ///
-/// É pequena de propósito: com uma dezena de entradas e meia dúzia de neurônios
-/// escondidos, treinar algumas centenas de épocas sobre um ano de cotações
-/// custa poucos milissegundos de CPU e alguns kilobytes de memória. Isso é o
-/// que permite que o "modelo de IA" do app seja treinado e executado no próprio
-/// aparelho, sem baixar pesos, sem plugin nativo e sem enviar dado nenhum para
-/// fora — inclusive na web, onde não há isolate de verdade.
+/// It is small on purpose: with a dozen inputs and half a dozen hidden
+/// neurons, training a few hundred epochs over a year of quotes costs a few
+/// milliseconds of CPU and a few kilobytes of memory. That is what lets the
+/// app's "AI model" be trained and run on the device itself, with no weights
+/// to download, no native plugin and no data leaving the phone — including on
+/// the web, where there is no real isolate.
 ///
-/// Escolhas de arquitetura:
-/// - ativação `tanh` na camada escondida, centrada em zero como os retornos que
-///   a rede recebe;
-/// - saída linear, porque o alvo é um retorno (pode ser negativo e não tem
-///   teto);
-/// - erro quadrático médio como perda, gradiente descendente estocástico com
-///   embaralhamento por época e decaimento de pesos (L2);
-/// - toda a aleatoriedade (pesos iniciais e ordem das amostras) sai de um
-///   [Random] semeado, então a mesma série produz sempre a mesma projeção —
-///   sem isso a tela mudaria de resposta a cada toque no botão.
+/// Architecture choices:
+/// - `tanh` activation on the hidden layer, centred on zero like the returns
+///   the network receives;
+/// - linear output, because the target is a return (it can be negative and has
+///   no ceiling);
+/// - mean squared error as the loss, stochastic gradient descent with
+///   per-epoch shuffling and weight decay (L2);
+/// - all randomness (initial weights and sample order) comes from a seeded
+///   [Random], so the same series always produces the same projection —
+///   without that the screen would change its answer on every tap.
 class NeuralNetwork {
   final int inputSize;
   final int hiddenSize;
 
-  /// Pesos da camada escondida: `[neurônio][entrada]`.
+  /// Hidden layer weights: `[neuron][input]`.
   final List<List<double>> _hiddenWeights;
   final List<double> _hiddenBiases;
   final List<double> _outputWeights;
@@ -66,8 +67,9 @@ class NeuralNetwork {
     _initializeWeights();
   }
 
-  /// Inicialização de Xavier/Glorot: a faixa dos pesos acompanha o número de
-  /// conexões, para o sinal não saturar a `tanh` já na primeira passada.
+  /// Xavier/Glorot initialisation: the weight range follows the number of
+  /// connections, so the signal does not saturate the `tanh` on the very first
+  /// pass.
   void _initializeWeights() {
     final hiddenLimit = sqrt(6 / (inputSize + hiddenSize));
     for (var neuron = 0; neuron < hiddenSize; neuron++) {
@@ -92,8 +94,8 @@ class NeuralNetwork {
       for (var input = 0; input < inputSize; input++) {
         sum += weights[input] * features[input];
       }
-      // tanh(x) = 2 * sigmoide(2x) - 1; dart:math não traz tanh, então usamos
-      // a forma com exponencial, protegida contra estouro para |x| grande.
+      // tanh(x) = 2 * sigmoid(2x) - 1; dart:math does not ship tanh, so we use
+      // the exponential form, guarded against overflow for large |x|.
       activations[neuron] = _hyperbolicTangent(sum);
     }
     return activations;
@@ -107,11 +109,11 @@ class NeuralNetwork {
     return (positive - negative) / (positive + negative);
   }
 
-  /// Saída da rede para um vetor de características.
+  /// The network's output for a feature vector.
   double predict(List<double> features) {
     if (features.length != inputSize)
-      throw ArgumentError("esperadas $inputSize entradas, "
-          "recebidas ${features.length}");
+      throw ArgumentError("expected $inputSize inputs, "
+          "got ${features.length}");
     final activations = _hiddenActivations(features);
     var output = _outputBias;
     for (var neuron = 0; neuron < hiddenSize; neuron++) {
@@ -123,13 +125,14 @@ class NeuralNetwork {
   List<double> predictAll(List<List<double>> inputs) =>
       inputs.map(predict).toList(growable: false);
 
-  /// Treina por gradiente descendente estocástico.
+  /// Trains by stochastic gradient descent.
   ///
-  /// Quando [validationInputs] é informado, o treino guarda os pesos da melhor
-  /// época segundo o erro de validação e os restaura no fim: numa série curta a
-  /// rede decora o treino em poucas dezenas de épocas, e sem isso a projeção
-  /// sairia do ajuste memorizado em vez do que generaliza. [patience] encerra o
-  /// treino quando a validação para de melhorar.
+  /// When [validationInputs] is given, training keeps the weights of the best
+  /// epoch by validation error and restores them at the end: on a short series
+  /// the network memorises the training set within a few dozen epochs, and
+  /// without this the projection would come from the memorised fit rather than
+  /// from what generalises. [patience] stops training once validation stops
+  /// improving.
   TrainingReport train(
     List<List<double>> inputs,
     List<double> targets, {
@@ -141,8 +144,8 @@ class NeuralNetwork {
     int patience = 40,
   }) {
     if (inputs.length != targets.length)
-      throw ArgumentError("entradas e alvos com tamanhos diferentes");
-    if (inputs.isEmpty) throw ArgumentError("treino sem amostras");
+      throw ArgumentError("inputs and targets of different lengths");
+    if (inputs.isEmpty) throw ArgumentError("training with no samples");
 
     final validates = validationInputs != null &&
         validationTargets != null &&
@@ -184,8 +187,8 @@ class NeuralNetwork {
     );
   }
 
-  /// Um passo de retropropagação para uma amostra, com a perda `0,5 * erro²`
-  /// (a constante deixa a derivada valendo exatamente o erro).
+  /// One backpropagation step for a single sample, with loss `0.5 * error²`
+  /// (the constant makes the derivative come out as exactly the error).
   void _applyGradient(List<double> features, double target, double learningRate,
       double weightDecay) {
     final activations = _hiddenActivations(features);
@@ -197,7 +200,7 @@ class NeuralNetwork {
 
     for (var neuron = 0; neuron < hiddenSize; neuron++) {
       final activation = activations[neuron];
-      // Derivada da tanh: 1 - tanh(x)².
+      // Derivative of tanh: 1 - tanh(x)².
       final hiddenDelta =
           outputDelta * _outputWeights[neuron] * (1 - activation * activation);
 

--- a/lib/ai/neural/neural_network.dart
+++ b/lib/ai/neural/neural_network.dart
@@ -1,0 +1,247 @@
+import 'dart:math';
+
+import 'package:cotacao_direta/ai/math/statistics.dart';
+
+/// Resultado de um treino, para o modelo decidir o quanto confiar na rede.
+class TrainingReport {
+  /// Erro quadrático médio no conjunto de treino, na última época rodada.
+  final double trainingError;
+
+  /// Erro quadrático médio no conjunto de validação (o trecho final da série,
+  /// que a rede não viu no treino). É nulo quando não houve validação.
+  final double? validationError;
+
+  /// Épocas efetivamente rodadas — menos que o teto quando a parada antecipada
+  /// entrou em ação.
+  final int epochs;
+
+  const TrainingReport(
+      {required this.trainingError,
+      required this.validationError,
+      required this.epochs});
+}
+
+/// Rede neural densa de uma camada escondida (perceptron multicamada) escrita
+/// em Dart puro, para regressão de uma saída.
+///
+/// É pequena de propósito: com uma dezena de entradas e meia dúzia de neurônios
+/// escondidos, treinar algumas centenas de épocas sobre um ano de cotações
+/// custa poucos milissegundos de CPU e alguns kilobytes de memória. Isso é o
+/// que permite que o "modelo de IA" do app seja treinado e executado no próprio
+/// aparelho, sem baixar pesos, sem plugin nativo e sem enviar dado nenhum para
+/// fora — inclusive na web, onde não há isolate de verdade.
+///
+/// Escolhas de arquitetura:
+/// - ativação `tanh` na camada escondida, centrada em zero como os retornos que
+///   a rede recebe;
+/// - saída linear, porque o alvo é um retorno (pode ser negativo e não tem
+///   teto);
+/// - erro quadrático médio como perda, gradiente descendente estocástico com
+///   embaralhamento por época e decaimento de pesos (L2);
+/// - toda a aleatoriedade (pesos iniciais e ordem das amostras) sai de um
+///   [Random] semeado, então a mesma série produz sempre a mesma projeção —
+///   sem isso a tela mudaria de resposta a cada toque no botão.
+class NeuralNetwork {
+  final int inputSize;
+  final int hiddenSize;
+
+  /// Pesos da camada escondida: `[neurônio][entrada]`.
+  final List<List<double>> _hiddenWeights;
+  final List<double> _hiddenBiases;
+  final List<double> _outputWeights;
+  double _outputBias;
+
+  final Random _random;
+
+  NeuralNetwork({required this.inputSize, required this.hiddenSize, int seed = 7})
+      : assert(inputSize > 0),
+        assert(hiddenSize > 0),
+        _random = Random(seed),
+        _hiddenWeights = List.generate(
+            hiddenSize, (_) => List<double>.filled(inputSize, 0),
+            growable: false),
+        _hiddenBiases = List<double>.filled(hiddenSize, 0),
+        _outputWeights = List<double>.filled(hiddenSize, 0),
+        _outputBias = 0 {
+    _initializeWeights();
+  }
+
+  /// Inicialização de Xavier/Glorot: a faixa dos pesos acompanha o número de
+  /// conexões, para o sinal não saturar a `tanh` já na primeira passada.
+  void _initializeWeights() {
+    final hiddenLimit = sqrt(6 / (inputSize + hiddenSize));
+    for (var neuron = 0; neuron < hiddenSize; neuron++) {
+      for (var input = 0; input < inputSize; input++) {
+        _hiddenWeights[neuron][input] =
+            (_random.nextDouble() * 2 - 1) * hiddenLimit;
+      }
+      _hiddenBiases[neuron] = 0;
+    }
+    final outputLimit = sqrt(6 / (hiddenSize + 1));
+    for (var neuron = 0; neuron < hiddenSize; neuron++) {
+      _outputWeights[neuron] = (_random.nextDouble() * 2 - 1) * outputLimit;
+    }
+    _outputBias = 0;
+  }
+
+  List<double> _hiddenActivations(List<double> features) {
+    final activations = List<double>.filled(hiddenSize, 0);
+    for (var neuron = 0; neuron < hiddenSize; neuron++) {
+      var sum = _hiddenBiases[neuron];
+      final weights = _hiddenWeights[neuron];
+      for (var input = 0; input < inputSize; input++) {
+        sum += weights[input] * features[input];
+      }
+      // tanh(x) = 2 * sigmoide(2x) - 1; dart:math não traz tanh, então usamos
+      // a forma com exponencial, protegida contra estouro para |x| grande.
+      activations[neuron] = _hyperbolicTangent(sum);
+    }
+    return activations;
+  }
+
+  static double _hyperbolicTangent(double value) {
+    if (value > 20) return 1;
+    if (value < -20) return -1;
+    final positive = exp(value);
+    final negative = exp(-value);
+    return (positive - negative) / (positive + negative);
+  }
+
+  /// Saída da rede para um vetor de características.
+  double predict(List<double> features) {
+    if (features.length != inputSize)
+      throw ArgumentError("esperadas $inputSize entradas, "
+          "recebidas ${features.length}");
+    final activations = _hiddenActivations(features);
+    var output = _outputBias;
+    for (var neuron = 0; neuron < hiddenSize; neuron++) {
+      output += _outputWeights[neuron] * activations[neuron];
+    }
+    return output;
+  }
+
+  List<double> predictAll(List<List<double>> inputs) =>
+      inputs.map(predict).toList(growable: false);
+
+  /// Treina por gradiente descendente estocástico.
+  ///
+  /// Quando [validationInputs] é informado, o treino guarda os pesos da melhor
+  /// época segundo o erro de validação e os restaura no fim: numa série curta a
+  /// rede decora o treino em poucas dezenas de épocas, e sem isso a projeção
+  /// sairia do ajuste memorizado em vez do que generaliza. [patience] encerra o
+  /// treino quando a validação para de melhorar.
+  TrainingReport train(
+    List<List<double>> inputs,
+    List<double> targets, {
+    List<List<double>>? validationInputs,
+    List<double>? validationTargets,
+    int epochs = 250,
+    double learningRate = 0.02,
+    double weightDecay = 1e-4,
+    int patience = 40,
+  }) {
+    if (inputs.length != targets.length)
+      throw ArgumentError("entradas e alvos com tamanhos diferentes");
+    if (inputs.isEmpty) throw ArgumentError("treino sem amostras");
+
+    final validates = validationInputs != null &&
+        validationTargets != null &&
+        validationInputs.isNotEmpty;
+
+    final order = List<int>.generate(inputs.length, (index) => index);
+    var bestValidationError = double.infinity;
+    var bestWeights = validates ? _snapshot() : null;
+    var epochsWithoutImprovement = 0;
+    var epochsRun = 0;
+
+    for (var epoch = 0; epoch < epochs; epoch++) {
+      order.shuffle(_random);
+      for (var index in order) {
+        _applyGradient(inputs[index], targets[index], learningRate, weightDecay);
+      }
+      epochsRun++;
+
+      if (!validates) continue;
+      final validationError =
+          meanSquaredError(predictAll(validationInputs), validationTargets);
+      if (validationError < bestValidationError - 1e-9) {
+        bestValidationError = validationError;
+        bestWeights = _snapshot();
+        epochsWithoutImprovement = 0;
+      } else if (++epochsWithoutImprovement >= patience) {
+        break;
+      }
+    }
+
+    if (validates && bestWeights != null) _restore(bestWeights);
+
+    return TrainingReport(
+      trainingError: meanSquaredError(predictAll(inputs), targets),
+      validationError: validates
+          ? meanSquaredError(predictAll(validationInputs), validationTargets)
+          : null,
+      epochs: epochsRun,
+    );
+  }
+
+  /// Um passo de retropropagação para uma amostra, com a perda `0,5 * erro²`
+  /// (a constante deixa a derivada valendo exatamente o erro).
+  void _applyGradient(List<double> features, double target, double learningRate,
+      double weightDecay) {
+    final activations = _hiddenActivations(features);
+    var output = _outputBias;
+    for (var neuron = 0; neuron < hiddenSize; neuron++) {
+      output += _outputWeights[neuron] * activations[neuron];
+    }
+    final outputDelta = output - target;
+
+    for (var neuron = 0; neuron < hiddenSize; neuron++) {
+      final activation = activations[neuron];
+      // Derivada da tanh: 1 - tanh(x)².
+      final hiddenDelta =
+          outputDelta * _outputWeights[neuron] * (1 - activation * activation);
+
+      _outputWeights[neuron] -= learningRate *
+          (outputDelta * activation + weightDecay * _outputWeights[neuron]);
+
+      final weights = _hiddenWeights[neuron];
+      for (var input = 0; input < inputSize; input++) {
+        weights[input] -= learningRate *
+            (hiddenDelta * features[input] + weightDecay * weights[input]);
+      }
+      _hiddenBiases[neuron] -= learningRate * hiddenDelta;
+    }
+    _outputBias -= learningRate * outputDelta;
+  }
+
+  _Weights _snapshot() => _Weights(
+        hiddenWeights: _hiddenWeights
+            .map((weights) => List<double>.from(weights))
+            .toList(growable: false),
+        hiddenBiases: List<double>.from(_hiddenBiases),
+        outputWeights: List<double>.from(_outputWeights),
+        outputBias: _outputBias,
+      );
+
+  void _restore(_Weights weights) {
+    for (var neuron = 0; neuron < hiddenSize; neuron++) {
+      _hiddenWeights[neuron].setAll(0, weights.hiddenWeights[neuron]);
+      _hiddenBiases[neuron] = weights.hiddenBiases[neuron];
+      _outputWeights[neuron] = weights.outputWeights[neuron];
+    }
+    _outputBias = weights.outputBias;
+  }
+}
+
+class _Weights {
+  final List<List<double>> hiddenWeights;
+  final List<double> hiddenBiases;
+  final List<double> outputWeights;
+  final double outputBias;
+
+  const _Weights(
+      {required this.hiddenWeights,
+      required this.hiddenBiases,
+      required this.outputWeights,
+      required this.outputBias});
+}

--- a/lib/blocs/ai_insights_bloc.dart
+++ b/lib/blocs/ai_insights_bloc.dart
@@ -1,0 +1,212 @@
+import 'dart:async';
+
+import 'package:cotacao_direta/ai/financial_ai_service.dart';
+import 'package:cotacao_direta/blocs/base_bloc.dart';
+import 'package:cotacao_direta/model/asset_series.dart';
+import 'package:cotacao_direta/model/financial_analysis.dart';
+import 'package:cotacao_direta/repository/currency_repository.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+/// Por que a análise não pôde ser feita, para a tela escolher a mensagem.
+enum AiInsightsError {
+  /// Nenhuma cotação voltou: sem rede e sem histórico salvo, ou par não cotado
+  /// pela API.
+  noData,
+
+  /// Vieram cotações, mas poucas demais para calcular indicadores.
+  insufficientData,
+
+  /// Qualquer falha inesperada no caminho.
+  failure,
+}
+
+/// Estado da tela de insights. Um objeto só, em vez de três streams, porque as
+/// três informações mudam sempre juntas e a tela precisa delas em conjunto.
+class AiInsightsState {
+  final bool loading;
+  final FinancialAnalysis? analysis;
+  final AiInsightsError? error;
+
+  const AiInsightsState._({this.loading = false, this.analysis, this.error});
+
+  const AiInsightsState.idle() : this._();
+
+  const AiInsightsState.loading() : this._(loading: true);
+
+  const AiInsightsState.ready(FinancialAnalysis analysis)
+      : this._(analysis: analysis);
+
+  const AiInsightsState.failed(AiInsightsError error) : this._(error: error);
+
+  bool get hasAnalysis => analysis != null;
+}
+
+/// Liga a tela de insights ao histórico de cotações e ao modelo local.
+///
+/// A análise roda no próprio aparelho: o bloc busca o histórico pelo
+/// repositório que o app já usa, monta a série e chama o [FinancialAiService].
+/// Nada de cotação ou de resultado sai do celular.
+class AiInsightsBloc extends BaseBloc {
+  final CurrencyRepository _currencyRepository;
+  final FinancialAiService _aiService;
+
+  final StreamController<AiInsightsState> _stateController =
+      StreamController<AiInsightsState>.broadcast();
+
+  final TextEditingController _amountController = TextEditingController();
+
+  final DateFormat _apiDateFormatter = DateFormat("yyyy-MM-dd");
+
+  /// Horizontes oferecidos na tela, em dias.
+  static const List<int> horizonOptions = [7, 15, 30];
+
+  /// Dias corridos de histórico pedidos à API. Cobre uns quatro meses de
+  /// pregão — o bastante para treinar a rede sem esbarrar no teto de 360
+  /// registros por consulta.
+  static const int historyWindowInDays = 180;
+
+  AiInsightsState _state = const AiInsightsState.idle();
+
+  String _selectedAssetCode;
+  AssetKind _selectedAssetKind;
+  int _horizonInDays;
+
+  Future<String>? _counterCurrencyFuture;
+
+  /// Requisição em andamento, para uma resposta atrasada não sobrescrever o
+  /// resultado de um pedido mais novo (o usuário troca de ativo e toca de novo
+  /// antes de a primeira consulta voltar).
+  int _requestId = 0;
+
+  /// Idioma da última análise pedida pela tela, para reaproveitar quando o
+  /// próprio bloc refaz a análise (troca de horizonte).
+  String _languageCode = "pt";
+
+  AiInsightsBloc({
+    CurrencyRepository? currencyRepository,
+    FinancialAiService? aiService,
+    String initialAssetCode = "USD",
+    AssetKind initialAssetKind = AssetKind.currency,
+    int initialHorizonInDays = 15,
+  })  : _currencyRepository = currencyRepository ?? CurrencyRepository(),
+        _aiService = aiService ?? FinancialAiService(),
+        _selectedAssetCode = initialAssetCode,
+        _selectedAssetKind = initialAssetKind,
+        _horizonInDays = initialHorizonInDays;
+
+  Stream<AiInsightsState> get stateStream => _stateController.stream;
+
+  /// Último estado emitido. A stream é broadcast e não repete o último evento,
+  /// então a tela usa isto como `initialData` ao reconstruir.
+  AiInsightsState get currentState => _state;
+
+  String get selectedAssetCode => _selectedAssetCode;
+
+  AssetKind get selectedAssetKind => _selectedAssetKind;
+
+  int get horizonInDays => _horizonInDays;
+
+  TextEditingController get amountController => _amountController;
+
+  /// Moeda em que as cotações estão expressas, resolvida uma vez e mantida em
+  /// cache (a tela reconsulta a cada rebuild).
+  Future<String> get counterCurrencyCode =>
+      _counterCurrencyFuture ??= _currencyRepository.resolveCounterCurrency();
+
+  void selectAsset(String assetCode, AssetKind kind) {
+    if (_selectedAssetCode == assetCode && _selectedAssetKind == kind) return;
+    _selectedAssetCode = assetCode;
+    _selectedAssetKind = kind;
+    // O resultado na tela é de outro ativo: mantê-lo visível ao lado do nome
+    // novo faria a análise parecer atualizada.
+    _emit(const AiInsightsState.idle());
+  }
+
+  void selectHorizon(int days) {
+    if (_horizonInDays == days) return;
+    _horizonInDays = days;
+    // O horizonte muda só a projeção; refazer a análise é barato e não precisa
+    // de rede, então a tela responde na hora se já houver um resultado.
+    if (_state.hasAnalysis) analyze(languageCode: _languageCode);
+  }
+
+  /// Valor digitado para simulação, ou nulo quando o campo está vazio ou
+  /// inválido. Aceita tanto "1.234,50" quanto "1,234.50": o separador decimal é
+  /// o último que aparecer.
+  double? get simulationAmount => parseAmount(_amountController.text);
+
+  static double? parseAmount(String text) {
+    var cleaned = text.trim().replaceAll(RegExp(r"[^0-9.,-]"), "");
+    if (cleaned.isEmpty) return null;
+    final lastComma = cleaned.lastIndexOf(",");
+    final lastDot = cleaned.lastIndexOf(".");
+    if (lastComma > lastDot) {
+      cleaned = cleaned.replaceAll(".", "").replaceAll(",", ".");
+    } else {
+      cleaned = cleaned.replaceAll(",", "");
+    }
+    final value = double.tryParse(cleaned);
+    if (value == null || !value.isFinite || value <= 0) return null;
+    return value;
+  }
+
+  /// Busca o histórico do ativo selecionado e roda o modelo local sobre ele.
+  Future<void> analyze({String languageCode = "pt"}) async {
+    final requestId = ++_requestId;
+    _languageCode = languageCode;
+    _emit(const AiInsightsState.loading());
+    try {
+      final today = DateTime.now();
+      final history = await _currencyRepository.getCurrencyHistoricalData(
+        [_selectedAssetCode],
+        _apiDateFormatter
+            .format(today.subtract(const Duration(days: historyWindowInDays))),
+        _apiDateFormatter.format(today),
+      );
+      if (requestId != _requestId) return;
+
+      final series = AssetSeries.fromQuoteHistory(
+        code: _selectedAssetCode,
+        kind: _selectedAssetKind,
+        quoteCurrency: await counterCurrencyCode,
+        history: history,
+      );
+      if (requestId != _requestId) return;
+
+      if (series.isEmpty) {
+        _emit(const AiInsightsState.failed(AiInsightsError.noData));
+        return;
+      }
+      if (series.length < FinancialAiService.minimumPoints) {
+        _emit(const AiInsightsState.failed(AiInsightsError.insufficientData));
+        return;
+      }
+
+      // Devolve o controle ao laço de eventos antes de treinar: o treino é
+      // curto (milissegundos), mas assim o indicador de carregamento chega a
+      // aparecer e a tela não trava em aparelho lento.
+      final analysis = await Future(() => _aiService.analyze(
+            series,
+            horizonInDays: _horizonInDays,
+            languageCode: languageCode,
+          ));
+      if (requestId != _requestId) return;
+      _emit(AiInsightsState.ready(analysis));
+    } catch (exception) {
+      if (requestId != _requestId) return;
+      _emit(const AiInsightsState.failed(AiInsightsError.failure));
+    }
+  }
+
+  void _emit(AiInsightsState state) {
+    _state = state;
+    if (!_stateController.isClosed) _stateController.sink.add(state);
+  }
+
+  @override
+  void dispose() {
+    _stateController.close();
+    _amountController.dispose();
+  }
+}

--- a/lib/blocs/ai_insights_bloc.dart
+++ b/lib/blocs/ai_insights_bloc.dart
@@ -8,21 +8,22 @@ import 'package:cotacao_direta/repository/currency_repository.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
-/// Por que a análise não pôde ser feita, para a tela escolher a mensagem.
+/// Why the analysis could not be done, so the screen can pick the message.
 enum AiInsightsError {
-  /// Nenhuma cotação voltou: sem rede e sem histórico salvo, ou par não cotado
-  /// pela API.
+  /// No quote came back: no network and no saved history, or a pair the API
+  /// does not quote.
   noData,
 
-  /// Vieram cotações, mas poucas demais para calcular indicadores.
+  /// Quotes did come back, but too few to compute indicators.
   insufficientData,
 
-  /// Qualquer falha inesperada no caminho.
+  /// Any unexpected failure along the way.
   failure,
 }
 
-/// Estado da tela de insights. Um objeto só, em vez de três streams, porque as
-/// três informações mudam sempre juntas e a tela precisa delas em conjunto.
+/// State of the insights screen. A single object instead of three streams,
+/// because the three pieces always change together and the screen needs them
+/// as a set.
 class AiInsightsState {
   final bool loading;
   final FinancialAnalysis? analysis;
@@ -42,11 +43,11 @@ class AiInsightsState {
   bool get hasAnalysis => analysis != null;
 }
 
-/// Liga a tela de insights ao histórico de cotações e ao modelo local.
+/// Connects the insights screen to the quote history and to the local model.
 ///
-/// A análise roda no próprio aparelho: o bloc busca o histórico pelo
-/// repositório que o app já usa, monta a série e chama o [FinancialAiService].
-/// Nada de cotação ou de resultado sai do celular.
+/// The analysis runs on the device itself: the bloc fetches the history
+/// through the repository the app already uses, builds the series and calls
+/// the [FinancialAiService]. No quote and no result leaves the phone.
 class AiInsightsBloc extends BaseBloc {
   final CurrencyRepository _currencyRepository;
   final FinancialAiService _aiService;
@@ -58,12 +59,12 @@ class AiInsightsBloc extends BaseBloc {
 
   final DateFormat _apiDateFormatter = DateFormat("yyyy-MM-dd");
 
-  /// Horizontes oferecidos na tela, em dias.
+  /// Horizons offered on the screen, in days.
   static const List<int> horizonOptions = [7, 15, 30];
 
-  /// Dias corridos de histórico pedidos à API. Cobre uns quatro meses de
-  /// pregão — o bastante para treinar a rede sem esbarrar no teto de 360
-  /// registros por consulta.
+  /// Calendar days of history requested from the API. It covers about four
+  /// months of trading — enough to train the network without hitting the cap
+  /// of 360 records per request.
   static const int historyWindowInDays = 180;
 
   AiInsightsState _state = const AiInsightsState.idle();
@@ -74,13 +75,13 @@ class AiInsightsBloc extends BaseBloc {
 
   Future<String>? _counterCurrencyFuture;
 
-  /// Requisição em andamento, para uma resposta atrasada não sobrescrever o
-  /// resultado de um pedido mais novo (o usuário troca de ativo e toca de novo
-  /// antes de a primeira consulta voltar).
+  /// Request in flight, so a late response does not overwrite the result of a
+  /// newer request (the user switches asset and taps again before the first
+  /// query comes back).
   int _requestId = 0;
 
-  /// Idioma da última análise pedida pela tela, para reaproveitar quando o
-  /// próprio bloc refaz a análise (troca de horizonte).
+  /// Language of the last analysis requested by the screen, to reuse when the
+  /// bloc itself re-runs the analysis (on a horizon change).
   String _languageCode = "pt";
 
   AiInsightsBloc({
@@ -97,8 +98,8 @@ class AiInsightsBloc extends BaseBloc {
 
   Stream<AiInsightsState> get stateStream => _stateController.stream;
 
-  /// Último estado emitido. A stream é broadcast e não repete o último evento,
-  /// então a tela usa isto como `initialData` ao reconstruir.
+  /// Last emitted state. The stream is a broadcast one and does not replay the
+  /// latest event, so the screen uses this as `initialData` when rebuilding.
   AiInsightsState get currentState => _state;
 
   String get selectedAssetCode => _selectedAssetCode;
@@ -109,8 +110,8 @@ class AiInsightsBloc extends BaseBloc {
 
   TextEditingController get amountController => _amountController;
 
-  /// Moeda em que as cotações estão expressas, resolvida uma vez e mantida em
-  /// cache (a tela reconsulta a cada rebuild).
+  /// Currency the quotes are expressed in, resolved once and cached (the
+  /// screen asks for it on every rebuild).
   Future<String> get counterCurrencyCode =>
       _counterCurrencyFuture ??= _currencyRepository.resolveCounterCurrency();
 
@@ -118,22 +119,23 @@ class AiInsightsBloc extends BaseBloc {
     if (_selectedAssetCode == assetCode && _selectedAssetKind == kind) return;
     _selectedAssetCode = assetCode;
     _selectedAssetKind = kind;
-    // O resultado na tela é de outro ativo: mantê-lo visível ao lado do nome
-    // novo faria a análise parecer atualizada.
+    // The result on screen belongs to another asset: keeping it next to the
+    // new name would make the analysis look up to date.
     _emit(const AiInsightsState.idle());
   }
 
   void selectHorizon(int days) {
     if (_horizonInDays == days) return;
     _horizonInDays = days;
-    // O horizonte muda só a projeção; refazer a análise é barato e não precisa
-    // de rede, então a tela responde na hora se já houver um resultado.
+    // The horizon only changes the projection; redoing the analysis is cheap
+    // and needs no network, so the screen answers right away when a result is
+    // already there.
     if (_state.hasAnalysis) analyze(languageCode: _languageCode);
   }
 
-  /// Valor digitado para simulação, ou nulo quando o campo está vazio ou
-  /// inválido. Aceita tanto "1.234,50" quanto "1,234.50": o separador decimal é
-  /// o último que aparecer.
+  /// Amount typed for the simulation, or null when the field is empty or
+  /// invalid. It takes both "1.234,50" and "1,234.50": the decimal separator
+  /// is whichever comes last.
   double? get simulationAmount => parseAmount(_amountController.text);
 
   static double? parseAmount(String text) {
@@ -151,7 +153,8 @@ class AiInsightsBloc extends BaseBloc {
     return value;
   }
 
-  /// Busca o histórico do ativo selecionado e roda o modelo local sobre ele.
+  /// Fetches the history of the selected asset and runs the local model over
+  /// it.
   Future<void> analyze({String languageCode = "pt"}) async {
     final requestId = ++_requestId;
     _languageCode = languageCode;
@@ -183,9 +186,9 @@ class AiInsightsBloc extends BaseBloc {
         return;
       }
 
-      // Devolve o controle ao laço de eventos antes de treinar: o treino é
-      // curto (milissegundos), mas assim o indicador de carregamento chega a
-      // aparecer e a tela não trava em aparelho lento.
+      // Hands control back to the event loop before training: training is
+      // short (milliseconds), but this way the loading indicator does get to
+      // show and the screen does not freeze on a slow device.
       final analysis = await Future(() => _aiService.analyze(
             series,
             horizonInDays: _horizonInDays,

--- a/lib/model/asset_series.dart
+++ b/lib/model/asset_series.dart
@@ -1,0 +1,108 @@
+import 'package:cotacao_direta/model/currency.dart';
+
+/// Natureza do ativo analisado. O modelo local é o mesmo para os três: o que
+/// muda é o rótulo mostrado na tela e os limiares de volatilidade usados nos
+/// insights, já que cripto oscila numa ordem de grandeza acima de moeda
+/// fiduciária.
+enum AssetKind { currency, cryptocurrency, stock }
+
+/// Um ponto da série: o preço do ativo naquele dia, expresso na moeda de
+/// contrapartida.
+class AssetPoint {
+  final DateTime date;
+  final double price;
+
+  const AssetPoint({required this.date, required this.price});
+
+  @override
+  String toString() => "AssetPoint(${date.toIso8601String()}, $price)";
+}
+
+/// Série temporal de preços pronta para o modelo local.
+///
+/// O app guarda em [Currency.value] o inverso da cotação — quantas unidades da
+/// moeda valem uma unidade da contrapartida (ver `CurrencyRepository`). Quem
+/// olha o gráfico raciocina no sentido oposto ("quanto custa um dólar"), e é
+/// esse o número que a análise precisa: uma alta do dólar tem que aparecer como
+/// alta, não como queda. Por isso [AssetSeries.fromQuoteHistory] inverte o
+/// valor guardado ao montar a série.
+class AssetSeries {
+  final String code;
+  final AssetKind kind;
+
+  /// Moeda em que os preços estão expressos (a contrapartida das cotações).
+  final String quoteCurrency;
+
+  /// Pontos em ordem cronológica, um por dia, sem repetição de data.
+  final List<AssetPoint> points;
+
+  AssetSeries._(this.code, this.kind, this.quoteCurrency, this.points);
+
+  factory AssetSeries({
+    required String code,
+    required AssetKind kind,
+    required String quoteCurrency,
+    required List<AssetPoint> points,
+  }) {
+    // Um dia repetido (a API às vezes devolve o pregão do dia junto do
+    // fechamento anterior) viraria um retorno zero no meio da série e
+    // rebaixaria a volatilidade estimada. Fica o último ponto de cada dia.
+    final byDay = <DateTime, AssetPoint>{};
+    for (var point in points) {
+      if (!point.price.isFinite || point.price <= 0) continue;
+      byDay[DateTime(point.date.year, point.date.month, point.date.day)] = point;
+    }
+    final ordered = byDay.entries.toList()
+      ..sort((a, b) => a.key.compareTo(b.key));
+    return AssetSeries._(code, kind, quoteCurrency,
+        List.unmodifiable(ordered.map((entry) => entry.value)));
+  }
+
+  /// Monta a série a partir do histórico que o `CurrencyRepository` devolve,
+  /// invertendo cada valor para a convenção de preço descrita na classe.
+  factory AssetSeries.fromQuoteHistory({
+    required String code,
+    required AssetKind kind,
+    required String quoteCurrency,
+    required List<Currency> history,
+  }) {
+    final points = <AssetPoint>[];
+    for (var currency in history) {
+      final value = currency.value;
+      final date = currency.historicalDate;
+      if (value == null || value == 0 || !value.isFinite) continue;
+      if (date == null) continue;
+      final parsedDate = DateTime.tryParse(date);
+      if (parsedDate == null) continue;
+      points.add(AssetPoint(date: parsedDate, price: 1 / value));
+    }
+    return AssetSeries(
+        code: code, kind: kind, quoteCurrency: quoteCurrency, points: points);
+  }
+
+  int get length => points.length;
+
+  bool get isEmpty => points.isEmpty;
+
+  bool get isNotEmpty => points.isNotEmpty;
+
+  List<double> get prices =>
+      points.map((point) => point.price).toList(growable: false);
+
+  List<DateTime> get dates =>
+      points.map((point) => point.date).toList(growable: false);
+
+  double get lastPrice => points.last.price;
+
+  DateTime get lastDate => points.last.date;
+
+  DateTime get firstDate => points.first.date;
+
+  /// Dias corridos cobertos pela série, usado para anualizar a tendência.
+  int get spanInDays => lastDate.difference(firstDate).inDays;
+
+  /// Últimos [count] pontos, para o gráfico não desenhar um ano inteiro de
+  /// histórico ao lado de duas semanas de projeção.
+  List<AssetPoint> tail(int count) =>
+      points.length <= count ? points : points.sublist(points.length - count);
+}

--- a/lib/model/asset_series.dart
+++ b/lib/model/asset_series.dart
@@ -1,13 +1,13 @@
 import 'package:cotacao_direta/model/currency.dart';
 
-/// Natureza do ativo analisado. O modelo local é o mesmo para os três: o que
-/// muda é o rótulo mostrado na tela e os limiares de volatilidade usados nos
-/// insights, já que cripto oscila numa ordem de grandeza acima de moeda
-/// fiduciária.
+/// Nature of the analysed asset. The local model treats all three the same
+/// way: what changes is the label shown on screen and the volatility
+/// thresholds used by the insights, since crypto swings an order of magnitude
+/// more than fiat currency.
 enum AssetKind { currency, cryptocurrency, stock }
 
-/// Um ponto da série: o preço do ativo naquele dia, expresso na moeda de
-/// contrapartida.
+/// A single point of the series: the asset price on that day, expressed in the
+/// counter currency.
 class AssetPoint {
   final DateTime date;
   final double price;
@@ -18,22 +18,23 @@ class AssetPoint {
   String toString() => "AssetPoint(${date.toIso8601String()}, $price)";
 }
 
-/// Série temporal de preços pronta para o modelo local.
+/// Price time series ready for the local model.
 ///
-/// O app guarda em [Currency.value] o inverso da cotação — quantas unidades da
-/// moeda valem uma unidade da contrapartida (ver `CurrencyRepository`). Quem
-/// olha o gráfico raciocina no sentido oposto ("quanto custa um dólar"), e é
-/// esse o número que a análise precisa: uma alta do dólar tem que aparecer como
-/// alta, não como queda. Por isso [AssetSeries.fromQuoteHistory] inverte o
-/// valor guardado ao montar a série.
+/// The app stores in [Currency.value] the inverse of the quote — how many
+/// units of the currency one unit of the counter currency is worth (see
+/// `CurrencyRepository`). Whoever looks at the chart thinks the other way
+/// around ("how much does a dollar cost"), and that is the number the analysis
+/// needs: a rise of the dollar has to show up as a rise, not as a drop. Hence
+/// [AssetSeries.fromQuoteHistory] inverts the stored value while building the
+/// series.
 class AssetSeries {
   final String code;
   final AssetKind kind;
 
-  /// Moeda em que os preços estão expressos (a contrapartida das cotações).
+  /// Currency the prices are expressed in (the counterpart of the quotes).
   final String quoteCurrency;
 
-  /// Pontos em ordem cronológica, um por dia, sem repetição de data.
+  /// Points in chronological order, one per day, with no repeated dates.
   final List<AssetPoint> points;
 
   AssetSeries._(this.code, this.kind, this.quoteCurrency, this.points);
@@ -44,9 +45,9 @@ class AssetSeries {
     required String quoteCurrency,
     required List<AssetPoint> points,
   }) {
-    // Um dia repetido (a API às vezes devolve o pregão do dia junto do
-    // fechamento anterior) viraria um retorno zero no meio da série e
-    // rebaixaria a volatilidade estimada. Fica o último ponto de cada dia.
+    // A repeated day (the API sometimes returns today's quote alongside the
+    // previous close) would become a zero return in the middle of the series
+    // and drag the estimated volatility down. The last point of each day wins.
     final byDay = <DateTime, AssetPoint>{};
     for (var point in points) {
       if (!point.price.isFinite || point.price <= 0) continue;
@@ -58,8 +59,8 @@ class AssetSeries {
         List.unmodifiable(ordered.map((entry) => entry.value)));
   }
 
-  /// Monta a série a partir do histórico que o `CurrencyRepository` devolve,
-  /// invertendo cada valor para a convenção de preço descrita na classe.
+  /// Builds the series from the history the `CurrencyRepository` returns,
+  /// inverting each value into the price convention described on the class.
   factory AssetSeries.fromQuoteHistory({
     required String code,
     required AssetKind kind,
@@ -98,11 +99,11 @@ class AssetSeries {
 
   DateTime get firstDate => points.first.date;
 
-  /// Dias corridos cobertos pela série, usado para anualizar a tendência.
+  /// Calendar days covered by the series, used to annualise the trend.
   int get spanInDays => lastDate.difference(firstDate).inDays;
 
-  /// Últimos [count] pontos, para o gráfico não desenhar um ano inteiro de
-  /// histórico ao lado de duas semanas de projeção.
+  /// The last [count] points, so the chart does not draw a whole year of
+  /// history next to two weeks of projection.
   List<AssetPoint> tail(int count) =>
       points.length <= count ? points : points.sublist(points.length - count);
 }

--- a/lib/model/financial_analysis.dart
+++ b/lib/model/financial_analysis.dart
@@ -1,12 +1,12 @@
 import 'package:cotacao_direta/model/asset_series.dart';
 
-/// Um dia projetado pelo modelo local, com a faixa de confiança em volta.
+/// One projected day from the local model, with the confidence band around it.
 class ForecastPoint {
-  /// Quantos dias à frente do último ponto observado, começando em 1.
+  /// How many days ahead of the last observed point, starting at 1.
   final int step;
   final DateTime date;
 
-  /// Preço projetado (o centro da faixa).
+  /// Projected price (the centre of the band).
   final double price;
 
   final double lowerBound;
@@ -20,32 +20,32 @@ class ForecastPoint {
       required this.upperBound});
 }
 
-/// O que o treino da rede revelou sobre a própria confiabilidade. Vai para a
-/// tela porque muda a leitura da projeção: uma rede que não superou o passeio
-/// aleatório está, na prática, repetindo a média.
+/// What training revealed about the network's own reliability. It reaches the
+/// screen because it changes how the projection should be read: a network that
+/// did not beat the random walk is, in practice, repeating the average.
 class ModelDiagnostics {
-  /// Amostras (janelas) montadas a partir do histórico para treinar.
+  /// Samples (windows) built from the history to train on.
   final int trainingSamples;
 
-  /// Erro da rede no trecho de validação.
+  /// The network's error on the validation slice.
   final double? validationError;
 
-  /// Erro, no mesmo trecho, de prever "amanhã igual a hoje" — o passeio
-  /// aleatório, que é o rival honesto de qualquer previsor de preço.
+  /// The error, on that same slice, of predicting "tomorrow equals today" —
+  /// the random walk, which is the fair rival of any price forecaster.
   final double? baselineError;
 
-  /// `1 - erro da rede / erro do passeio aleatório`, limitado a [0, 1]. Zero
-  /// quer dizer que a rede não trouxe informação nenhuma.
+  /// `1 - network error / random walk error`, clamped to [0, 1]. Zero means
+  /// the network added no information at all.
   final double skill;
 
-  /// Peso dado à rede na projeção final; o restante fica com a deriva
-  /// estatística.
+  /// Weight given to the network in the final projection; the remainder goes
+  /// to the statistical drift.
   final double neuralWeight;
 
   final int epochs;
 
-  /// Falso quando o histórico era curto demais para treinar e a projeção saiu
-  /// só da base estatística.
+  /// False when the history was too short to train and the projection came
+  /// from the statistical baseline alone.
   final bool trained;
 
   const ModelDiagnostics(
@@ -68,13 +68,13 @@ class ModelDiagnostics {
           trained: false);
 }
 
-/// Projeção completa de um ativo.
+/// Full projection for an asset.
 class AssetForecast {
   final double lastPrice;
   final List<ForecastPoint> points;
   final ModelDiagnostics diagnostics;
 
-  /// Nível de confiança da faixa (0,8 = 80%).
+  /// Confidence level of the band (0.8 = 80%).
   final double confidenceLevel;
 
   const AssetForecast(
@@ -85,7 +85,7 @@ class AssetForecast {
 
   int get horizonInDays => points.isEmpty ? 0 : points.last.step;
 
-  /// Preço no fim do horizonte projetado.
+  /// Price at the end of the projected horizon.
   double get projectedPrice => points.isEmpty ? lastPrice : points.last.price;
 
   double get projectedLowerBound =>
@@ -94,15 +94,15 @@ class AssetForecast {
   double get projectedUpperBound =>
       points.isEmpty ? lastPrice : points.last.upperBound;
 
-  /// Variação projetada como fração (0,03 = alta de 3%).
+  /// Projected change as a fraction (0.03 = up 3%).
   double get projectedChange =>
       lastPrice <= 0 ? 0 : projectedPrice / lastPrice - 1;
 
-  /// Quanto [amount] investido hoje valeria no fim do horizonte, com a mesma
-  /// faixa de confiança da projeção de preço.
+  /// What [amount] invested today would be worth at the end of the horizon,
+  /// with the same confidence band as the price projection.
   ///
-  /// É uma regra de três sobre a variação projetada — o "manuseio financeiro"
-  /// que a tela oferece por cima do modelo.
+  /// It is a rule of three over the projected change — the "financial
+  /// handling" the screen offers on top of the model.
   AmountProjection projectAmount(double amount) {
     if (lastPrice <= 0 || !amount.isFinite)
       return AmountProjection(
@@ -116,7 +116,8 @@ class AssetForecast {
   }
 }
 
-/// Simulação de um valor aplicado hoje, projetado para o fim do horizonte.
+/// Simulation of an amount invested today, projected to the end of the
+/// horizon.
 class AmountProjection {
   final double initialAmount;
   final double expected;
@@ -132,10 +133,9 @@ class AmountProjection {
   double get expectedProfit => expected - initialAmount;
 }
 
-/// Retrato estatístico da série, mostrado no resumo de mercado e usado pelos
-/// insights. Os campos opcionais ficam nulos quando o histórico é curto demais
-/// para o indicador (o IFR precisa de 15 pontos, a variação de 30 dias precisa
-/// de 31, e assim por diante).
+/// Statistical portrait of the series, shown in the market summary and used by
+/// the insights. Optional fields stay null when the history is too short for
+/// the indicator (RSI needs 15 points, the 30-day change needs 31, and so on).
 class MarketStatistics {
   final double lastPrice;
   final double? weeklyChange;
@@ -147,8 +147,9 @@ class MarketStatistics {
   final double maxDrawdown;
   final double compoundAnnualGrowthRate;
 
-  /// Inclinação da reta ajustada sobre o log dos preços, em log-retorno por
-  /// dia, com o R² do ajuste: quanto da variação a tendência explica.
+  /// Slope of the line fitted over the log of the prices, in log-return per
+  /// day, with the R² of the fit: how much of the variation the trend
+  /// explains.
   final double trendSlopePerDay;
   final double trendRSquared;
 
@@ -168,19 +169,20 @@ class MarketStatistics {
       required this.trendRSquared,
       required this.sampleCount});
 
-  /// Variação do período mais longo disponível, para os insights de tendência.
+  /// Change over the longest period available, for the trend insights.
   double? get referenceChange => monthlyChange ?? weeklyChange;
 
-  /// Média curta acima da longa é o cruzamento clássico de alta.
+  /// A short average above the long one is the classic bullish crossover.
   bool? get shortAboveLong =>
       shortMovingAverage == null || longMovingAverage == null
           ? null
           : shortMovingAverage! > longMovingAverage!;
 }
 
-/// O que a rede acha digno de nota. O texto não vem pronto: o código identifica
-/// o tipo de observação e [arguments] traz os números já formatados no idioma
-/// pedido, que a tela encaixa no modelo de frase traduzido.
+/// What the analysis finds worth pointing out. The text does not come ready
+/// made: the code identifies the kind of remark and [arguments] carries the
+/// numbers already formatted in the requested language, which the screen slots
+/// into the translated sentence template.
 enum InsightCode {
   trendUp,
   trendDown,
@@ -199,7 +201,7 @@ enum InsightCode {
   dataLimited,
 }
 
-/// Tom da observação, para a tela escolher ícone e cor.
+/// Tone of the remark, so the screen can pick an icon and a colour.
 enum InsightSentiment { positive, negative, neutral, caution }
 
 class FinancialInsight {
@@ -216,7 +218,7 @@ class FinancialInsight {
   String toString() => "FinancialInsight($code, $sentiment, $arguments)";
 }
 
-/// Tudo o que a análise local produz para um ativo.
+/// Everything the local analysis produces for one asset.
 class FinancialAnalysis {
   final AssetSeries series;
   final MarketStatistics statistics;

--- a/lib/model/financial_analysis.dart
+++ b/lib/model/financial_analysis.dart
@@ -1,0 +1,235 @@
+import 'package:cotacao_direta/model/asset_series.dart';
+
+/// Um dia projetado pelo modelo local, com a faixa de confiança em volta.
+class ForecastPoint {
+  /// Quantos dias à frente do último ponto observado, começando em 1.
+  final int step;
+  final DateTime date;
+
+  /// Preço projetado (o centro da faixa).
+  final double price;
+
+  final double lowerBound;
+  final double upperBound;
+
+  const ForecastPoint(
+      {required this.step,
+      required this.date,
+      required this.price,
+      required this.lowerBound,
+      required this.upperBound});
+}
+
+/// O que o treino da rede revelou sobre a própria confiabilidade. Vai para a
+/// tela porque muda a leitura da projeção: uma rede que não superou o passeio
+/// aleatório está, na prática, repetindo a média.
+class ModelDiagnostics {
+  /// Amostras (janelas) montadas a partir do histórico para treinar.
+  final int trainingSamples;
+
+  /// Erro da rede no trecho de validação.
+  final double? validationError;
+
+  /// Erro, no mesmo trecho, de prever "amanhã igual a hoje" — o passeio
+  /// aleatório, que é o rival honesto de qualquer previsor de preço.
+  final double? baselineError;
+
+  /// `1 - erro da rede / erro do passeio aleatório`, limitado a [0, 1]. Zero
+  /// quer dizer que a rede não trouxe informação nenhuma.
+  final double skill;
+
+  /// Peso dado à rede na projeção final; o restante fica com a deriva
+  /// estatística.
+  final double neuralWeight;
+
+  final int epochs;
+
+  /// Falso quando o histórico era curto demais para treinar e a projeção saiu
+  /// só da base estatística.
+  final bool trained;
+
+  const ModelDiagnostics(
+      {required this.trainingSamples,
+      required this.validationError,
+      required this.baselineError,
+      required this.skill,
+      required this.neuralWeight,
+      required this.epochs,
+      required this.trained});
+
+  factory ModelDiagnostics.untrained({int trainingSamples = 0}) =>
+      ModelDiagnostics(
+          trainingSamples: trainingSamples,
+          validationError: null,
+          baselineError: null,
+          skill: 0,
+          neuralWeight: 0,
+          epochs: 0,
+          trained: false);
+}
+
+/// Projeção completa de um ativo.
+class AssetForecast {
+  final double lastPrice;
+  final List<ForecastPoint> points;
+  final ModelDiagnostics diagnostics;
+
+  /// Nível de confiança da faixa (0,8 = 80%).
+  final double confidenceLevel;
+
+  const AssetForecast(
+      {required this.lastPrice,
+      required this.points,
+      required this.diagnostics,
+      required this.confidenceLevel});
+
+  int get horizonInDays => points.isEmpty ? 0 : points.last.step;
+
+  /// Preço no fim do horizonte projetado.
+  double get projectedPrice => points.isEmpty ? lastPrice : points.last.price;
+
+  double get projectedLowerBound =>
+      points.isEmpty ? lastPrice : points.last.lowerBound;
+
+  double get projectedUpperBound =>
+      points.isEmpty ? lastPrice : points.last.upperBound;
+
+  /// Variação projetada como fração (0,03 = alta de 3%).
+  double get projectedChange =>
+      lastPrice <= 0 ? 0 : projectedPrice / lastPrice - 1;
+
+  /// Quanto [amount] investido hoje valeria no fim do horizonte, com a mesma
+  /// faixa de confiança da projeção de preço.
+  ///
+  /// É uma regra de três sobre a variação projetada — o "manuseio financeiro"
+  /// que a tela oferece por cima do modelo.
+  AmountProjection projectAmount(double amount) {
+    if (lastPrice <= 0 || !amount.isFinite)
+      return AmountProjection(
+          initialAmount: amount, expected: amount, lower: amount, upper: amount);
+    return AmountProjection(
+      initialAmount: amount,
+      expected: amount * projectedPrice / lastPrice,
+      lower: amount * projectedLowerBound / lastPrice,
+      upper: amount * projectedUpperBound / lastPrice,
+    );
+  }
+}
+
+/// Simulação de um valor aplicado hoje, projetado para o fim do horizonte.
+class AmountProjection {
+  final double initialAmount;
+  final double expected;
+  final double lower;
+  final double upper;
+
+  const AmountProjection(
+      {required this.initialAmount,
+      required this.expected,
+      required this.lower,
+      required this.upper});
+
+  double get expectedProfit => expected - initialAmount;
+}
+
+/// Retrato estatístico da série, mostrado no resumo de mercado e usado pelos
+/// insights. Os campos opcionais ficam nulos quando o histórico é curto demais
+/// para o indicador (o IFR precisa de 15 pontos, a variação de 30 dias precisa
+/// de 31, e assim por diante).
+class MarketStatistics {
+  final double lastPrice;
+  final double? weeklyChange;
+  final double? monthlyChange;
+  final double annualizedVolatility;
+  final double? relativeStrengthIndex;
+  final double? shortMovingAverage;
+  final double? longMovingAverage;
+  final double maxDrawdown;
+  final double compoundAnnualGrowthRate;
+
+  /// Inclinação da reta ajustada sobre o log dos preços, em log-retorno por
+  /// dia, com o R² do ajuste: quanto da variação a tendência explica.
+  final double trendSlopePerDay;
+  final double trendRSquared;
+
+  final int sampleCount;
+
+  const MarketStatistics(
+      {required this.lastPrice,
+      required this.weeklyChange,
+      required this.monthlyChange,
+      required this.annualizedVolatility,
+      required this.relativeStrengthIndex,
+      required this.shortMovingAverage,
+      required this.longMovingAverage,
+      required this.maxDrawdown,
+      required this.compoundAnnualGrowthRate,
+      required this.trendSlopePerDay,
+      required this.trendRSquared,
+      required this.sampleCount});
+
+  /// Variação do período mais longo disponível, para os insights de tendência.
+  double? get referenceChange => monthlyChange ?? weeklyChange;
+
+  /// Média curta acima da longa é o cruzamento clássico de alta.
+  bool? get shortAboveLong =>
+      shortMovingAverage == null || longMovingAverage == null
+          ? null
+          : shortMovingAverage! > longMovingAverage!;
+}
+
+/// O que a rede acha digno de nota. O texto não vem pronto: o código identifica
+/// o tipo de observação e [arguments] traz os números já formatados no idioma
+/// pedido, que a tela encaixa no modelo de frase traduzido.
+enum InsightCode {
+  trendUp,
+  trendDown,
+  trendSideways,
+  momentumOverbought,
+  momentumOversold,
+  momentumNeutral,
+  volatilityHigh,
+  volatilityLow,
+  projectionUp,
+  projectionDown,
+  projectionStable,
+  drawdown,
+  confidenceGood,
+  confidenceLow,
+  dataLimited,
+}
+
+/// Tom da observação, para a tela escolher ícone e cor.
+enum InsightSentiment { positive, negative, neutral, caution }
+
+class FinancialInsight {
+  final InsightCode code;
+  final InsightSentiment sentiment;
+  final List<String> arguments;
+
+  const FinancialInsight(
+      {required this.code,
+      required this.sentiment,
+      this.arguments = const []});
+
+  @override
+  String toString() => "FinancialInsight($code, $sentiment, $arguments)";
+}
+
+/// Tudo o que a análise local produz para um ativo.
+class FinancialAnalysis {
+  final AssetSeries series;
+  final MarketStatistics statistics;
+  final AssetForecast forecast;
+  final List<FinancialInsight> insights;
+
+  const FinancialAnalysis(
+      {required this.series,
+      required this.statistics,
+      required this.forecast,
+      required this.insights});
+
+  String get assetCode => series.code;
+
+  AssetKind get assetKind => series.kind;
+}

--- a/lib/providers/ai_insights_bloc_provider.dart
+++ b/lib/providers/ai_insights_bloc_provider.dart
@@ -1,0 +1,52 @@
+import 'package:cotacao_direta/blocs/ai_insights_bloc.dart';
+import 'package:flutter/material.dart';
+
+/// Cria o [AiInsightsBloc] e o mantém vivo enquanto esta parte da árvore
+/// existir. Um InheritedWidget sozinho não dá conta disso: ele é recriado a cada
+/// rebuild e não tem dispose, então o bloc precisa de um State para acompanhar o
+/// ciclo de vida.
+class AiInsightsBlocProvider extends StatefulWidget {
+  final Widget child;
+
+  /// Bloc pronto, fornecido pelo chamador. Quem cria também descarta: o
+  /// provider só chama dispose no bloc que ele mesmo criou.
+  final AiInsightsBloc? bloc;
+
+  AiInsightsBlocProvider({Key? key, required this.child, this.bloc})
+      : super(key: key);
+
+  @override
+  State<AiInsightsBlocProvider> createState() => _AiInsightsBlocProviderState();
+
+  static AiInsightsBloc of(BuildContext context) {
+    return context
+        .dependOnInheritedWidgetOfExactType<_AiInsightsBlocScope>()!
+        .bloc;
+  }
+}
+
+class _AiInsightsBlocProviderState extends State<AiInsightsBlocProvider> {
+  late final AiInsightsBloc _bloc = widget.bloc ?? AiInsightsBloc();
+  late final bool _ownsBloc = widget.bloc == null;
+
+  @override
+  Widget build(BuildContext context) =>
+      _AiInsightsBlocScope(bloc: _bloc, child: widget.child);
+
+  @override
+  void dispose() {
+    if (_ownsBloc) _bloc.dispose();
+    super.dispose();
+  }
+}
+
+class _AiInsightsBlocScope extends InheritedWidget {
+  final AiInsightsBloc bloc;
+
+  _AiInsightsBlocScope({Key? key, required this.bloc, required Widget child})
+      : super(key: key, child: child);
+
+  @override
+  bool updateShouldNotify(_AiInsightsBlocScope oldWidget) =>
+      bloc != oldWidget.bloc;
+}

--- a/lib/providers/ai_insights_bloc_provider.dart
+++ b/lib/providers/ai_insights_bloc_provider.dart
@@ -1,15 +1,15 @@
 import 'package:cotacao_direta/blocs/ai_insights_bloc.dart';
 import 'package:flutter/material.dart';
 
-/// Cria o [AiInsightsBloc] e o mantém vivo enquanto esta parte da árvore
-/// existir. Um InheritedWidget sozinho não dá conta disso: ele é recriado a cada
-/// rebuild e não tem dispose, então o bloc precisa de um State para acompanhar o
-/// ciclo de vida.
+/// Creates the [AiInsightsBloc] and keeps it alive for as long as this part of
+/// the tree exists. An InheritedWidget alone cannot do that: it is rebuilt on
+/// every rebuild and has no dispose, so the bloc needs a State to follow the
+/// lifecycle.
 class AiInsightsBlocProvider extends StatefulWidget {
   final Widget child;
 
-  /// Bloc pronto, fornecido pelo chamador. Quem cria também descarta: o
-  /// provider só chama dispose no bloc que ele mesmo criou.
+  /// Ready-made bloc supplied by the caller. Whoever creates it also disposes
+  /// of it: the provider only disposes the bloc it created itself.
   final AiInsightsBloc? bloc;
 
   AiInsightsBlocProvider({Key? key, required this.child, this.bloc})

--- a/lib/util/localizations.dart
+++ b/lib/util/localizations.dart
@@ -68,6 +68,73 @@ class MyAppLocalizations {
       'currencyAlertDeleteTooltip': 'Delete',
       'currencyAlertNotificationTitle': 'Exchange rate alert',
       'currencyAlertNotificationBody': '%s reached %s',
+      'aiInsightsBottomNavItemLabel': 'AI',
+      'aiInsightsSectionLabel': 'On-device AI insights',
+      'aiInsightsDescription': 'A small neural network is trained on this '
+          'device, over the quotes the app already downloaded, to summarise the '
+          'market and project the coming days. No data leaves your phone.',
+      'aiInsightsAssetLabel': 'Asset',
+      'aiInsightsHorizonLabel': 'Projection horizon',
+      'aiInsightsHorizonOptionLabel': '%s days',
+      'aiInsightsAmountLabel': 'Amount to simulate (optional)',
+      'aiInsightsAnalyzeBtnLabel': 'Analyse on device',
+      'aiInsightsRunningLabel': 'Training the local model…',
+      'aiInsightsEmptyLabel': 'Choose an asset and run the analysis.',
+      'aiInsightsNoDataError': 'No quotes found for this asset.',
+      'aiInsightsInsufficientDataError':
+          'Not enough history to analyse this asset.',
+      'aiInsightsFailureError': 'The analysis could not be completed.',
+      'aiInsightsSummarySectionLabel': 'Market summary',
+      'aiInsightsProjectionSectionLabel': 'Projection',
+      'aiInsightsInsightsSectionLabel': 'Insights',
+      'aiInsightsModelSectionLabel': 'Local model',
+      'aiInsightsLastPriceLabel': 'Latest quote',
+      'aiInsightsWeeklyChangeLabel': '7-day change',
+      'aiInsightsMonthlyChangeLabel': '30-day change',
+      'aiInsightsVolatilityLabel': 'Annualised volatility',
+      'aiInsightsRsiLabel': 'Momentum (RSI 14)',
+      'aiInsightsDrawdownLabel': 'Largest drop',
+      'aiInsightsTrendLabel': 'Annualised trend',
+      'aiInsightsTrendFitLabel': 'Trend fit (R²)',
+      'aiInsightsProjectedPriceLabel': 'Projected quote in %s days',
+      'aiInsightsProjectedChangeLabel': 'Projected change',
+      'aiInsightsConfidenceBandLabel': 'Range at %s confidence',
+      'aiInsightsAmountProjectionLabel': 'Simulated amount',
+      'aiInsightsAmountProjectionHint': '%s invested today',
+      'aiInsightsModelSamplesLabel': 'Training windows',
+      'aiInsightsModelSkillLabel': 'Edge over random walk',
+      'aiInsightsModelEpochsLabel': 'Epochs',
+      'aiInsightsModelUntrainedLabel':
+          'Short history: the projection uses the statistical baseline only.',
+      'aiInsightsDisclaimerLabel': 'Estimates calculated on your device from '
+          'past quotes. Not investment advice.',
+      'aiInsightsChartHistoryLabel': 'History',
+      'aiInsightsChartProjectionLabel': 'Projection',
+      'aiInsightTrendUp': 'Uptrend: %s over the last %s days.',
+      'aiInsightTrendDown': 'Downtrend: %s over the last %s days.',
+      'aiInsightTrendSideways': 'No clear trend: %s over the last %s days.',
+      'aiInsightMomentumOverbought':
+          'Stretched momentum: RSI at %s, in overbought territory.',
+      'aiInsightMomentumOversold':
+          'Pressured momentum: RSI at %s, in oversold territory.',
+      'aiInsightMomentumNeutral': 'Balanced momentum: RSI at %s.',
+      'aiInsightVolatilityHigh':
+          'High volatility: %s a year, so the projection carries a wide range.',
+      'aiInsightVolatilityLow': 'Low volatility: %s a year.',
+      'aiInsightProjectionUp':
+          'The model projects a %s rise in %s days, to %s.',
+      'aiInsightProjectionDown':
+          'The model projects a %s drop in %s days, to %s.',
+      'aiInsightProjectionStable':
+          'The model projects stability over %s days, around %s.',
+      'aiInsightDrawdown':
+          'The asset fell %s from its peak in the analysed period.',
+      'aiInsightConfidenceGood':
+          'The network beat the random walk by %s in validation.',
+      'aiInsightConfidenceLow': 'The network did not beat the random walk on '
+          'this history, so the projection follows the statistical baseline.',
+      'aiInsightDataLimited': 'Short history (%s windows): the projection uses '
+          'the statistical baseline only.',
     },
     'pt': {
       'conversionButtonLabel': "Conversões",
@@ -126,6 +193,73 @@ class MyAppLocalizations {
       'currencyAlertDeleteTooltip': 'Excluir',
       'currencyAlertNotificationTitle': 'Alerta de câmbio',
       'currencyAlertNotificationBody': '%s atingiu %s',
+      'aiInsightsBottomNavItemLabel': 'IA',
+      'aiInsightsSectionLabel': 'Insights com IA no aparelho',
+      'aiInsightsDescription': 'Uma rede neural pequena é treinada neste '
+          'aparelho, sobre as cotações que o app já baixou, para resumir o '
+          'mercado e projetar os próximos dias. Nenhum dado sai do seu celular.',
+      'aiInsightsAssetLabel': 'Ativo',
+      'aiInsightsHorizonLabel': 'Horizonte da projeção',
+      'aiInsightsHorizonOptionLabel': '%s dias',
+      'aiInsightsAmountLabel': 'Valor para simular (opcional)',
+      'aiInsightsAnalyzeBtnLabel': 'Analisar no aparelho',
+      'aiInsightsRunningLabel': 'Treinando o modelo local…',
+      'aiInsightsEmptyLabel': 'Escolha um ativo e rode a análise.',
+      'aiInsightsNoDataError': 'Nenhuma cotação encontrada para este ativo.',
+      'aiInsightsInsufficientDataError':
+          'Histórico insuficiente para analisar este ativo.',
+      'aiInsightsFailureError': 'Não foi possível concluir a análise.',
+      'aiInsightsSummarySectionLabel': 'Resumo do mercado',
+      'aiInsightsProjectionSectionLabel': 'Projeção',
+      'aiInsightsInsightsSectionLabel': 'Insights',
+      'aiInsightsModelSectionLabel': 'Modelo local',
+      'aiInsightsLastPriceLabel': 'Cotação atual',
+      'aiInsightsWeeklyChangeLabel': 'Variação em 7 dias',
+      'aiInsightsMonthlyChangeLabel': 'Variação em 30 dias',
+      'aiInsightsVolatilityLabel': 'Volatilidade anualizada',
+      'aiInsightsRsiLabel': 'Momento (IFR 14)',
+      'aiInsightsDrawdownLabel': 'Maior queda',
+      'aiInsightsTrendLabel': 'Tendência anualizada',
+      'aiInsightsTrendFitLabel': 'Aderência da tendência (R²)',
+      'aiInsightsProjectedPriceLabel': 'Cotação projetada em %s dias',
+      'aiInsightsProjectedChangeLabel': 'Variação projetada',
+      'aiInsightsConfidenceBandLabel': 'Faixa com %s de confiança',
+      'aiInsightsAmountProjectionLabel': 'Valor simulado',
+      'aiInsightsAmountProjectionHint': '%s aplicados hoje',
+      'aiInsightsModelSamplesLabel': 'Janelas de treino',
+      'aiInsightsModelSkillLabel': 'Vantagem sobre o passeio aleatório',
+      'aiInsightsModelEpochsLabel': 'Épocas',
+      'aiInsightsModelUntrainedLabel':
+          'Histórico curto: a projeção usa apenas a base estatística.',
+      'aiInsightsDisclaimerLabel': 'Estimativas calculadas no seu aparelho a '
+          'partir de cotações passadas. Não é recomendação de investimento.',
+      'aiInsightsChartHistoryLabel': 'Histórico',
+      'aiInsightsChartProjectionLabel': 'Projeção',
+      'aiInsightTrendUp': 'Tendência de alta: %s nos últimos %s dias.',
+      'aiInsightTrendDown': 'Tendência de baixa: %s nos últimos %s dias.',
+      'aiInsightTrendSideways':
+          'Sem tendência definida: %s nos últimos %s dias.',
+      'aiInsightMomentumOverbought':
+          'Momento esticado: IFR em %s, na faixa de sobrecompra.',
+      'aiInsightMomentumOversold':
+          'Momento pressionado: IFR em %s, na faixa de sobrevenda.',
+      'aiInsightMomentumNeutral': 'Momento equilibrado: IFR em %s.',
+      'aiInsightVolatilityHigh':
+          'Volatilidade alta: %s ao ano, então a projeção tem faixa larga.',
+      'aiInsightVolatilityLow': 'Volatilidade baixa: %s ao ano.',
+      'aiInsightProjectionUp':
+          'O modelo projeta alta de %s em %s dias, para %s.',
+      'aiInsightProjectionDown':
+          'O modelo projeta queda de %s em %s dias, para %s.',
+      'aiInsightProjectionStable':
+          'O modelo projeta estabilidade em %s dias, em torno de %s.',
+      'aiInsightDrawdown': 'O ativo caiu %s do topo no período analisado.',
+      'aiInsightConfidenceGood':
+          'A rede superou o passeio aleatório em %s na validação.',
+      'aiInsightConfidenceLow': 'A rede não superou o passeio aleatório neste '
+          'histórico, então a projeção segue a base estatística.',
+      'aiInsightDataLimited': 'Histórico curto (%s janelas): a projeção usa '
+          'apenas a base estatística.',
     }
   };
 
@@ -362,6 +496,229 @@ class MyAppLocalizations {
   String? get currencyAlertNotificationBody {
     return _localizedValues[locale.languageCode]!
         ['currencyAlertNotificationBody'];
+  }
+
+  String? get aiInsightsBottomNavItemLabel {
+    return _localizedValues[locale.languageCode]!
+        ['aiInsightsBottomNavItemLabel'];
+  }
+
+  String? get aiInsightsSectionLabel {
+    return _localizedValues[locale.languageCode]!['aiInsightsSectionLabel'];
+  }
+
+  String? get aiInsightsDescription {
+    return _localizedValues[locale.languageCode]!['aiInsightsDescription'];
+  }
+
+  String? get aiInsightsAssetLabel {
+    return _localizedValues[locale.languageCode]!['aiInsightsAssetLabel'];
+  }
+
+  String? get aiInsightsHorizonLabel {
+    return _localizedValues[locale.languageCode]!['aiInsightsHorizonLabel'];
+  }
+
+  String? get aiInsightsHorizonOptionLabel {
+    return _localizedValues[locale.languageCode]!
+        ['aiInsightsHorizonOptionLabel'];
+  }
+
+  String? get aiInsightsAmountLabel {
+    return _localizedValues[locale.languageCode]!['aiInsightsAmountLabel'];
+  }
+
+  String? get aiInsightsAnalyzeBtnLabel {
+    return _localizedValues[locale.languageCode]!['aiInsightsAnalyzeBtnLabel'];
+  }
+
+  String? get aiInsightsRunningLabel {
+    return _localizedValues[locale.languageCode]!['aiInsightsRunningLabel'];
+  }
+
+  String? get aiInsightsEmptyLabel {
+    return _localizedValues[locale.languageCode]!['aiInsightsEmptyLabel'];
+  }
+
+  String? get aiInsightsNoDataError {
+    return _localizedValues[locale.languageCode]!['aiInsightsNoDataError'];
+  }
+
+  String? get aiInsightsInsufficientDataError {
+    return _localizedValues[locale.languageCode]!
+        ['aiInsightsInsufficientDataError'];
+  }
+
+  String? get aiInsightsFailureError {
+    return _localizedValues[locale.languageCode]!['aiInsightsFailureError'];
+  }
+
+  String? get aiInsightsSummarySectionLabel {
+    return _localizedValues[locale.languageCode]!
+        ['aiInsightsSummarySectionLabel'];
+  }
+
+  String? get aiInsightsProjectionSectionLabel {
+    return _localizedValues[locale.languageCode]!
+        ['aiInsightsProjectionSectionLabel'];
+  }
+
+  String? get aiInsightsInsightsSectionLabel {
+    return _localizedValues[locale.languageCode]!
+        ['aiInsightsInsightsSectionLabel'];
+  }
+
+  String? get aiInsightsModelSectionLabel {
+    return _localizedValues[locale.languageCode]!['aiInsightsModelSectionLabel'];
+  }
+
+  String? get aiInsightsLastPriceLabel {
+    return _localizedValues[locale.languageCode]!['aiInsightsLastPriceLabel'];
+  }
+
+  String? get aiInsightsWeeklyChangeLabel {
+    return _localizedValues[locale.languageCode]!['aiInsightsWeeklyChangeLabel'];
+  }
+
+  String? get aiInsightsMonthlyChangeLabel {
+    return _localizedValues[locale.languageCode]!
+        ['aiInsightsMonthlyChangeLabel'];
+  }
+
+  String? get aiInsightsVolatilityLabel {
+    return _localizedValues[locale.languageCode]!['aiInsightsVolatilityLabel'];
+  }
+
+  String? get aiInsightsRsiLabel {
+    return _localizedValues[locale.languageCode]!['aiInsightsRsiLabel'];
+  }
+
+  String? get aiInsightsDrawdownLabel {
+    return _localizedValues[locale.languageCode]!['aiInsightsDrawdownLabel'];
+  }
+
+  String? get aiInsightsTrendLabel {
+    return _localizedValues[locale.languageCode]!['aiInsightsTrendLabel'];
+  }
+
+  String? get aiInsightsTrendFitLabel {
+    return _localizedValues[locale.languageCode]!['aiInsightsTrendFitLabel'];
+  }
+
+  String? get aiInsightsProjectedPriceLabel {
+    return _localizedValues[locale.languageCode]!
+        ['aiInsightsProjectedPriceLabel'];
+  }
+
+  String? get aiInsightsProjectedChangeLabel {
+    return _localizedValues[locale.languageCode]!
+        ['aiInsightsProjectedChangeLabel'];
+  }
+
+  String? get aiInsightsConfidenceBandLabel {
+    return _localizedValues[locale.languageCode]!
+        ['aiInsightsConfidenceBandLabel'];
+  }
+
+  String? get aiInsightsAmountProjectionLabel {
+    return _localizedValues[locale.languageCode]!
+        ['aiInsightsAmountProjectionLabel'];
+  }
+
+  String? get aiInsightsAmountProjectionHint {
+    return _localizedValues[locale.languageCode]!
+        ['aiInsightsAmountProjectionHint'];
+  }
+
+  String? get aiInsightsModelSamplesLabel {
+    return _localizedValues[locale.languageCode]!['aiInsightsModelSamplesLabel'];
+  }
+
+  String? get aiInsightsModelSkillLabel {
+    return _localizedValues[locale.languageCode]!['aiInsightsModelSkillLabel'];
+  }
+
+  String? get aiInsightsModelEpochsLabel {
+    return _localizedValues[locale.languageCode]!['aiInsightsModelEpochsLabel'];
+  }
+
+  String? get aiInsightsModelUntrainedLabel {
+    return _localizedValues[locale.languageCode]!
+        ['aiInsightsModelUntrainedLabel'];
+  }
+
+  String? get aiInsightsDisclaimerLabel {
+    return _localizedValues[locale.languageCode]!['aiInsightsDisclaimerLabel'];
+  }
+
+  String? get aiInsightsChartHistoryLabel {
+    return _localizedValues[locale.languageCode]!['aiInsightsChartHistoryLabel'];
+  }
+
+  String? get aiInsightsChartProjectionLabel {
+    return _localizedValues[locale.languageCode]!
+        ['aiInsightsChartProjectionLabel'];
+  }
+
+  String? get aiInsightTrendUp {
+    return _localizedValues[locale.languageCode]!['aiInsightTrendUp'];
+  }
+
+  String? get aiInsightTrendDown {
+    return _localizedValues[locale.languageCode]!['aiInsightTrendDown'];
+  }
+
+  String? get aiInsightTrendSideways {
+    return _localizedValues[locale.languageCode]!['aiInsightTrendSideways'];
+  }
+
+  String? get aiInsightMomentumOverbought {
+    return _localizedValues[locale.languageCode]!
+        ['aiInsightMomentumOverbought'];
+  }
+
+  String? get aiInsightMomentumOversold {
+    return _localizedValues[locale.languageCode]!['aiInsightMomentumOversold'];
+  }
+
+  String? get aiInsightMomentumNeutral {
+    return _localizedValues[locale.languageCode]!['aiInsightMomentumNeutral'];
+  }
+
+  String? get aiInsightVolatilityHigh {
+    return _localizedValues[locale.languageCode]!['aiInsightVolatilityHigh'];
+  }
+
+  String? get aiInsightVolatilityLow {
+    return _localizedValues[locale.languageCode]!['aiInsightVolatilityLow'];
+  }
+
+  String? get aiInsightProjectionUp {
+    return _localizedValues[locale.languageCode]!['aiInsightProjectionUp'];
+  }
+
+  String? get aiInsightProjectionDown {
+    return _localizedValues[locale.languageCode]!['aiInsightProjectionDown'];
+  }
+
+  String? get aiInsightProjectionStable {
+    return _localizedValues[locale.languageCode]!['aiInsightProjectionStable'];
+  }
+
+  String? get aiInsightDrawdown {
+    return _localizedValues[locale.languageCode]!['aiInsightDrawdown'];
+  }
+
+  String? get aiInsightConfidenceGood {
+    return _localizedValues[locale.languageCode]!['aiInsightConfidenceGood'];
+  }
+
+  String? get aiInsightConfidenceLow {
+    return _localizedValues[locale.languageCode]!['aiInsightConfidenceLow'];
+  }
+
+  String? get aiInsightDataLimited {
+    return _localizedValues[locale.languageCode]!['aiInsightDataLimited'];
   }
 }
 

--- a/lib/view/pages/home.dart
+++ b/lib/view/pages/home.dart
@@ -1,6 +1,7 @@
 import 'package:cotacao_direta/blocs/currency_alerts_bloc.dart';
 import 'package:cotacao_direta/blocs/home_bloc.dart';
 import 'package:cotacao_direta/notifications/update_currency_value_notification.dart';
+import 'package:cotacao_direta/providers/ai_insights_bloc_provider.dart';
 import 'package:cotacao_direta/providers/configurations_page_bloc_provider.dart';
 import 'package:cotacao_direta/providers/conversion_page_bloc_provider.dart';
 import 'package:cotacao_direta/providers/currency_alerts_bloc_provider.dart';
@@ -11,6 +12,7 @@ import 'package:cotacao_direta/util/localizations.dart';
 import 'package:cotacao_direta/util/responsive.dart';
 import 'package:cotacao_direta/view/pages/conversion_page.dart';
 import 'package:cotacao_direta/view/pages/main_menu_items/about_page.dart';
+import 'package:cotacao_direta/view/pages/main_menu_items/ai_insights_page.dart';
 import 'package:cotacao_direta/view/pages/main_menu_items/configurations_page.dart';
 import 'package:cotacao_direta/view/pages/main_menu_items/currency_alerts_page.dart';
 import 'package:cotacao_direta/view/widgets/canadian_dollar_exchange_rate.dart';
@@ -364,6 +366,9 @@ class HomeState extends State<Home> with SingleTickerProviderStateMixin {
       ),
       Container(child: CurrencyAlertsPage()),
       Container(
+        child: AiInsightsBlocProvider(child: AiInsightsPage()),
+      ),
+      Container(
         child: ConfigurationsPageBlocProvider(child: ConfigurationsPage()),
       ),
       Container(child: AboutPage()),
@@ -384,6 +389,10 @@ class HomeState extends State<Home> with SingleTickerProviderStateMixin {
           BottomNavigationBarItem(
             icon: Icon(Icons.notifications),
             label: _localization.currencyAlertsBottomNavItemLabel,
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.auto_awesome),
+            label: _localization.aiInsightsBottomNavItemLabel,
           ),
           BottomNavigationBarItem(
             icon: Icon(Icons.settings),

--- a/lib/view/pages/main_menu_items/ai_insights_page.dart
+++ b/lib/view/pages/main_menu_items/ai_insights_page.dart
@@ -1,0 +1,597 @@
+import 'package:cotacao_direta/blocs/ai_insights_bloc.dart';
+import 'package:cotacao_direta/enums/cryptocurrency_enum.dart';
+import 'package:cotacao_direta/enums/currency_enum.dart';
+import 'package:cotacao_direta/model/asset_series.dart';
+import 'package:cotacao_direta/model/financial_analysis.dart';
+import 'package:cotacao_direta/providers/ai_insights_bloc_provider.dart';
+import 'package:cotacao_direta/util/cryptocurrency_info.dart';
+import 'package:cotacao_direta/util/localizations.dart';
+import 'package:cotacao_direta/util/quote_format.dart';
+import 'package:cotacao_direta/util/responsive.dart';
+import 'package:cotacao_direta/util/string_utils.dart';
+import 'package:cotacao_direta/view/widgets/ai_insight_text.dart';
+import 'package:cotacao_direta/view/widgets/forecast_chart.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:sprintf/sprintf.dart';
+
+/// Um ativo oferecido na lista da tela.
+class _AssetOption {
+  final String code;
+  final AssetKind kind;
+  final String name;
+
+  const _AssetOption({required this.code, required this.kind, required this.name});
+
+  // O DropdownButtonFormField compara o valor selecionado com os itens da lista
+  // por igualdade, e a lista é remontada a cada build.
+  @override
+  bool operator ==(Object other) =>
+      other is _AssetOption && other.code == code && other.kind == kind;
+
+  @override
+  int get hashCode => Object.hash(code, kind);
+}
+
+/// Tela de insights gerados pelo modelo de IA que roda no próprio aparelho.
+///
+/// O fluxo é: escolher o ativo e o horizonte, tocar em analisar, e a tela mostra
+/// o resumo de mercado, a projeção com faixa de confiança, o gráfico e as
+/// observações em texto. Nenhuma dessas contas sai do celular.
+class AiInsightsPage extends StatefulWidget {
+  AiInsightsPage({Key? key}) : super(key: key);
+
+  @override
+  State<AiInsightsPage> createState() => _AiInsightsPageState();
+}
+
+class _AiInsightsPageState extends State<AiInsightsPage> {
+  static String _codeOf(Object enumValue) =>
+      EnumValueAsString().getEnumValue(enumValue.toString());
+
+  List<_AssetOption> _assetOptions(String counterCurrency) => [
+        // A moeda de contrapartida não tem série própria: cotada contra ela
+        // mesma valeria sempre 1, e o repositório pula a consulta.
+        ...Currencies.values
+            .where((currency) => _codeOf(currency) != counterCurrency)
+            .map((currency) => _AssetOption(
+                code: _codeOf(currency),
+                kind: AssetKind.currency,
+                name: _codeOf(currency))),
+        ...Cryptocurrencies.values.map((cryptocurrency) => _AssetOption(
+            code: _codeOf(cryptocurrency),
+            kind: AssetKind.cryptocurrency,
+            name: cryptocurrencyName(cryptocurrency))),
+      ];
+
+  @override
+  Widget build(BuildContext context) {
+    final bloc = AiInsightsBlocProvider.of(context);
+    final localizations = MyAppLocalizations.of(context)!;
+    final scale = Responsive.scaleFactor(context);
+    final contentWidth = Responsive.contentMaxWidth(context);
+
+    return FutureBuilder<String>(
+      future: bloc.counterCurrencyCode,
+      builder: (context, snapshot) {
+        if (!snapshot.hasData) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        final options = _assetOptions(snapshot.data!);
+        final selected = options.firstWhere(
+          (option) =>
+              option.code == bloc.selectedAssetCode &&
+              option.kind == bloc.selectedAssetKind,
+          orElse: () => options.first,
+        );
+        // A moeda de contrapartida pode ter mudado nas opções e deixado o ativo
+        // selecionado fora da lista.
+        if (selected.code != bloc.selectedAssetCode)
+          bloc.selectAsset(selected.code, selected.kind);
+
+        return Center(
+          child: ConstrainedBox(
+            constraints: BoxConstraints(maxWidth: contentWidth),
+            child: ListView(
+              padding: EdgeInsets.all(16 * scale),
+              children: [
+                _header(context, localizations, scale),
+                SizedBox(height: 16 * scale),
+                _assetField(context, bloc, localizations, options, selected),
+                SizedBox(height: 16 * scale),
+                _horizonField(context, bloc, localizations, scale),
+                SizedBox(height: 16 * scale),
+                _amountField(bloc, localizations),
+                SizedBox(height: 16 * scale),
+                _analyzeButton(bloc, localizations),
+                SizedBox(height: 8 * scale),
+                StreamBuilder<AiInsightsState>(
+                  stream: bloc.stateStream,
+                  initialData: bloc.currentState,
+                  builder: (context, stateSnapshot) => _result(
+                    context,
+                    bloc,
+                    localizations,
+                    stateSnapshot.data ?? const AiInsightsState.idle(),
+                    scale,
+                  ),
+                ),
+                SizedBox(height: 24 * scale),
+                Text(
+                  localizations.aiInsightsDisclaimerLabel!,
+                  style: TextStyle(
+                    fontSize: 11 * scale,
+                    color: Theme.of(context).colorScheme.outline,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _header(BuildContext context, MyAppLocalizations localizations,
+      double scale) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Icon(Icons.auto_awesome,
+                size: 20 * scale, color: Theme.of(context).colorScheme.primary),
+            SizedBox(width: 8 * scale),
+            Expanded(
+              child: Text(
+                localizations.aiInsightsSectionLabel!,
+                style: TextStyle(
+                  fontSize: 16 * scale,
+                  fontWeight: FontWeight.bold,
+                  color: Theme.of(context).colorScheme.primary,
+                ),
+              ),
+            ),
+          ],
+        ),
+        SizedBox(height: 8 * scale),
+        Text(
+          localizations.aiInsightsDescription!,
+          style: TextStyle(
+            fontSize: 13 * scale,
+            color: Theme.of(context).colorScheme.onSurfaceVariant,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _assetField(
+    BuildContext context,
+    AiInsightsBloc bloc,
+    MyAppLocalizations localizations,
+    List<_AssetOption> options,
+    _AssetOption selected,
+  ) {
+    return DropdownButtonFormField<_AssetOption>(
+      initialValue: selected,
+      isExpanded: true,
+      decoration: InputDecoration(
+        border: const OutlineInputBorder(),
+        labelText: localizations.aiInsightsAssetLabel,
+      ),
+      items: options
+          .map((option) => DropdownMenuItem<_AssetOption>(
+                value: option,
+                child: Text(option.code == option.name
+                    ? option.code
+                    : "${option.code} — ${option.name}"),
+              ))
+          .toList(),
+      onChanged: (option) {
+        if (option == null) return;
+        setState(() => bloc.selectAsset(option.code, option.kind));
+      },
+    );
+  }
+
+  Widget _horizonField(BuildContext context, AiInsightsBloc bloc,
+      MyAppLocalizations localizations, double scale) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          localizations.aiInsightsHorizonLabel!,
+          style: TextStyle(fontSize: 13 * scale),
+        ),
+        SizedBox(height: 8 * scale),
+        SegmentedButton<int>(
+          segments: AiInsightsBloc.horizonOptions
+              .map((days) => ButtonSegment<int>(
+                    value: days,
+                    label: Text(sprintf(
+                        localizations.aiInsightsHorizonOptionLabel!, ["$days"])),
+                  ))
+              .toList(),
+          selected: {bloc.horizonInDays},
+          showSelectedIcon: false,
+          onSelectionChanged: (selection) =>
+              setState(() => bloc.selectHorizon(selection.first)),
+        ),
+      ],
+    );
+  }
+
+  Widget _amountField(AiInsightsBloc bloc, MyAppLocalizations localizations) {
+    return TextField(
+      controller: bloc.amountController,
+      keyboardType: const TextInputType.numberWithOptions(decimal: true),
+      decoration: InputDecoration(
+        border: const OutlineInputBorder(),
+        labelText: localizations.aiInsightsAmountLabel,
+        prefixIcon: const Icon(Icons.savings_outlined),
+      ),
+      // O valor simulado é uma regra de três sobre a projeção já calculada:
+      // basta redesenhar, sem treinar de novo.
+      onChanged: (_) => setState(() {}),
+    );
+  }
+
+  Widget _analyzeButton(AiInsightsBloc bloc, MyAppLocalizations localizations) {
+    return StreamBuilder<AiInsightsState>(
+      stream: bloc.stateStream,
+      initialData: bloc.currentState,
+      builder: (context, snapshot) {
+        final loading = snapshot.data?.loading == true;
+        return FilledButton.icon(
+          onPressed: loading
+              ? null
+              : () => bloc.analyze(
+                  languageCode: localizations.locale.languageCode),
+          icon: const Icon(Icons.psychology_alt),
+          label: Text(localizations.aiInsightsAnalyzeBtnLabel!),
+        );
+      },
+    );
+  }
+
+  Widget _result(
+    BuildContext context,
+    AiInsightsBloc bloc,
+    MyAppLocalizations localizations,
+    AiInsightsState state,
+    double scale,
+  ) {
+    if (state.loading) {
+      return Padding(
+        padding: EdgeInsets.symmetric(vertical: 32 * scale),
+        child: Column(
+          children: [
+            const CircularProgressIndicator(),
+            SizedBox(height: 12 * scale),
+            Text(localizations.aiInsightsRunningLabel!),
+          ],
+        ),
+      );
+    }
+
+    final error = state.error;
+    if (error != null) {
+      return _message(
+        context,
+        Icons.error_outline,
+        switch (error) {
+          AiInsightsError.noData => localizations.aiInsightsNoDataError!,
+          AiInsightsError.insufficientData =>
+            localizations.aiInsightsInsufficientDataError!,
+          AiInsightsError.failure => localizations.aiInsightsFailureError!,
+        },
+        scale,
+      );
+    }
+
+    final analysis = state.analysis;
+    if (analysis == null) {
+      return _message(context, Icons.auto_graph,
+          localizations.aiInsightsEmptyLabel!, scale);
+    }
+
+    final formatter = _NumberFormatter(localizations.locale.languageCode);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        SizedBox(height: 16 * scale),
+        _sectionTitle(context, localizations.aiInsightsSummarySectionLabel!,
+            scale),
+        _summary(context, localizations, analysis, formatter, scale),
+        SizedBox(height: 16 * scale),
+        _sectionTitle(context, localizations.aiInsightsProjectionSectionLabel!,
+            scale),
+        _projection(context, bloc, localizations, analysis, formatter, scale),
+        SizedBox(height: 16 * scale),
+        SizedBox(
+          height: 220 * scale,
+          child: Padding(
+            padding: EdgeInsets.only(right: 8 * scale, top: 8 * scale),
+            child: ForecastChart(
+              // Um trimestre de histórico já dá contexto para a projeção sem
+              // espremer as duas semanas que interessam.
+              history: analysis.series.tail(60),
+              forecast: analysis.forecast.points,
+            ),
+          ),
+        ),
+        SizedBox(height: 8 * scale),
+        _chartLegend(context, localizations, scale),
+        SizedBox(height: 16 * scale),
+        _sectionTitle(
+            context, localizations.aiInsightsInsightsSectionLabel!, scale),
+        ...analysis.insights.map(
+            (insight) => _insightTile(context, localizations, insight, scale)),
+        SizedBox(height: 16 * scale),
+        _sectionTitle(context, localizations.aiInsightsModelSectionLabel!, scale),
+        _diagnostics(context, localizations, analysis.forecast.diagnostics,
+            formatter, scale),
+      ],
+    );
+  }
+
+  Widget _message(
+      BuildContext context, IconData icon, String text, double scale) {
+    return Padding(
+      padding: EdgeInsets.symmetric(vertical: 32 * scale),
+      child: Column(
+        children: [
+          Icon(icon,
+              size: 40 * scale, color: Theme.of(context).colorScheme.outline),
+          SizedBox(height: 12 * scale),
+          Text(
+            text,
+            textAlign: TextAlign.center,
+            style: TextStyle(color: Theme.of(context).colorScheme.outline),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _sectionTitle(BuildContext context, String label, double scale) {
+    return Padding(
+      padding: EdgeInsets.only(bottom: 8 * scale),
+      child: Text(
+        label,
+        style: TextStyle(
+          fontSize: 14 * scale,
+          fontWeight: FontWeight.bold,
+          color: Theme.of(context).colorScheme.primary,
+        ),
+      ),
+    );
+  }
+
+  Widget _summary(
+    BuildContext context,
+    MyAppLocalizations localizations,
+    FinancialAnalysis analysis,
+    _NumberFormatter formatter,
+    double scale,
+  ) {
+    final statistics = analysis.statistics;
+    final quoteCurrency = analysis.series.quoteCurrency;
+    return _metricCard(context, scale, [
+      _metric(context, localizations.aiInsightsLastPriceLabel!,
+          "${formatter.price(statistics.lastPrice)} $quoteCurrency", scale),
+      if (statistics.weeklyChange != null)
+        _metric(context, localizations.aiInsightsWeeklyChangeLabel!,
+            formatter.signedPercent(statistics.weeklyChange!), scale),
+      if (statistics.monthlyChange != null)
+        _metric(context, localizations.aiInsightsMonthlyChangeLabel!,
+            formatter.signedPercent(statistics.monthlyChange!), scale),
+      _metric(context, localizations.aiInsightsVolatilityLabel!,
+          formatter.percent(statistics.annualizedVolatility), scale),
+      if (statistics.relativeStrengthIndex != null)
+        _metric(context, localizations.aiInsightsRsiLabel!,
+            formatter.decimal(statistics.relativeStrengthIndex!, digits: 0),
+            scale),
+      _metric(context, localizations.aiInsightsDrawdownLabel!,
+          formatter.percent(statistics.maxDrawdown), scale),
+      _metric(context, localizations.aiInsightsTrendLabel!,
+          formatter.signedPercent(statistics.compoundAnnualGrowthRate), scale),
+      _metric(context, localizations.aiInsightsTrendFitLabel!,
+          formatter.decimal(statistics.trendRSquared, digits: 2), scale),
+    ]);
+  }
+
+  Widget _projection(
+    BuildContext context,
+    AiInsightsBloc bloc,
+    MyAppLocalizations localizations,
+    FinancialAnalysis analysis,
+    _NumberFormatter formatter,
+    double scale,
+  ) {
+    final forecast = analysis.forecast;
+    final quoteCurrency = analysis.series.quoteCurrency;
+    final amount = bloc.simulationAmount;
+    return _metricCard(context, scale, [
+      _metric(
+          context,
+          sprintf(localizations.aiInsightsProjectedPriceLabel!,
+              ["${forecast.horizonInDays}"]),
+          "${formatter.price(forecast.projectedPrice)} $quoteCurrency",
+          scale),
+      _metric(context, localizations.aiInsightsProjectedChangeLabel!,
+          formatter.signedPercent(forecast.projectedChange), scale),
+      _metric(
+          context,
+          sprintf(localizations.aiInsightsConfidenceBandLabel!,
+              [formatter.percent(forecast.confidenceLevel, digits: 0)]),
+          "${formatter.price(forecast.projectedLowerBound)} – "
+              "${formatter.price(forecast.projectedUpperBound)}",
+          scale),
+      if (amount != null)
+        _metric(
+          context,
+          localizations.aiInsightsAmountProjectionLabel!,
+          "${formatter.money(forecast.projectAmount(amount).expected)} "
+              "$quoteCurrency",
+          scale,
+          hint: sprintf(localizations.aiInsightsAmountProjectionHint!,
+              ["${formatter.money(amount)} $quoteCurrency"]),
+        ),
+    ]);
+  }
+
+  Widget _metricCard(BuildContext context, double scale, List<Widget> metrics) {
+    return Card(
+      margin: EdgeInsets.zero,
+      child: Padding(
+        padding: EdgeInsets.all(12 * scale),
+        child: Wrap(
+          spacing: 24 * scale,
+          runSpacing: 12 * scale,
+          children: metrics,
+        ),
+      ),
+    );
+  }
+
+  Widget _metric(
+      BuildContext context, String label, String value, double scale,
+      {String? hint}) {
+    return SizedBox(
+      width: 150 * scale,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            label,
+            style: TextStyle(
+              fontSize: 11 * scale,
+              color: Theme.of(context).colorScheme.outline,
+            ),
+          ),
+          SizedBox(height: 2 * scale),
+          Text(
+            value,
+            style: TextStyle(
+                fontSize: 15 * scale, fontWeight: FontWeight.w600),
+          ),
+          if (hint != null)
+            Text(
+              hint,
+              style: TextStyle(
+                fontSize: 10 * scale,
+                color: Theme.of(context).colorScheme.outline,
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _chartLegend(
+      BuildContext context, MyAppLocalizations localizations, double scale) {
+    final colorScheme = Theme.of(context).colorScheme;
+    Widget entry(Color color, String label) => Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(width: 16 * scale, height: 3, color: color),
+            SizedBox(width: 6 * scale),
+            Text(label, style: TextStyle(fontSize: 11 * scale)),
+          ],
+        );
+    return Wrap(
+      spacing: 16 * scale,
+      alignment: WrapAlignment.center,
+      children: [
+        entry(colorScheme.primary, localizations.aiInsightsChartHistoryLabel!),
+        entry(colorScheme.tertiary,
+            localizations.aiInsightsChartProjectionLabel!),
+      ],
+    );
+  }
+
+  Widget _insightTile(BuildContext context, MyAppLocalizations localizations,
+      FinancialInsight insight, double scale) {
+    return Padding(
+      padding: EdgeInsets.symmetric(vertical: 4 * scale),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(
+            insightIcon(insight.sentiment),
+            size: 18 * scale,
+            color: insightColor(context, insight.sentiment),
+          ),
+          SizedBox(width: 8 * scale),
+          Expanded(
+            child: Text(
+              insightText(localizations, insight),
+              style: TextStyle(fontSize: 13 * scale),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _diagnostics(
+    BuildContext context,
+    MyAppLocalizations localizations,
+    ModelDiagnostics diagnostics,
+    _NumberFormatter formatter,
+    double scale,
+  ) {
+    if (!diagnostics.trained) {
+      return Text(
+        localizations.aiInsightsModelUntrainedLabel!,
+        style: TextStyle(
+          fontSize: 12 * scale,
+          color: Theme.of(context).colorScheme.outline,
+        ),
+      );
+    }
+    return _metricCard(context, scale, [
+      _metric(context, localizations.aiInsightsModelSamplesLabel!,
+          "${diagnostics.trainingSamples}", scale),
+      _metric(context, localizations.aiInsightsModelSkillLabel!,
+          formatter.percent(diagnostics.skill), scale),
+      _metric(context, localizations.aiInsightsModelEpochsLabel!,
+          "${diagnostics.epochs}", scale),
+    ]);
+  }
+}
+
+/// Formatação dos números da tela no idioma corrente.
+class _NumberFormatter {
+  final String languageCode;
+
+  const _NumberFormatter(this.languageCode);
+
+  String decimal(double value, {int digits = 2}) =>
+      NumberFormat.decimalPatternDigits(
+              locale: languageCode, decimalDigits: digits)
+          .format(value);
+
+  String percent(double fraction, {int digits = 1}) =>
+      NumberFormat.decimalPercentPattern(
+              locale: languageCode, decimalDigits: digits)
+          .format(fraction);
+
+  /// Percentual com sinal explícito: numa variação, "+1,2%" e "-1,2%" se
+  /// distinguem à primeira vista, e o "+" não aparece sozinho por engano no
+  /// zero.
+  String signedPercent(double fraction, {int digits = 1}) {
+    final formatted = percent(fraction, digits: digits);
+    return fraction > 0 ? "+$formatted" : formatted;
+  }
+
+  /// Cotação, com casas decimais conforme a ordem de grandeza (cripto em real
+  /// tem preço na casa dos milhares; alguns pares, na casa dos centésimos).
+  String price(double value) => decimal(value,
+      digits: quoteDecimalDigits(value, minimumDigits: 2, significantDigits: 4));
+
+  /// Valor monetário simulado: duas casas bastam, é dinheiro.
+  String money(double value) => decimal(value, digits: 2);
+}

--- a/lib/view/pages/main_menu_items/ai_insights_page.dart
+++ b/lib/view/pages/main_menu_items/ai_insights_page.dart
@@ -15,7 +15,7 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:sprintf/sprintf.dart';
 
-/// Um ativo oferecido na lista da tela.
+/// An asset offered in the screen's list.
 class _AssetOption {
   final String code;
   final AssetKind kind;
@@ -23,8 +23,8 @@ class _AssetOption {
 
   const _AssetOption({required this.code, required this.kind, required this.name});
 
-  // O DropdownButtonFormField compara o valor selecionado com os itens da lista
-  // por igualdade, e a lista é remontada a cada build.
+  // DropdownButtonFormField compares the selected value against the list items
+  // by equality, and the list is rebuilt on every build.
   @override
   bool operator ==(Object other) =>
       other is _AssetOption && other.code == code && other.kind == kind;
@@ -33,11 +33,13 @@ class _AssetOption {
   int get hashCode => Object.hash(code, kind);
 }
 
-/// Tela de insights gerados pelo modelo de IA que roda no próprio aparelho.
+/// Screen for the insights produced by the AI model that runs on the device
+/// itself.
 ///
-/// O fluxo é: escolher o ativo e o horizonte, tocar em analisar, e a tela mostra
-/// o resumo de mercado, a projeção com faixa de confiança, o gráfico e as
-/// observações em texto. Nenhuma dessas contas sai do celular.
+/// The flow is: pick the asset and the horizon, tap analyse, and the screen
+/// shows the market summary, the projection with its confidence band, the
+/// chart and the remarks in text form. None of these computations leave the
+/// phone.
 class AiInsightsPage extends StatefulWidget {
   AiInsightsPage({Key? key}) : super(key: key);
 
@@ -50,8 +52,8 @@ class _AiInsightsPageState extends State<AiInsightsPage> {
       EnumValueAsString().getEnumValue(enumValue.toString());
 
   List<_AssetOption> _assetOptions(String counterCurrency) => [
-        // A moeda de contrapartida não tem série própria: cotada contra ela
-        // mesma valeria sempre 1, e o repositório pula a consulta.
+        // The counter currency has no series of its own: quoted against
+        // itself it would always be 1, and the repository skips the query.
         ...Currencies.values
             .where((currency) => _codeOf(currency) != counterCurrency)
             .map((currency) => _AssetOption(
@@ -84,8 +86,8 @@ class _AiInsightsPageState extends State<AiInsightsPage> {
               option.kind == bloc.selectedAssetKind,
           orElse: () => options.first,
         );
-        // A moeda de contrapartida pode ter mudado nas opções e deixado o ativo
-        // selecionado fora da lista.
+        // The counter currency may have changed in the settings, leaving the
+        // selected asset out of the list.
         if (selected.code != bloc.selectedAssetCode)
           bloc.selectAsset(selected.code, selected.kind);
 
@@ -231,8 +233,8 @@ class _AiInsightsPageState extends State<AiInsightsPage> {
         labelText: localizations.aiInsightsAmountLabel,
         prefixIcon: const Icon(Icons.savings_outlined),
       ),
-      // O valor simulado é uma regra de três sobre a projeção já calculada:
-      // basta redesenhar, sem treinar de novo.
+      // The simulated amount is a rule of three over the projection already
+      // computed: it is enough to redraw, with no retraining.
       onChanged: (_) => setState(() {}),
     );
   }
@@ -314,8 +316,8 @@ class _AiInsightsPageState extends State<AiInsightsPage> {
           child: Padding(
             padding: EdgeInsets.only(right: 8 * scale, top: 8 * scale),
             child: ForecastChart(
-              // Um trimestre de histórico já dá contexto para a projeção sem
-              // espremer as duas semanas que interessam.
+              // A quarter of history gives the projection enough context
+              // without squeezing the two weeks that matter.
               history: analysis.series.tail(60),
               forecast: analysis.forecast.points,
             ),
@@ -563,7 +565,7 @@ class _AiInsightsPageState extends State<AiInsightsPage> {
   }
 }
 
-/// Formatação dos números da tela no idioma corrente.
+/// Formatting of the screen's numbers in the current language.
 class _NumberFormatter {
   final String languageCode;
 
@@ -579,19 +581,19 @@ class _NumberFormatter {
               locale: languageCode, decimalDigits: digits)
           .format(fraction);
 
-  /// Percentual com sinal explícito: numa variação, "+1,2%" e "-1,2%" se
-  /// distinguem à primeira vista, e o "+" não aparece sozinho por engano no
+  /// Percentage with an explicit sign: on a change, "+1.2%" and "-1.2%" are
+  /// told apart at a glance, and the "+" does not show up by mistake on
   /// zero.
   String signedPercent(double fraction, {int digits = 1}) {
     final formatted = percent(fraction, digits: digits);
     return fraction > 0 ? "+$formatted" : formatted;
   }
 
-  /// Cotação, com casas decimais conforme a ordem de grandeza (cripto em real
-  /// tem preço na casa dos milhares; alguns pares, na casa dos centésimos).
+  /// Quote, with decimal places following the order of magnitude (crypto in
+  /// reais runs in the thousands; some pairs, in the hundredths).
   String price(double value) => decimal(value,
       digits: quoteDecimalDigits(value, minimumDigits: 2, significantDigits: 4));
 
-  /// Valor monetário simulado: duas casas bastam, é dinheiro.
+  /// Simulated monetary amount: two places are enough, it is money.
   String money(double value) => decimal(value, digits: 2);
 }

--- a/lib/view/widgets/ai_insight_text.dart
+++ b/lib/view/widgets/ai_insight_text.dart
@@ -1,0 +1,57 @@
+import 'package:cotacao_direta/model/financial_analysis.dart';
+import 'package:cotacao_direta/util/localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:sprintf/sprintf.dart';
+
+/// Ponte entre o motor de insights, que é Dart puro, e a tela.
+///
+/// O motor decide *o que* dizer ([InsightCode]) e com que tom
+/// ([InsightSentiment]), e já formata os números no idioma pedido; aqui o código
+/// vira a frase traduzida, o ícone e a cor.
+
+/// Frase traduzida do insight, com os números encaixados nos marcadores.
+String insightText(MyAppLocalizations localizations, FinancialInsight insight) {
+  final template = switch (insight.code) {
+    InsightCode.trendUp => localizations.aiInsightTrendUp,
+    InsightCode.trendDown => localizations.aiInsightTrendDown,
+    InsightCode.trendSideways => localizations.aiInsightTrendSideways,
+    InsightCode.momentumOverbought => localizations.aiInsightMomentumOverbought,
+    InsightCode.momentumOversold => localizations.aiInsightMomentumOversold,
+    InsightCode.momentumNeutral => localizations.aiInsightMomentumNeutral,
+    InsightCode.volatilityHigh => localizations.aiInsightVolatilityHigh,
+    InsightCode.volatilityLow => localizations.aiInsightVolatilityLow,
+    InsightCode.projectionUp => localizations.aiInsightProjectionUp,
+    InsightCode.projectionDown => localizations.aiInsightProjectionDown,
+    InsightCode.projectionStable => localizations.aiInsightProjectionStable,
+    InsightCode.drawdown => localizations.aiInsightDrawdown,
+    InsightCode.confidenceGood => localizations.aiInsightConfidenceGood,
+    InsightCode.confidenceLow => localizations.aiInsightConfidenceLow,
+    InsightCode.dataLimited => localizations.aiInsightDataLimited,
+  }!;
+  return insight.arguments.isEmpty
+      ? template
+      : sprintf(template, insight.arguments);
+}
+
+IconData insightIcon(InsightSentiment sentiment) => switch (sentiment) {
+      InsightSentiment.positive => Icons.trending_up,
+      InsightSentiment.negative => Icons.trending_down,
+      InsightSentiment.caution => Icons.warning_amber_rounded,
+      InsightSentiment.neutral => Icons.remove,
+    };
+
+/// Cor do ícone do insight. Alta e baixa não saem do esquema de cores do tema:
+/// verde e vermelho vêm de tons fixos, ajustados ao brilho do tema para
+/// continuarem legíveis no modo escuro.
+Color insightColor(BuildContext context, InsightSentiment sentiment) {
+  final colorScheme = Theme.of(context).colorScheme;
+  final isDark = Theme.of(context).brightness == Brightness.dark;
+  return switch (sentiment) {
+    InsightSentiment.positive =>
+      isDark ? Colors.green.shade300 : Colors.green.shade700,
+    InsightSentiment.negative => colorScheme.error,
+    InsightSentiment.caution =>
+      isDark ? Colors.amber.shade300 : Colors.amber.shade800,
+    InsightSentiment.neutral => colorScheme.outline,
+  };
+}

--- a/lib/view/widgets/ai_insight_text.dart
+++ b/lib/view/widgets/ai_insight_text.dart
@@ -3,13 +3,15 @@ import 'package:cotacao_direta/util/localizations.dart';
 import 'package:flutter/material.dart';
 import 'package:sprintf/sprintf.dart';
 
-/// Ponte entre o motor de insights, que é Dart puro, e a tela.
+/// Bridge between the insight engine, which is pure Dart, and the screen.
 ///
-/// O motor decide *o que* dizer ([InsightCode]) e com que tom
-/// ([InsightSentiment]), e já formata os números no idioma pedido; aqui o código
-/// vira a frase traduzida, o ícone e a cor.
+/// The engine decides *what* to say ([InsightCode]) and in what tone
+/// ([InsightSentiment]), and already formats the numbers in the requested
+/// language; here the code becomes the translated sentence, the icon and the
+/// colour.
 
-/// Frase traduzida do insight, com os números encaixados nos marcadores.
+/// Translated sentence for the insight, with the numbers slotted into the
+/// placeholders.
 String insightText(MyAppLocalizations localizations, FinancialInsight insight) {
   final template = switch (insight.code) {
     InsightCode.trendUp => localizations.aiInsightTrendUp,
@@ -40,9 +42,9 @@ IconData insightIcon(InsightSentiment sentiment) => switch (sentiment) {
       InsightSentiment.neutral => Icons.remove,
     };
 
-/// Cor do ícone do insight. Alta e baixa não saem do esquema de cores do tema:
-/// verde e vermelho vêm de tons fixos, ajustados ao brilho do tema para
-/// continuarem legíveis no modo escuro.
+/// Colour of the insight icon. Rises and falls do not come out of the theme's
+/// colour scheme: green and red come from fixed shades, adjusted to the theme
+/// brightness so they stay readable in dark mode.
 Color insightColor(BuildContext context, InsightSentiment sentiment) {
   final colorScheme = Theme.of(context).colorScheme;
   final isDark = Theme.of(context).brightness == Brightness.dark;

--- a/lib/view/widgets/forecast_chart.dart
+++ b/lib/view/widgets/forecast_chart.dart
@@ -5,12 +5,12 @@ import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
-/// Histórico recente e projeção do modelo local no mesmo gráfico: a linha cheia
-/// é o que aconteceu, a tracejada é o que o modelo espera, e a faixa em volta
-/// dela é o intervalo de confiança.
+/// Recent history and the local model's projection on the same chart: the
+/// solid line is what happened, the dashed one is what the model expects, and
+/// the band around it is the confidence interval.
 ///
-/// A projeção começa no último ponto observado (e não no dia seguinte) para as
-/// duas linhas se encontrarem, em vez de a tracejada nascer solta no ar.
+/// The projection starts at the last observed point (rather than the next day)
+/// so the two lines meet, instead of the dashed one starting out of thin air.
 class ForecastChart extends StatelessWidget {
   final List<AssetPoint> history;
   final List<ForecastPoint> forecast;
@@ -54,9 +54,9 @@ class ForecastChart extends StatelessWidget {
           (point) => FlSpot(joinIndex + point.step, point.upperBound)),
     ];
 
-    // Mesma lógica de casas decimais do gráfico de histórico: a ordem de
-    // grandeza da série decide a precisão, senão cotação de cripto vira "0,00"
-    // no eixo.
+    // Same decimal-places logic as the history chart: the order of magnitude
+    // of the series decides the precision, otherwise a crypto quote turns into
+    // "0.00" on the axis.
     final peakValue = [...historySpots, ...upperSpots].fold<double>(
         0, (peak, spot) => spot.y.abs() > peak ? spot.y.abs() : peak);
     final axisDigits = quoteDecimalDigits(peakValue);
@@ -89,7 +89,7 @@ class ForecastChart extends StatelessWidget {
             }).toList(),
           ),
         ),
-        // Marca onde o observado termina e a projeção começa.
+        // Marks where the observed data ends and the projection begins.
         extraLinesData: ExtraLinesData(verticalLines: [
           VerticalLine(
             x: joinIndex,
@@ -159,7 +159,7 @@ class ForecastChart extends StatelessWidget {
             dotData: const FlDotData(show: false),
           ),
         ],
-        // Preenche o intervalo de confiança entre as duas linhas da faixa.
+        // Fills the confidence interval between the two band lines.
         betweenBarsData: [
           BetweenBarsData(
             fromIndex: 1,

--- a/lib/view/widgets/forecast_chart.dart
+++ b/lib/view/widgets/forecast_chart.dart
@@ -1,0 +1,173 @@
+import 'package:cotacao_direta/model/asset_series.dart';
+import 'package:cotacao_direta/model/financial_analysis.dart';
+import 'package:cotacao_direta/util/quote_format.dart';
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+/// Histórico recente e projeção do modelo local no mesmo gráfico: a linha cheia
+/// é o que aconteceu, a tracejada é o que o modelo espera, e a faixa em volta
+/// dela é o intervalo de confiança.
+///
+/// A projeção começa no último ponto observado (e não no dia seguinte) para as
+/// duas linhas se encontrarem, em vez de a tracejada nascer solta no ar.
+class ForecastChart extends StatelessWidget {
+  final List<AssetPoint> history;
+  final List<ForecastPoint> forecast;
+
+  ForecastChart({Key? key, required this.history, required this.forecast})
+      : super(key: key);
+
+  final DateFormat _axisDateFormatter = DateFormat("dd/MM");
+
+  @override
+  Widget build(BuildContext context) {
+    if (history.isEmpty) return const SizedBox.shrink();
+
+    final colorScheme = Theme.of(context).colorScheme;
+    final historyColor = colorScheme.primary;
+    final forecastColor = colorScheme.tertiary;
+
+    final dates = [
+      ...history.map((point) => point.date),
+      ...forecast.map((point) => point.date),
+    ];
+    final joinIndex = (history.length - 1).toDouble();
+
+    final historySpots = List.generate(history.length,
+        (index) => FlSpot(index.toDouble(), history[index].price));
+
+    final lastPrice = history.last.price;
+    final forecastSpots = [
+      FlSpot(joinIndex, lastPrice),
+      ...forecast.map(
+          (point) => FlSpot(joinIndex + point.step, point.price)),
+    ];
+    final lowerSpots = [
+      FlSpot(joinIndex, lastPrice),
+      ...forecast.map(
+          (point) => FlSpot(joinIndex + point.step, point.lowerBound)),
+    ];
+    final upperSpots = [
+      FlSpot(joinIndex, lastPrice),
+      ...forecast.map(
+          (point) => FlSpot(joinIndex + point.step, point.upperBound)),
+    ];
+
+    // Mesma lógica de casas decimais do gráfico de histórico: a ordem de
+    // grandeza da série decide a precisão, senão cotação de cripto vira "0,00"
+    // no eixo.
+    final peakValue = [...historySpots, ...upperSpots].fold<double>(
+        0, (peak, spot) => spot.y.abs() > peak ? spot.y.abs() : peak);
+    final axisDigits = quoteDecimalDigits(peakValue);
+    final leftAxisWidth =
+        (peakValue.toStringAsFixed(axisDigits).length * 6.5 + 12)
+            .clamp(48.0, 110.0);
+
+    LineChartBarData bandLine(List<FlSpot> spots) => LineChartBarData(
+          spots: spots,
+          isCurved: false,
+          color: forecastColor.withValues(alpha: 0.35),
+          barWidth: 1,
+          dotData: const FlDotData(show: false),
+        );
+
+    return LineChart(
+      LineChartData(
+        minX: 0,
+        maxX: (dates.length - 1).toDouble(),
+        lineTouchData: LineTouchData(
+          touchTooltipData: LineTouchTooltipData(
+            getTooltipItems: (touchedSpots) => touchedSpots.map((spot) {
+              final index = spot.x.round();
+              final date = dates[index.clamp(0, dates.length - 1)];
+              return LineTooltipItem(
+                "${_axisDateFormatter.format(date)}\n"
+                "${spot.y.toStringAsFixed(quoteDecimalDigits(peakValue, minimumDigits: 4, significantDigits: 4))}",
+                TextStyle(color: colorScheme.onInverseSurface),
+              );
+            }).toList(),
+          ),
+        ),
+        // Marca onde o observado termina e a projeção começa.
+        extraLinesData: ExtraLinesData(verticalLines: [
+          VerticalLine(
+            x: joinIndex,
+            color: colorScheme.outline.withValues(alpha: 0.6),
+            strokeWidth: 1,
+            dashArray: const [4, 4],
+          ),
+        ]),
+        titlesData: FlTitlesData(
+          topTitles: const AxisTitles(
+            sideTitles: SideTitles(showTitles: false),
+          ),
+          rightTitles: const AxisTitles(
+            sideTitles: SideTitles(showTitles: false),
+          ),
+          bottomTitles: AxisTitles(
+            sideTitles: SideTitles(
+              showTitles: true,
+              reservedSize: 28,
+              interval: dates.length > 1 ? (dates.length - 1) / 4 : 1,
+              getTitlesWidget: (value, meta) {
+                final index = value.round();
+                if (index < 0 || index >= dates.length) {
+                  return const SizedBox.shrink();
+                }
+                return Padding(
+                  padding: const EdgeInsets.only(top: 8.0),
+                  child: Text(
+                    _axisDateFormatter.format(dates[index]),
+                    style: const TextStyle(fontSize: 10),
+                  ),
+                );
+              },
+            ),
+          ),
+          leftTitles: AxisTitles(
+            sideTitles: SideTitles(
+              showTitles: true,
+              reservedSize: leftAxisWidth,
+              getTitlesWidget: (value, meta) => Text(
+                value.toStringAsFixed(axisDigits),
+                style: const TextStyle(fontSize: 10),
+              ),
+            ),
+          ),
+        ),
+        gridData: const FlGridData(show: true),
+        borderData: FlBorderData(show: true),
+        lineBarsData: [
+          LineChartBarData(
+            spots: historySpots,
+            isCurved: true,
+            color: historyColor,
+            barWidth: 2,
+            dotData: const FlDotData(show: false),
+            belowBarData:
+                BarAreaData(show: true, color: historyColor.withValues(alpha: 0.12)),
+          ),
+          bandLine(lowerSpots),
+          bandLine(upperSpots),
+          LineChartBarData(
+            spots: forecastSpots,
+            isCurved: false,
+            color: forecastColor,
+            barWidth: 2,
+            dashArray: const [6, 4],
+            dotData: const FlDotData(show: false),
+          ),
+        ],
+        // Preenche o intervalo de confiança entre as duas linhas da faixa.
+        betweenBarsData: [
+          BetweenBarsData(
+            fromIndex: 1,
+            toIndex: 2,
+            color: forecastColor.withValues(alpha: 0.15),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/test/ai/financial_ai_service_test.dart
+++ b/test/ai/financial_ai_service_test.dart
@@ -1,0 +1,175 @@
+import 'package:cotacao_direta/ai/financial_ai_service.dart';
+import 'package:cotacao_direta/ai/local_financial_model.dart';
+import 'package:cotacao_direta/model/asset_series.dart';
+import 'package:cotacao_direta/model/financial_analysis.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../helpers/series_test_helper.dart';
+
+void main() {
+  final service = FinancialAiService();
+
+  group('FinancialAiService.computeStatistics', () {
+    test('mede as variações de 7 e 30 dias', () {
+      // 40 preços subindo 1% ao dia, de forma exata.
+      final prices = List<double>.generate(
+          40, (index) => 100 * _power(1.01, index));
+
+      final statistics =
+          service.computeStatistics(seriesFromPrices(prices));
+
+      expect(statistics.weeklyChange, closeTo(_power(1.01, 7) - 1, 1e-9));
+      expect(statistics.monthlyChange, closeTo(_power(1.01, 30) - 1, 1e-9));
+      expect(statistics.lastPrice, prices.last);
+      expect(statistics.sampleCount, 40);
+    });
+
+    test('série que só sobe não tem queda a reportar', () {
+      final prices = List<double>.generate(40, (index) => 100.0 + index);
+
+      final statistics = service.computeStatistics(seriesFromPrices(prices));
+
+      expect(statistics.maxDrawdown, 0);
+      expect(statistics.relativeStrengthIndex, 100);
+    });
+
+    test('crescimento exponencial constante tem R² perto de 1', () {
+      final prices =
+          List<double>.generate(60, (index) => 10 * _power(1.005, index));
+
+      final statistics = service.computeStatistics(seriesFromPrices(prices));
+
+      expect(statistics.trendRSquared, closeTo(1, 1e-6));
+      expect(statistics.trendSlopePerDay, greaterThan(0));
+      expect(statistics.compoundAnnualGrowthRate, greaterThan(0));
+    });
+
+    test('série sem variação é plana em todos os indicadores', () {
+      final statistics =
+          service.computeStatistics(seriesFromPrices(List.filled(60, 4.0)));
+
+      expect(statistics.annualizedVolatility, 0);
+      expect(statistics.maxDrawdown, 0);
+      expect(statistics.weeklyChange, 0);
+      expect(statistics.relativeStrengthIndex, 50);
+      expect(statistics.compoundAnnualGrowthRate, closeTo(0, 1e-12));
+    });
+
+    test('cripto é anualizada com 365 dias, e não com 252 pregões', () {
+      final prices = syntheticPrices(length: 90);
+
+      final moeda = service.computeStatistics(seriesFromPrices(prices));
+      final cripto = service.computeStatistics(seriesFromPrices(prices,
+          code: "BTC", kind: AssetKind.cryptocurrency));
+
+      expect(cripto.annualizedVolatility,
+          greaterThan(moeda.annualizedVolatility));
+    });
+
+    test('as médias móveis exigem histórico suficiente', () {
+      final curta = service.computeStatistics(
+          seriesFromPrices(syntheticPrices(length: 10)));
+
+      expect(curta.shortMovingAverage, isNotNull);
+      expect(curta.longMovingAverage, isNull);
+      expect(curta.monthlyChange, isNull);
+    });
+
+    test('recusa série vazia', () {
+      final vazia = AssetSeries(
+          code: "USD",
+          kind: AssetKind.currency,
+          quoteCurrency: "BRL",
+          points: []);
+
+      expect(() => service.computeStatistics(vazia), throwsArgumentError);
+    });
+  });
+
+  group('FinancialAiService.analyze', () {
+    test('devolve estatísticas, projeção e observações juntas', () {
+      final series = seriesFromPrices(syntheticPrices(length: 150));
+
+      final analysis = service.analyze(series, horizonInDays: 15);
+
+      expect(analysis.assetCode, "USD");
+      expect(analysis.assetKind, AssetKind.currency);
+      expect(analysis.statistics.sampleCount, 150);
+      expect(analysis.forecast.points.length, 15);
+      expect(analysis.insights, isNotEmpty);
+    });
+
+    test('o idioma pedido formata os números das observações', () {
+      final series = seriesFromPrices(
+          syntheticPrices(length: 150, dailyDrift: 0.004, noise: 0.002));
+
+      final portugues = service.analyze(series, languageCode: "pt");
+      final ingles = service.analyze(series, languageCode: "en");
+
+      expect(
+          portugues.insights
+              .expand((insight) => insight.arguments)
+              .any((argument) => argument.contains(",")),
+          isTrue);
+      expect(
+          ingles.insights
+              .expand((insight) => insight.arguments)
+              .any((argument) => argument.contains(",")),
+          isFalse);
+    });
+
+    test('recusa série curta demais para os indicadores', () {
+      final series = seriesFromPrices(syntheticPrices(length: 5));
+
+      expect(() => service.analyze(series), throwsArgumentError);
+    });
+
+    test('aceita um modelo configurado pelo chamador', () {
+      final service = FinancialAiService(
+          model: LocalFinancialModel(confidenceLevel: 0.95, seed: 99));
+      final series = seriesFromPrices(syntheticPrices(length: 120));
+
+      final analysis = service.analyze(series, horizonInDays: 7);
+
+      expect(analysis.forecast.confidenceLevel, 0.95);
+      expect(analysis.forecast.points.length, 7);
+    });
+
+    test('a análise inteira é reprodutível', () {
+      final series = seriesFromPrices(syntheticPrices(length: 150));
+
+      final first = service.analyze(series);
+      final second = service.analyze(series);
+
+      expect(first.forecast.projectedPrice, second.forecast.projectedPrice);
+      expect(first.insights.map((insight) => insight.code),
+          second.insights.map((insight) => insight.code));
+    });
+
+    test('série de cripto é analisada como cripto', () {
+      final series = seriesFromPrices(syntheticPrices(length: 150),
+          code: "BTC", kind: AssetKind.cryptocurrency, quoteCurrency: "BRL");
+
+      final analysis = service.analyze(series);
+
+      expect(analysis.assetKind, AssetKind.cryptocurrency);
+      expect(analysis.series.quoteCurrency, "BRL");
+    });
+
+    test('o insight de projeção concorda com o número projetado', () {
+      final series = seriesFromPrices(
+          syntheticPrices(length: 150, dailyDrift: 0.004, noise: 0.002));
+
+      final analysis = service.analyze(series, horizonInDays: 15);
+
+      expect(analysis.forecast.projectedChange, greaterThan(0));
+      expect(analysis.insights.first.code, InsightCode.projectionUp);
+    });
+  });
+}
+
+double _power(double base, int exponent) {
+  var result = 1.0;
+  for (var index = 0; index < exponent; index++) result *= base;
+  return result;
+}

--- a/test/ai/indicators_test.dart
+++ b/test/ai/indicators_test.dart
@@ -1,0 +1,166 @@
+import 'dart:math';
+
+import 'package:cotacao_direta/ai/math/indicators.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('simpleMovingAverage', () {
+    test('usa apenas os últimos pontos do período', () {
+      expect(simpleMovingAverage([1, 2, 3, 10, 20, 30], 3), 20);
+    });
+
+    test('série mais curta que o período não tem média', () {
+      expect(simpleMovingAverage([1, 2], 3), isNull);
+    });
+
+    test('recusa período não positivo', () {
+      expect(() => simpleMovingAverage([1, 2], 0), throwsArgumentError);
+    });
+  });
+
+  group('exponentialMovingAverage', () {
+    test('série constante devolve o próprio valor', () {
+      expect(exponentialMovingAverage([4, 4, 4, 4, 4], 3), closeTo(4, 1e-12));
+    });
+
+    test('reage mais rápido que a média simples numa virada', () {
+      final prices = [1.0, 1.0, 1.0, 1.0, 5.0];
+
+      expect(exponentialMovingAverage(prices, 4)!,
+          greaterThan(simpleMovingAverage(prices, 4)!));
+    });
+
+    test('série mais curta que o período não tem média', () {
+      expect(exponentialMovingAverage([1, 2], 5), isNull);
+    });
+  });
+
+  group('relativeStrengthIndex', () {
+    test('série sempre em alta satura em 100', () {
+      final prices = List<double>.generate(30, (index) => 10.0 + index);
+
+      expect(relativeStrengthIndex(prices), 100);
+    });
+
+    test('série sempre em baixa fica perto de zero', () {
+      final prices = List<double>.generate(30, (index) => 50.0 - index);
+
+      expect(relativeStrengthIndex(prices), closeTo(0, 1e-9));
+    });
+
+    test('série constante fica no meio da escala', () {
+      final prices = List<double>.filled(30, 7);
+
+      expect(relativeStrengthIndex(prices), 50);
+    });
+
+    test('alternância simétrica fica em torno de 50', () {
+      final prices = List<double>.generate(
+          40, (index) => index.isEven ? 10.0 : 11.0);
+
+      expect(relativeStrengthIndex(prices), closeTo(50, 5));
+    });
+
+    test('precisa de mais preços que o período', () {
+      expect(relativeStrengthIndex([1, 2, 3], period: 14), isNull);
+      expect(relativeStrengthIndex([1, 2, 3, 4], period: 3), isNotNull);
+    });
+  });
+
+  group('maxDrawdown', () {
+    test('mede a queda do topo até o vale seguinte', () {
+      expect(maxDrawdown([100, 120, 60, 90]), closeTo(0.5, 1e-12));
+    });
+
+    test('série que só sobe não tem queda', () {
+      expect(maxDrawdown([1, 2, 3, 4]), 0);
+    });
+
+    test('ignora a recuperação posterior ao vale', () {
+      expect(maxDrawdown([100, 50, 200]), closeTo(0.5, 1e-12));
+    });
+
+    test('série vazia devolve zero', () {
+      expect(maxDrawdown([]), 0);
+    });
+  });
+
+  group('annualizedVolatility', () {
+    test('multiplica o desvio diário pela raiz do número de pregões', () {
+      final returns = [0.01, -0.01, 0.01, -0.01];
+      final expected = 0.011547005383792515 * sqrt(252);
+
+      expect(annualizedVolatility(returns), closeTo(expected, 1e-6));
+    });
+
+    test('série sem variação tem volatilidade zero', () {
+      expect(annualizedVolatility([0, 0, 0]), 0);
+    });
+
+    test('cripto usa o ano de 365 dias', () {
+      final returns = [0.02, -0.02, 0.02, -0.02];
+
+      expect(annualizedVolatility(returns, periodsPerYear: 365),
+          greaterThan(annualizedVolatility(returns)));
+    });
+
+    test('menos de dois retornos não define volatilidade', () {
+      expect(annualizedVolatility([0.01]), 0);
+    });
+  });
+
+  group('momentum', () {
+    test('devolve a variação percentual do período', () {
+      expect(momentum([10, 11, 12, 20], 3), closeTo(1.0, 1e-12));
+    });
+
+    test('é negativo quando o preço cai', () {
+      expect(momentum([10, 9, 8], 2), closeTo(-0.2, 1e-12));
+    });
+
+    test('precisa de mais pontos que o período', () {
+      expect(momentum([10, 11], 5), isNull);
+    });
+  });
+
+  group('compoundAnnualGrowthRate', () {
+    test('dobrar em um ano é 100% ao ano', () {
+      expect(
+          compoundAnnualGrowthRate(
+              initialPrice: 100, finalPrice: 200, spanInDays: 365),
+          closeTo(1.0, 1e-9));
+    });
+
+    test('dobrar em dois anos rende bem menos que 100% ao ano', () {
+      expect(
+          compoundAnnualGrowthRate(
+              initialPrice: 100, finalPrice: 200, spanInDays: 730),
+          closeTo(sqrt(2) - 1, 1e-9));
+    });
+
+    test('sem intervalo de tempo devolve zero', () {
+      expect(
+          compoundAnnualGrowthRate(
+              initialPrice: 100, finalPrice: 200, spanInDays: 0),
+          0);
+    });
+  });
+
+  group('bollingerZScore', () {
+    test('preço na média tem z igual a zero', () {
+      expect(bollingerZScore([1, 3, 1, 3, 2], 5), closeTo(0, 1e-12));
+    });
+
+    test('preço acima da média tem z positivo', () {
+      expect(bollingerZScore([1, 1, 1, 1, 5], 5)!, greaterThan(0));
+    });
+
+    test('janela sem variação devolve zero', () {
+      expect(bollingerZScore([2, 2, 2, 2], 4), 0);
+    });
+
+    test('série mais curta que a janela não tem z', () {
+      expect(bollingerZScore([1, 2], 5), isNull);
+    });
+  });
+}

--- a/test/ai/insight_engine_test.dart
+++ b/test/ai/insight_engine_test.dart
@@ -1,0 +1,363 @@
+import 'package:cotacao_direta/ai/insight_engine.dart';
+import 'package:cotacao_direta/model/asset_series.dart';
+import 'package:cotacao_direta/model/financial_analysis.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../helpers/series_test_helper.dart';
+
+MarketStatistics _statistics({
+  double lastPrice = 5.0,
+  double? weeklyChange = 0.0,
+  double? monthlyChange = 0.0,
+  double annualizedVolatility = 0.10,
+  double? relativeStrengthIndex = 50,
+  double maxDrawdown = 0.05,
+  double compoundAnnualGrowthRate = 0.0,
+  int sampleCount = 120,
+}) =>
+    MarketStatistics(
+      lastPrice: lastPrice,
+      weeklyChange: weeklyChange,
+      monthlyChange: monthlyChange,
+      annualizedVolatility: annualizedVolatility,
+      relativeStrengthIndex: relativeStrengthIndex,
+      shortMovingAverage: lastPrice,
+      longMovingAverage: lastPrice,
+      maxDrawdown: maxDrawdown,
+      compoundAnnualGrowthRate: compoundAnnualGrowthRate,
+      trendSlopePerDay: 0,
+      trendRSquared: 0.5,
+      sampleCount: sampleCount,
+    );
+
+AssetForecast _forecast({
+  double lastPrice = 5.0,
+  double projectedPrice = 5.0,
+  int horizonInDays = 15,
+  ModelDiagnostics? diagnostics,
+}) =>
+    AssetForecast(
+      lastPrice: lastPrice,
+      points: [
+        ForecastPoint(
+          step: horizonInDays,
+          date: DateTime(2024, 6, 1),
+          price: projectedPrice,
+          lowerBound: projectedPrice * 0.95,
+          upperBound: projectedPrice * 1.05,
+        )
+      ],
+      diagnostics: diagnostics ??
+          const ModelDiagnostics(
+            trainingSamples: 90,
+            validationError: 0.8,
+            baselineError: 1.0,
+            skill: 0.2,
+            neuralWeight: 0.12,
+            epochs: 120,
+            trained: true,
+          ),
+      confidenceLevel: 0.8,
+    );
+
+List<InsightCode> _codes(List<FinancialInsight> insights) =>
+    insights.map((insight) => insight.code).toList();
+
+FinancialInsight _insightOf(
+        List<FinancialInsight> insights, InsightCode code) =>
+    insights.firstWhere((insight) => insight.code == code);
+
+void main() {
+  final engine = const InsightEngine();
+  final series = seriesFromPrices(syntheticPrices(length: 60));
+  final cryptoSeries = seriesFromPrices(syntheticPrices(length: 60),
+      code: "BTC", kind: AssetKind.cryptocurrency);
+
+  group('InsightEngine projeção', () {
+    test('alta projetada vira insight positivo', () {
+      final insights = engine.generate(
+          series: series,
+          statistics: _statistics(),
+          forecast: _forecast(projectedPrice: 5.5));
+
+      final insight = _insightOf(insights, InsightCode.projectionUp);
+      expect(insight.sentiment, InsightSentiment.positive);
+      // Alta de 10%, horizonte de 15 dias e a cotação projetada.
+      expect(insight.arguments.length, 3);
+      expect(insight.arguments.first, contains("10"));
+      expect(insight.arguments[1], "15");
+    });
+
+    test('queda projetada vira insight negativo', () {
+      final insights = engine.generate(
+          series: series,
+          statistics: _statistics(),
+          forecast: _forecast(projectedPrice: 4.5));
+
+      expect(_insightOf(insights, InsightCode.projectionDown).sentiment,
+          InsightSentiment.negative);
+    });
+
+    test('variação pequena é lida como estabilidade', () {
+      final insights = engine.generate(
+          series: series,
+          statistics: _statistics(),
+          forecast: _forecast(projectedPrice: 5.01));
+
+      expect(_codes(insights), contains(InsightCode.projectionStable));
+    });
+  });
+
+  group('InsightEngine tendência', () {
+    test('alta de 30 dias acima do limiar vira tendência de alta', () {
+      final insights = engine.generate(
+          series: series,
+          statistics: _statistics(monthlyChange: 0.08),
+          forecast: _forecast());
+
+      final insight = _insightOf(insights, InsightCode.trendUp);
+      expect(insight.sentiment, InsightSentiment.positive);
+      expect(insight.arguments.last, "30");
+    });
+
+    test('queda de 30 dias vira tendência de baixa', () {
+      final insights = engine.generate(
+          series: series,
+          statistics: _statistics(monthlyChange: -0.08),
+          forecast: _forecast());
+
+      expect(_codes(insights), contains(InsightCode.trendDown));
+    });
+
+    test('variação pequena não é tendência', () {
+      final insights = engine.generate(
+          series: series,
+          statistics: _statistics(monthlyChange: 0.005),
+          forecast: _forecast());
+
+      expect(_codes(insights), contains(InsightCode.trendSideways));
+    });
+
+    test('sem 30 dias de histórico usa a variação de 7 dias', () {
+      final insights = engine.generate(
+          series: series,
+          statistics: _statistics(monthlyChange: null, weeklyChange: 0.09),
+          forecast: _forecast());
+
+      expect(_insightOf(insights, InsightCode.trendUp).arguments.last, "7");
+    });
+
+    test('sem variação nenhuma não fala de tendência', () {
+      final insights = engine.generate(
+          series: series,
+          statistics: _statistics(monthlyChange: null, weeklyChange: null),
+          forecast: _forecast());
+
+      expect(
+          _codes(insights),
+          isNot(anyOf(contains(InsightCode.trendUp),
+              contains(InsightCode.trendDown),
+              contains(InsightCode.trendSideways))));
+    });
+  });
+
+  group('InsightEngine momento', () {
+    test('IFR alto avisa sobrecompra', () {
+      final insights = engine.generate(
+          series: series,
+          statistics: _statistics(relativeStrengthIndex: 78),
+          forecast: _forecast());
+
+      final insight = _insightOf(insights, InsightCode.momentumOverbought);
+      expect(insight.sentiment, InsightSentiment.caution);
+      expect(insight.arguments.single, "78");
+    });
+
+    test('IFR baixo avisa sobrevenda', () {
+      final insights = engine.generate(
+          series: series,
+          statistics: _statistics(relativeStrengthIndex: 22),
+          forecast: _forecast());
+
+      expect(_codes(insights), contains(InsightCode.momentumOversold));
+    });
+
+    test('IFR no meio da escala é momento equilibrado', () {
+      final insights = engine.generate(
+          series: series,
+          statistics: _statistics(relativeStrengthIndex: 51),
+          forecast: _forecast());
+
+      expect(_codes(insights), contains(InsightCode.momentumNeutral));
+    });
+
+    test('sem IFR calculado não fala de momento', () {
+      final insights = engine.generate(
+          series: series,
+          statistics: _statistics(relativeStrengthIndex: null),
+          forecast: _forecast());
+
+      expect(_codes(insights), isNot(contains(InsightCode.momentumNeutral)));
+    });
+  });
+
+  group('InsightEngine volatilidade', () {
+    test('o limiar de moeda fiduciária é mais baixo que o de cripto', () {
+      final statistics = _statistics(annualizedVolatility: 0.30);
+
+      final moeda = engine.generate(
+          series: series, statistics: statistics, forecast: _forecast());
+      final cripto = engine.generate(
+          series: cryptoSeries, statistics: statistics, forecast: _forecast());
+
+      expect(_codes(moeda), contains(InsightCode.volatilityHigh));
+      expect(_codes(cripto), isNot(contains(InsightCode.volatilityHigh)));
+    });
+
+    test('cripto acima de 60% ao ano também é volatilidade alta', () {
+      final insights = engine.generate(
+          series: cryptoSeries,
+          statistics: _statistics(annualizedVolatility: 0.75),
+          forecast: _forecast());
+
+      expect(_codes(insights), contains(InsightCode.volatilityHigh));
+    });
+
+    test('volatilidade baixa é ponto positivo', () {
+      final insights = engine.generate(
+          series: series,
+          statistics: _statistics(annualizedVolatility: 0.02),
+          forecast: _forecast());
+
+      expect(_insightOf(insights, InsightCode.volatilityLow).sentiment,
+          InsightSentiment.positive);
+    });
+
+    test('volatilidade intermediária não vira insight', () {
+      final insights = engine.generate(
+          series: series,
+          statistics: _statistics(annualizedVolatility: 0.10),
+          forecast: _forecast());
+
+      expect(
+          _codes(insights),
+          isNot(anyOf(contains(InsightCode.volatilityHigh),
+              contains(InsightCode.volatilityLow))));
+    });
+  });
+
+  group('InsightEngine risco e confiança', () {
+    test('queda relevante do topo vira aviso', () {
+      final insights = engine.generate(
+          series: series,
+          statistics: _statistics(maxDrawdown: 0.32),
+          forecast: _forecast());
+
+      final insight = _insightOf(insights, InsightCode.drawdown);
+      expect(insight.sentiment, InsightSentiment.caution);
+      expect(insight.arguments.single, contains("32"));
+    });
+
+    test('queda pequena não vira aviso', () {
+      final insights = engine.generate(
+          series: series,
+          statistics: _statistics(maxDrawdown: 0.03),
+          forecast: _forecast());
+
+      expect(_codes(insights), isNot(contains(InsightCode.drawdown)));
+    });
+
+    test('rede que superou o passeio aleatório é reportada como tal', () {
+      final insights = engine.generate(
+          series: series,
+          statistics: _statistics(),
+          forecast: _forecast(
+              diagnostics: const ModelDiagnostics(
+            trainingSamples: 90,
+            validationError: 0.7,
+            baselineError: 1.0,
+            skill: 0.3,
+            neuralWeight: 0.18,
+            epochs: 100,
+            trained: true,
+          )));
+
+      expect(_codes(insights), contains(InsightCode.confidenceGood));
+    });
+
+    test('rede sem vantagem avisa que a projeção é a base estatística', () {
+      final insights = engine.generate(
+          series: series,
+          statistics: _statistics(),
+          forecast: _forecast(
+              diagnostics: const ModelDiagnostics(
+            trainingSamples: 90,
+            validationError: 1.0,
+            baselineError: 1.0,
+            skill: 0.0,
+            neuralWeight: 0.0,
+            epochs: 60,
+            trained: true,
+          )));
+
+      final insight = _insightOf(insights, InsightCode.confidenceLow);
+      expect(insight.sentiment, InsightSentiment.caution);
+      expect(insight.arguments, isEmpty);
+    });
+
+    test('histórico curto é declarado explicitamente', () {
+      final insights = engine.generate(
+          series: series,
+          statistics: _statistics(),
+          forecast: _forecast(
+              diagnostics: ModelDiagnostics.untrained(trainingSamples: 8)));
+
+      final insight = _insightOf(insights, InsightCode.dataLimited);
+      expect(insight.arguments.single, "8");
+    });
+  });
+
+  group('InsightEngine formatação dos números', () {
+    test('em português o separador decimal é a vírgula', () {
+      final insights = const InsightEngine(languageCode: "pt").generate(
+          series: series,
+          statistics: _statistics(monthlyChange: 0.1234),
+          forecast: _forecast());
+
+      expect(_insightOf(insights, InsightCode.trendUp).arguments.first,
+          "12,3%");
+    });
+
+    test('em inglês o separador decimal é o ponto', () {
+      final insights = const InsightEngine(languageCode: "en").generate(
+          series: series,
+          statistics: _statistics(monthlyChange: 0.1234),
+          forecast: _forecast());
+
+      expect(_insightOf(insights, InsightCode.trendUp).arguments.first,
+          "12.3%");
+    });
+
+    test('a cotação projetada ganha casas decimais conforme a ordem de '
+        'grandeza', () {
+      final insights = const InsightEngine(languageCode: "en").generate(
+          series: cryptoSeries,
+          statistics: _statistics(lastPrice: 0.0000017),
+          forecast:
+              _forecast(lastPrice: 0.0000017, projectedPrice: 0.0000019));
+
+      final insight = _insightOf(insights, InsightCode.projectionUp);
+      expect(insight.arguments.last, isNot("0.00"));
+      expect(insight.arguments.last, startsWith("0.0000019"));
+    });
+  });
+
+  test('a projeção é sempre a primeira observação da lista', () {
+    final insights = engine.generate(
+        series: series,
+        statistics: _statistics(monthlyChange: 0.2),
+        forecast: _forecast(projectedPrice: 6));
+
+    expect(insights.first.code, InsightCode.projectionUp);
+  });
+}

--- a/test/ai/local_financial_model_test.dart
+++ b/test/ai/local_financial_model_test.dart
@@ -1,0 +1,220 @@
+import 'package:cotacao_direta/ai/local_financial_model.dart';
+import 'package:cotacao_direta/model/asset_series.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../helpers/series_test_helper.dart';
+
+void main() {
+  final model = LocalFinancialModel();
+
+  group('LocalFinancialModel.forecast', () {
+    test('projeta um ponto por dia do horizonte', () {
+      final series = seriesFromPrices(syntheticPrices(length: 120));
+
+      final forecast = model.forecast(series, horizonInDays: 10);
+
+      expect(forecast.points.length, 10);
+      expect(forecast.points.first.step, 1);
+      expect(forecast.points.last.step, 10);
+      expect(forecast.horizonInDays, 10);
+    });
+
+    test('as datas projetadas seguem o último dia observado', () {
+      final series = seriesFromPrices(syntheticPrices(length: 60),
+          startDate: DateTime(2024, 1, 1));
+
+      final forecast = model.forecast(series, horizonInDays: 3);
+
+      expect(forecast.points.first.date, series.lastDate.add(Duration(days: 1)));
+      expect(forecast.points.last.date, series.lastDate.add(Duration(days: 3)));
+    });
+
+    test('a faixa de confiança envolve o valor projetado', () {
+      final series = seriesFromPrices(syntheticPrices(length: 120));
+
+      final forecast = model.forecast(series, horizonInDays: 15);
+
+      for (var point in forecast.points) {
+        expect(point.lowerBound, lessThan(point.price));
+        expect(point.upperBound, greaterThan(point.price));
+        expect(point.lowerBound, greaterThan(0));
+      }
+    });
+
+    test('a incerteza cresce com a distância no tempo', () {
+      final series = seriesFromPrices(syntheticPrices(length: 120));
+
+      final forecast = model.forecast(series, horizonInDays: 20);
+      final primeiraFaixa = forecast.points.first.upperBound /
+          forecast.points.first.lowerBound;
+      final ultimaFaixa =
+          forecast.points.last.upperBound / forecast.points.last.lowerBound;
+
+      expect(ultimaFaixa, greaterThan(primeiraFaixa));
+    });
+
+    test('a mesma série produz sempre a mesma projeção', () {
+      final series = seriesFromPrices(syntheticPrices(length: 120));
+
+      final first = model.forecast(series, horizonInDays: 15);
+      final second = model.forecast(series, horizonInDays: 15);
+
+      expect(first.projectedPrice, second.projectedPrice);
+      expect(first.diagnostics.skill, second.diagnostics.skill);
+    });
+
+    test('série longa o bastante treina a rede', () {
+      final series = seriesFromPrices(syntheticPrices(length: 150));
+
+      final diagnostics = model.forecast(series).diagnostics;
+
+      expect(diagnostics.trained, isTrue);
+      expect(diagnostics.trainingSamples,
+          greaterThanOrEqualTo(LocalFinancialModel.minimumTrainingSamples));
+      expect(diagnostics.epochs, greaterThan(0));
+      expect(diagnostics.validationError, isNotNull);
+      expect(diagnostics.baselineError, isNotNull);
+    });
+
+    test('série curta cai na base estatística, sem treinar', () {
+      final series = seriesFromPrices(syntheticPrices(length: 20));
+
+      final forecast = model.forecast(series, horizonInDays: 5);
+
+      expect(forecast.diagnostics.trained, isFalse);
+      expect(forecast.diagnostics.neuralWeight, 0);
+      expect(forecast.points.length, 5);
+      expect(forecast.points.every((point) => point.price.isFinite), isTrue);
+    });
+
+    test('o peso da rede nunca passa do teto configurado', () {
+      final series = seriesFromPrices(syntheticPrices(length: 200));
+
+      final diagnostics = model.forecast(series).diagnostics;
+
+      expect(diagnostics.neuralWeight,
+          lessThanOrEqualTo(model.maximumNeuralWeight));
+      expect(diagnostics.neuralWeight, greaterThanOrEqualTo(0));
+      expect(diagnostics.skill, inInclusiveRange(0, 1));
+    });
+
+    test('série sem variação nenhuma projeta o mesmo valor, sem NaN', () {
+      final series = seriesFromPrices(List<double>.filled(120, 5.0));
+
+      final forecast = model.forecast(series, horizonInDays: 10);
+
+      for (var point in forecast.points) {
+        expect(point.price, closeTo(5.0, 1e-6));
+        expect(point.price.isNaN, isFalse);
+        expect(point.lowerBound.isNaN, isFalse);
+      }
+    });
+
+    test('acompanha o sentido de uma tendência forte de alta', () {
+      final series = seriesFromPrices(
+          syntheticPrices(length: 150, dailyDrift: 0.004, noise: 0.002));
+
+      final forecast = model.forecast(series, horizonInDays: 15);
+
+      expect(forecast.projectedPrice, greaterThan(forecast.lastPrice));
+      expect(forecast.projectedChange, greaterThan(0));
+    });
+
+    test('acompanha o sentido de uma tendência forte de baixa', () {
+      final series = seriesFromPrices(
+          syntheticPrices(length: 150, dailyDrift: -0.004, noise: 0.002));
+
+      final forecast = model.forecast(series, horizonInDays: 15);
+
+      expect(forecast.projectedPrice, lessThan(forecast.lastPrice));
+      expect(forecast.projectedChange, lessThan(0));
+    });
+
+    test('não extrapola a tendência sem freio: o movimento diário é limitado',
+        () {
+      final series = seriesFromPrices(
+          syntheticPrices(length: 150, dailyDrift: 0.05, noise: 0.001));
+
+      final forecast = model.forecast(series, horizonInDays: 30);
+
+      // Com amortecimento, 30 dias de alta projetada não podem multiplicar o
+      // preço por um fator absurdo.
+      expect(forecast.projectedPrice / forecast.lastPrice, lessThan(5));
+    });
+
+    test('a faixa acompanha a volatilidade da série', () {
+      final calma = model.forecast(
+          seriesFromPrices(syntheticPrices(length: 150, noise: 0.001)),
+          horizonInDays: 10);
+      final agitada = model.forecast(
+          seriesFromPrices(syntheticPrices(length: 150, noise: 0.02)),
+          horizonInDays: 10);
+
+      expect(
+          agitada.projectedUpperBound / agitada.projectedLowerBound,
+          greaterThan(
+              calma.projectedUpperBound / calma.projectedLowerBound));
+    });
+
+    test('mais confiança pedida, faixa mais larga', () {
+      final series = seriesFromPrices(syntheticPrices(length: 150));
+      final estreita = LocalFinancialModel(confidenceLevel: 0.8)
+          .forecast(series, horizonInDays: 10);
+      final larga = LocalFinancialModel(confidenceLevel: 0.99)
+          .forecast(series, horizonInDays: 10);
+
+      expect(larga.projectedUpperBound,
+          greaterThan(estreita.projectedUpperBound));
+      expect(larga.projectedLowerBound, lessThan(estreita.projectedLowerBound));
+      expect(larga.confidenceLevel, 0.99);
+    });
+
+    test('recusa série vazia', () {
+      final series = AssetSeries(
+          code: "USD",
+          kind: AssetKind.currency,
+          quoteCurrency: "BRL",
+          points: []);
+
+      expect(() => model.forecast(series), throwsArgumentError);
+    });
+
+    test('recusa horizonte não positivo', () {
+      final series = seriesFromPrices(syntheticPrices(length: 60));
+
+      expect(() => model.forecast(series, horizonInDays: 0),
+          throwsArgumentError);
+    });
+
+    test('roda rápido o bastante para um celular', () {
+      final series = seriesFromPrices(syntheticPrices(length: 360));
+
+      final stopwatch = Stopwatch()..start();
+      model.forecast(series, horizonInDays: 30);
+      stopwatch.stop();
+
+      // Folgado de propósito: o objetivo é pegar uma regressão de ordem de
+      // grandeza (treino saindo de milissegundos para segundos), não medir a
+      // máquina do CI.
+      expect(stopwatch.elapsedMilliseconds, lessThan(4000));
+    });
+  });
+
+  group('AssetForecast.projectAmount', () {
+    test('aplica a variação projetada sobre o valor investido', () {
+      final series = seriesFromPrices(
+          syntheticPrices(length: 150, dailyDrift: 0.003, noise: 0.002));
+      final forecast = model.forecast(series, horizonInDays: 15);
+
+      final projection = forecast.projectAmount(1000);
+
+      expect(projection.initialAmount, 1000);
+      expect(projection.expected,
+          closeTo(1000 * forecast.projectedPrice / forecast.lastPrice, 1e-9));
+      expect(projection.lower, lessThan(projection.expected));
+      expect(projection.upper, greaterThan(projection.expected));
+      expect(projection.expectedProfit,
+          closeTo(projection.expected - 1000, 1e-9));
+    });
+  });
+}

--- a/test/ai/neural_network_test.dart
+++ b/test/ai/neural_network_test.dart
@@ -1,0 +1,157 @@
+import 'dart:math';
+
+import 'package:cotacao_direta/ai/neural/neural_network.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Amostras de uma função conhecida, para verificar que a rede aprende de fato
+/// em vez de apenas rodar sem erro.
+({List<List<double>> inputs, List<double> targets}) _samples(
+    double Function(double, double) function,
+    {int count = 200,
+    int seed = 3}) {
+  final random = Random(seed);
+  final inputs = <List<double>>[];
+  final targets = <double>[];
+  for (var index = 0; index < count; index++) {
+    final first = random.nextDouble() * 2 - 1;
+    final second = random.nextDouble() * 2 - 1;
+    inputs.add([first, second]);
+    targets.add(function(first, second));
+  }
+  return (inputs: inputs, targets: targets);
+}
+
+void main() {
+  group('NeuralNetwork', () {
+    test('aprende uma relação linear', () {
+      final data = _samples((first, second) => 0.5 * first - 0.3 * second);
+      final network = NeuralNetwork(inputSize: 2, hiddenSize: 6);
+
+      final report = network.train(data.inputs, data.targets,
+          epochs: 300, learningRate: 0.05);
+
+      expect(report.trainingError, lessThan(1e-3));
+      expect(network.predict([1, 0]), closeTo(0.5, 0.1));
+      expect(network.predict([0, 1]), closeTo(-0.3, 0.1));
+    });
+
+    test('aprende uma relação não linear, que uma reta não daria conta', () {
+      final data = _samples((first, second) => first * second);
+      final network = NeuralNetwork(inputSize: 2, hiddenSize: 8);
+
+      final report = network.train(data.inputs, data.targets,
+          epochs: 400, learningRate: 0.05);
+
+      expect(report.trainingError, lessThan(0.01));
+      expect(network.predict([0.8, 0.8]), closeTo(0.64, 0.15));
+      expect(network.predict([-0.8, 0.8]), closeTo(-0.64, 0.15));
+    });
+
+    test('a mesma semente produz a mesma rede', () {
+      final data = _samples((first, second) => 0.5 * first - 0.3 * second);
+      final first = NeuralNetwork(inputSize: 2, hiddenSize: 5, seed: 11)
+        ..train(data.inputs, data.targets, epochs: 40);
+      final second = NeuralNetwork(inputSize: 2, hiddenSize: 5, seed: 11)
+        ..train(data.inputs, data.targets, epochs: 40);
+
+      expect(first.predict([0.3, -0.7]), second.predict([0.3, -0.7]));
+    });
+
+    test('sementes diferentes produzem redes diferentes', () {
+      final data = _samples((first, second) => 0.5 * first - 0.3 * second);
+      final first = NeuralNetwork(inputSize: 2, hiddenSize: 5, seed: 11)
+        ..train(data.inputs, data.targets, epochs: 5);
+      final second = NeuralNetwork(inputSize: 2, hiddenSize: 5, seed: 12)
+        ..train(data.inputs, data.targets, epochs: 5);
+
+      expect(first.predict([0.3, -0.7]),
+          isNot(closeTo(second.predict([0.3, -0.7]), 1e-12)));
+    });
+
+    test('mede o erro no conjunto de validação', () {
+      final data = _samples((first, second) => 0.5 * first - 0.3 * second);
+      final network = NeuralNetwork(inputSize: 2, hiddenSize: 6);
+
+      final report = network.train(
+        data.inputs.sublist(0, 150),
+        data.targets.sublist(0, 150),
+        validationInputs: data.inputs.sublist(150),
+        validationTargets: data.targets.sublist(150),
+        epochs: 200,
+        learningRate: 0.05,
+      );
+
+      expect(report.validationError, isNotNull);
+      expect(report.validationError!, lessThan(1e-2));
+    });
+
+    test('sem validação não há erro de validação a reportar', () {
+      final data = _samples((first, second) => first + second, count: 30);
+      final network = NeuralNetwork(inputSize: 2, hiddenSize: 4);
+
+      final report = network.train(data.inputs, data.targets, epochs: 10);
+
+      expect(report.validationError, isNull);
+      expect(report.epochs, 10);
+    });
+
+    test('a parada antecipada encurta o treino quando a validação empaca', () {
+      // Alvo puramente aleatório: não há o que aprender, então a validação para
+      // de melhorar cedo.
+      final random = Random(5);
+      final inputs = List.generate(
+          80, (_) => [random.nextDouble(), random.nextDouble()]);
+      final targets = List.generate(80, (_) => random.nextDouble() * 2 - 1);
+      final network = NeuralNetwork(inputSize: 2, hiddenSize: 6);
+
+      final report = network.train(
+        inputs.sublist(0, 60),
+        targets.sublist(0, 60),
+        validationInputs: inputs.sublist(60),
+        validationTargets: targets.sublist(60),
+        epochs: 2000,
+        learningRate: 0.05,
+        patience: 10,
+      );
+
+      expect(report.epochs, lessThan(2000));
+    });
+
+    test('recusa entradas e alvos de tamanhos diferentes', () {
+      final network = NeuralNetwork(inputSize: 2, hiddenSize: 3);
+
+      expect(
+          () => network.train([
+                [1, 2]
+              ], [
+                1,
+                2
+              ]),
+          throwsArgumentError);
+    });
+
+    test('recusa treino sem amostras', () {
+      final network = NeuralNetwork(inputSize: 2, hiddenSize: 3);
+
+      expect(() => network.train([], []), throwsArgumentError);
+    });
+
+    test('recusa um vetor de entrada com o tamanho errado', () {
+      final network = NeuralNetwork(inputSize: 3, hiddenSize: 3);
+
+      expect(() => network.predict([1, 2]), throwsArgumentError);
+    });
+
+    test('a rede recém-criada já responde sem treino', () {
+      final network = NeuralNetwork(inputSize: 3, hiddenSize: 4);
+
+      expect(network.predict([0.1, 0.2, 0.3]).isFinite, isTrue);
+    });
+
+    test('entradas extremas não estouram a ativação', () {
+      final network = NeuralNetwork(inputSize: 2, hiddenSize: 4);
+
+      expect(network.predict([1e6, -1e6]).isFinite, isTrue);
+    });
+  });
+}

--- a/test/ai/statistics_test.dart
+++ b/test/ai/statistics_test.dart
@@ -1,0 +1,189 @@
+import 'dart:math';
+
+import 'package:cotacao_direta/ai/math/statistics.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('mean', () {
+    test('devolve a média aritmética', () {
+      expect(mean([1, 2, 3, 4]), 2.5);
+    });
+
+    test('recusa lista vazia', () {
+      expect(() => mean([]), throwsArgumentError);
+    });
+  });
+
+  group('variance e standardDeviation', () {
+    test('usam o divisor n-1 por padrão', () {
+      // Desvios ±1 e ±1 em torno de 3: soma dos quadrados 4, dividida por 3.
+      expect(variance([2, 4, 4, 2]), closeTo(4 / 3, 1e-12));
+    });
+
+    test('com sample falso usam o divisor n', () {
+      expect(variance([2, 4, 4, 2], sample: false), 1);
+      expect(standardDeviation([2, 4, 4, 2], sample: false), 1);
+    });
+
+    test('um único ponto não tem dispersão', () {
+      expect(variance([7]), 0);
+      expect(standardDeviation([7]), 0);
+    });
+
+    test('série constante tem desvio zero', () {
+      expect(standardDeviation([3, 3, 3, 3]), 0);
+    });
+  });
+
+  group('logReturns', () {
+    test('devolve um retorno a menos que o número de preços', () {
+      expect(logReturns([1, 2, 4]).length, 2);
+    });
+
+    test('calcula o logaritmo da razão entre dias consecutivos', () {
+      final returns = logReturns([100, 110]);
+
+      expect(returns.single, closeTo(log(1.1), 1e-12));
+    });
+
+    test('somam-se ao longo do tempo', () {
+      final returns = logReturns([10, 12, 9, 15]);
+      final total = returns.reduce((a, b) => a + b);
+
+      expect(total, closeTo(log(15 / 10), 1e-12));
+    });
+
+    test('ignora pares com preço não positivo', () {
+      expect(logReturns([10, 0, 12]), isEmpty);
+    });
+
+    test('série de um ponto não tem retorno', () {
+      expect(logReturns([10]), isEmpty);
+    });
+  });
+
+  group('linearFit', () {
+    test('recupera exatamente uma reta', () {
+      final fit = linearFit([0, 1, 2, 3], [1, 3, 5, 7]);
+
+      expect(fit.slope, closeTo(2, 1e-12));
+      expect(fit.intercept, closeTo(1, 1e-12));
+      expect(fit.rSquared, closeTo(1, 1e-12));
+      expect(fit.predict(4), closeTo(9, 1e-12));
+    });
+
+    test('inclinação negativa para série que cai', () {
+      expect(linearFit([0, 1, 2], [9, 6, 3]).slope, closeTo(-3, 1e-12));
+    });
+
+    test('R² baixo quando os pontos não seguem reta nenhuma', () {
+      final fit = linearFit([0, 1, 2, 3], [1, 5, 5, 1]);
+
+      expect(fit.rSquared, lessThan(0.05));
+    });
+
+    test('sem variação em y o R² é zero', () {
+      final fit = linearFit([0, 1, 2], [4, 4, 4]);
+
+      expect(fit.slope, closeTo(0, 1e-12));
+      expect(fit.rSquared, 0);
+    });
+
+    test('menos de dois pontos devolve reta nula', () {
+      expect(linearFit([1], [2]).slope, 0);
+    });
+
+    test('recusa listas de tamanhos diferentes', () {
+      expect(() => linearFit([1, 2], [1]), throwsArgumentError);
+    });
+  });
+
+  group('exponentiallyWeightedMean', () {
+    test('série constante devolve o próprio valor', () {
+      expect(exponentiallyWeightedMean([5, 5, 5, 5]), closeTo(5, 1e-12));
+    });
+
+    test('pesa mais o fim da série que o começo', () {
+      // A estimativa é semeada pelo primeiro ponto, então o peso do começo só
+      // some numa série longa — que é o caso de uso real (meses de cotação).
+      final subindo = exponentiallyWeightedMean(
+          [...List<double>.filled(29, 0), 1]);
+      final descendo =
+          exponentiallyWeightedMean([1, ...List<double>.filled(29, 0)]);
+
+      expect(subindo, greaterThan(descendo));
+    });
+
+    test('alpha maior aproxima mais do último ponto', () {
+      final serie = [...List<double>.filled(29, 0.0), 1.0];
+      final lento = exponentiallyWeightedMean(serie, alpha: 0.1);
+      final rapido = exponentiallyWeightedMean(serie, alpha: 0.9);
+
+      expect(rapido, greaterThan(lento));
+      expect(rapido, closeTo(0.9, 1e-9));
+    });
+
+    test('recusa lista vazia', () {
+      expect(() => exponentiallyWeightedMean([]), throwsArgumentError);
+    });
+  });
+
+  group('meanSquaredError', () {
+    test('previsão exata tem erro zero', () {
+      expect(meanSquaredError([1, 2, 3], [1, 2, 3]), 0);
+    });
+
+    test('é a média dos quadrados das diferenças', () {
+      expect(meanSquaredError([1, 2], [2, 4]), closeTo((1 + 4) / 2, 1e-12));
+    });
+
+    test('recusa listas de tamanhos diferentes', () {
+      expect(() => meanSquaredError([1], [1, 2]), throwsArgumentError);
+    });
+  });
+
+  group('normalQuantile', () {
+    test('a mediana da normal é zero', () {
+      expect(normalQuantile(0.5), closeTo(0, 1e-9));
+    });
+
+    test('reproduz os quantis conhecidos', () {
+      expect(normalQuantile(0.975), closeTo(1.959964, 1e-5));
+      expect(normalQuantile(0.9), closeTo(1.281552, 1e-5));
+      expect(normalQuantile(0.99), closeTo(2.326348, 1e-5));
+    });
+
+    test('é simétrica em torno da mediana', () {
+      expect(normalQuantile(0.2), closeTo(-normalQuantile(0.8), 1e-6));
+    });
+
+    test('vale também nas caudas extremas', () {
+      expect(normalQuantile(0.001), closeTo(-3.090232, 1e-4));
+      expect(normalQuantile(0.999), closeTo(3.090232, 1e-4));
+    });
+
+    test('recusa probabilidade fora de (0, 1)', () {
+      expect(() => normalQuantile(0), throwsArgumentError);
+      expect(() => normalQuantile(1), throwsArgumentError);
+    });
+  });
+
+  group('confidenceMultiplier', () {
+    test('95% de confiança dá o 1,96 de sempre', () {
+      expect(confidenceMultiplier(0.95), closeTo(1.959964, 1e-5));
+    });
+
+    test('80% de confiança dá 1,28', () {
+      expect(confidenceMultiplier(0.8), closeTo(1.281552, 1e-5));
+    });
+
+    test('mais confiança pede faixa mais larga', () {
+      expect(confidenceMultiplier(0.99),
+          greaterThan(confidenceMultiplier(0.8)));
+    });
+
+    test('recusa nível fora de (0, 1)', () {
+      expect(() => confidenceMultiplier(1), throwsArgumentError);
+    });
+  });
+}

--- a/test/blocs/ai_insights_bloc_test.dart
+++ b/test/blocs/ai_insights_bloc_test.dart
@@ -1,0 +1,221 @@
+import 'package:cotacao_direta/ai/financial_ai_service.dart';
+import 'package:cotacao_direta/blocs/ai_insights_bloc.dart';
+import 'package:cotacao_direta/model/asset_series.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../helpers/fakes.dart';
+import '../helpers/series_test_helper.dart';
+
+void main() {
+  late FakeCurrencyRepository repository;
+  late AiInsightsBloc bloc;
+
+  setUp(() {
+    repository = FakeCurrencyRepository()
+      ..historicalData =
+          quoteHistoryFromPrices(syntheticPrices(length: 120));
+    bloc = AiInsightsBloc(currencyRepository: repository);
+  });
+
+  tearDown(() => bloc.dispose());
+
+  group('AiInsightsBloc.analyze', () {
+    test('emite carregando e depois o resultado', () async {
+      final states = <AiInsightsState>[];
+      bloc.stateStream.listen(states.add);
+
+      await bloc.analyze();
+      // A stream é broadcast: a entrega aos ouvintes é agendada, então o último
+      // evento só chega depois de o laço de eventos girar.
+      await pumpEventQueue();
+
+      expect(states.first.loading, isTrue);
+      expect(states.last.hasAnalysis, isTrue);
+      expect(states.last.analysis!.assetCode, "USD");
+      expect(states.last.error, isNull);
+    });
+
+    test('o estado final fica disponível para quem chegar depois', () async {
+      await bloc.analyze();
+
+      expect(bloc.currentState.hasAnalysis, isTrue);
+      expect(bloc.currentState.loading, isFalse);
+    });
+
+    test('pede o histórico do ativo selecionado', () async {
+      bloc.selectAsset("BTC", AssetKind.cryptocurrency);
+
+      await bloc.analyze();
+
+      expect(repository.historicalDataCalls.single.first, ["BTC"]);
+      expect(bloc.currentState.analysis!.assetKind,
+          AssetKind.cryptocurrency);
+    });
+
+    test('pede a janela de histórico configurada, em datas da API', () async {
+      await bloc.analyze();
+
+      final call = repository.historicalDataCalls.single;
+      final start = DateTime.parse(call[1] as String);
+      final end = DateTime.parse(call[2] as String);
+
+      // O horário de verão de alguns fusos encurta um dos dias do intervalo.
+      expect(
+          end.difference(start).inDays,
+          inInclusiveRange(AiInsightsBloc.historyWindowInDays - 1,
+              AiInsightsBloc.historyWindowInDays));
+    });
+
+    test('usa a moeda de contrapartida resolvida pelo repositório', () async {
+      repository.counterCurrency = "EUR";
+
+      await bloc.analyze();
+
+      expect(bloc.currentState.analysis!.series.quoteCurrency, "EUR");
+    });
+
+    test('projeta o horizonte selecionado', () async {
+      bloc.selectHorizon(7);
+
+      await bloc.analyze();
+
+      expect(bloc.currentState.analysis!.forecast.points.length, 7);
+    });
+
+    test('sem cotação nenhuma reporta ausência de dados', () async {
+      repository.historicalData = [];
+
+      await bloc.analyze();
+
+      expect(bloc.currentState.error, AiInsightsError.noData);
+      expect(bloc.currentState.hasAnalysis, isFalse);
+    });
+
+    test('histórico curto demais é reportado como tal', () async {
+      repository.historicalData = quoteHistoryFromPrices(
+          syntheticPrices(length: FinancialAiService.minimumPoints - 1));
+
+      await bloc.analyze();
+
+      expect(bloc.currentState.error, AiInsightsError.insufficientData);
+    });
+
+    test('falha do repositório vira erro genérico, sem derrubar o bloc',
+        () async {
+      repository.failure = Exception("sem rede");
+
+      await bloc.analyze();
+
+      expect(bloc.currentState.error, AiInsightsError.failure);
+    });
+
+    test('uma resposta atrasada não sobrescreve o pedido mais novo', () async {
+      final primeira = bloc.analyze();
+      bloc.selectAsset("EUR", AssetKind.currency);
+      await bloc.analyze();
+      await primeira;
+
+      expect(bloc.currentState.analysis!.assetCode, "EUR");
+    });
+  });
+
+  group('AiInsightsBloc seleção', () {
+    test('trocar de ativo limpa o resultado anterior', () async {
+      await bloc.analyze();
+      expect(bloc.currentState.hasAnalysis, isTrue);
+
+      bloc.selectAsset("EUR", AssetKind.currency);
+
+      expect(bloc.currentState.hasAnalysis, isFalse);
+      expect(bloc.selectedAssetCode, "EUR");
+    });
+
+    test('selecionar o mesmo ativo não mexe no resultado', () async {
+      await bloc.analyze();
+
+      bloc.selectAsset("USD", AssetKind.currency);
+
+      expect(bloc.currentState.hasAnalysis, isTrue);
+    });
+
+    test('trocar o horizonte com resultado na tela refaz a análise', () async {
+      await bloc.analyze();
+      expect(bloc.currentState.analysis!.forecast.points.length, 15);
+
+      bloc.selectHorizon(30);
+      // A reanálise é assíncrona: espera o estado final voltar.
+      await bloc.stateStream.firstWhere((state) => state.hasAnalysis);
+
+      expect(bloc.currentState.analysis!.forecast.points.length, 30);
+      expect(bloc.horizonInDays, 30);
+    });
+
+    test('trocar o horizonte sem resultado não consulta o repositório', () {
+      bloc.selectHorizon(7);
+
+      expect(repository.historicalDataCalls, isEmpty);
+      expect(bloc.horizonInDays, 7);
+    });
+
+    test('a moeda de contrapartida é resolvida uma única vez', () async {
+      final first = await bloc.counterCurrencyCode;
+      repository.counterCurrency = "EUR";
+      final second = await bloc.counterCurrencyCode;
+
+      expect(first, "BRL");
+      expect(second, "BRL");
+    });
+  });
+
+  group('AiInsightsBloc.parseAmount', () {
+    test('aceita o formato brasileiro', () {
+      expect(AiInsightsBloc.parseAmount("1.234,50"), 1234.5);
+      expect(AiInsightsBloc.parseAmount("10,25"), 10.25);
+    });
+
+    test('aceita o formato inglês', () {
+      expect(AiInsightsBloc.parseAmount("1,234.50"), 1234.5);
+      expect(AiInsightsBloc.parseAmount("10.25"), 10.25);
+    });
+
+    test('ignora símbolos e espaços', () {
+      expect(AiInsightsBloc.parseAmount(" R\$ 1.000,00 "), 1000);
+    });
+
+    test('recusa vazio, texto e valores não positivos', () {
+      expect(AiInsightsBloc.parseAmount(""), isNull);
+      expect(AiInsightsBloc.parseAmount("abc"), isNull);
+      expect(AiInsightsBloc.parseAmount("0"), isNull);
+      expect(AiInsightsBloc.parseAmount("-10"), isNull);
+    });
+
+    test('o campo da tela alimenta o valor da simulação', () {
+      bloc.amountController.text = "2.500,00";
+
+      expect(bloc.simulationAmount, 2500);
+    });
+  });
+
+  group('AiInsightsBloc.dispose', () {
+    // Blocs próprios: o tearDown descarta o do setUp, e descartar duas vezes o
+    // mesmo controller de texto quebraria.
+    test('fecha a stream de estado', () async {
+      final descartavel = AiInsightsBloc(currencyRepository: repository);
+      final stream = descartavel.stateStream;
+
+      descartavel.dispose();
+
+      expect(await stream.isEmpty, isTrue);
+    });
+
+    test('descarta o controller do campo de valor', () {
+      final descartavel = AiInsightsBloc(currencyRepository: repository);
+      final controller = descartavel.amountController;
+
+      descartavel.dispose();
+
+      expect(() => controller.text = "1", throwsA(isA<FlutterError>()));
+    });
+  });
+}

--- a/test/helpers/fakes.dart
+++ b/test/helpers/fakes.dart
@@ -6,6 +6,7 @@ import 'package:cotacao_direta/model/currency.dart';
 import 'package:cotacao_direta/model/currency_alert.dart';
 import 'package:cotacao_direta/repository/configuration_repository.dart';
 import 'package:cotacao_direta/repository/currency_alert_repository.dart';
+import 'package:cotacao_direta/repository/currency_repository.dart';
 import 'package:cotacao_direta/util/network_util.dart';
 import 'package:cotacao_direta/util/notification_service.dart';
 
@@ -52,6 +53,38 @@ class FakeCurrencyDao implements CurrencyDao {
     historicalDataCalls.add([currencyCodeList, initialDate, finalDate]);
     return historicalData;
   }
+}
+
+/// Repositório de cotações em memória, para isolar quem consome o histórico
+/// (a análise local) da API e do banco.
+class FakeCurrencyRepository implements CurrencyRepository {
+  /// Histórico devolvido por [getCurrencyHistoricalData], independentemente do
+  /// período pedido.
+  List<Currency> historicalData = [];
+
+  Currency? latestCurrency;
+  String counterCurrency = "BRL";
+
+  /// Argumentos de cada chamada ao histórico, na ordem em que chegaram.
+  final List<List<dynamic>> historicalDataCalls = [];
+
+  /// Quando definido, é lançado no lugar de devolver o histórico.
+  Object? failure;
+
+  @override
+  Future<List<Currency>> getCurrencyHistoricalData(
+      List<String> currencyCodeList, initialDate, finalDate) async {
+    historicalDataCalls.add([currencyCodeList, initialDate, finalDate]);
+    if (failure != null) throw failure!;
+    return historicalData;
+  }
+
+  @override
+  Future<Currency?> getLatestDataByCurrencyCode(String? currencyCode) async =>
+      latestCurrency;
+
+  @override
+  Future<String> resolveCounterCurrency() async => counterCurrency;
 }
 
 /// DAO de configuração em memória.

--- a/test/helpers/series_test_helper.dart
+++ b/test/helpers/series_test_helper.dart
@@ -1,0 +1,73 @@
+import 'dart:math';
+
+import 'package:cotacao_direta/model/asset_series.dart';
+import 'package:cotacao_direta/model/currency.dart';
+
+/// Séries sintéticas para os testes da análise local.
+///
+/// São determinísticas de propósito (o ruído sai de um [Random] semeado): o
+/// modelo também é, e um teste que mudasse de série a cada execução não
+/// conseguiria afirmar nada sobre a projeção.
+
+/// Série de preços com tendência geométrica e ruído.
+///
+/// [dailyDrift] é o log-retorno médio por dia (0,002 ≈ +0,2% ao dia) e [noise],
+/// o desvio padrão do ruído diário.
+List<double> syntheticPrices({
+  int length = 120,
+  double initialPrice = 5.0,
+  double dailyDrift = 0.0,
+  double noise = 0.004,
+  int seed = 42,
+}) {
+  final random = Random(seed);
+  final prices = <double>[initialPrice];
+  for (var day = 1; day < length; day++) {
+    // Box-Muller a partir de dois uniformes, para o ruído ser normal.
+    final first = random.nextDouble().clamp(1e-9, 1.0);
+    final second = random.nextDouble();
+    final gaussian = sqrt(-2 * log(first)) * cos(2 * pi * second);
+    prices.add(prices.last * exp(dailyDrift + noise * gaussian));
+  }
+  return prices;
+}
+
+/// Monta uma [AssetSeries] a partir de preços, um por dia corrido.
+AssetSeries seriesFromPrices(
+  List<double> prices, {
+  String code = "USD",
+  AssetKind kind = AssetKind.currency,
+  String quoteCurrency = "BRL",
+  DateTime? startDate,
+}) {
+  final start = startDate ?? DateTime(2024, 1, 1);
+  return AssetSeries(
+    code: code,
+    kind: kind,
+    quoteCurrency: quoteCurrency,
+    points: List.generate(
+      prices.length,
+      (index) =>
+          AssetPoint(date: start.add(Duration(days: index)), price: prices[index]),
+    ),
+  );
+}
+
+/// Histórico no formato que o `CurrencyRepository` devolve: o valor guardado é
+/// o inverso do preço (ver `AssetSeries.fromQuoteHistory`).
+List<Currency> quoteHistoryFromPrices(
+  List<double> prices, {
+  String code = "USD",
+  DateTime? startDate,
+}) {
+  final start = startDate ?? DateTime(2024, 1, 1);
+  return List.generate(prices.length, (index) {
+    final date = start.add(Duration(days: index));
+    return Currency(
+      id: code,
+      value: 1 / prices[index],
+      historicalDate: date.toIso8601String(),
+      timestamp: date.toIso8601String(),
+    );
+  });
+}

--- a/test/model/asset_series_test.dart
+++ b/test/model/asset_series_test.dart
@@ -1,0 +1,164 @@
+import 'package:cotacao_direta/model/asset_series.dart';
+import 'package:cotacao_direta/model/currency.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+AssetSeries _series(List<AssetPoint> points) => AssetSeries(
+      code: "USD",
+      kind: AssetKind.currency,
+      quoteCurrency: "BRL",
+      points: points,
+    );
+
+AssetPoint _point(int day, double price) =>
+    AssetPoint(date: DateTime(2024, 1, day), price: price);
+
+void main() {
+  group('AssetSeries', () {
+    test('ordena os pontos por data', () {
+      final series = _series([_point(3, 5.3), _point(1, 5.1), _point(2, 5.2)]);
+
+      expect(series.prices, [5.1, 5.2, 5.3]);
+      expect(series.firstDate, DateTime(2024, 1, 1));
+      expect(series.lastDate, DateTime(2024, 1, 3));
+      expect(series.lastPrice, 5.3);
+    });
+
+    test('mantém um ponto por dia, o último de cada data', () {
+      final series = _series([
+        AssetPoint(date: DateTime(2024, 1, 1, 10), price: 5.0),
+        AssetPoint(date: DateTime(2024, 1, 1, 18), price: 5.4),
+        _point(2, 5.5),
+      ]);
+
+      expect(series.length, 2);
+      expect(series.prices, [5.4, 5.5]);
+    });
+
+    test('descarta preço não positivo ou não finito', () {
+      final series = _series([
+        _point(1, 5.0),
+        _point(2, 0),
+        _point(3, -1),
+        _point(4, double.nan),
+        _point(5, 5.5),
+      ]);
+
+      expect(series.prices, [5.0, 5.5]);
+    });
+
+    test('conta o intervalo coberto em dias corridos', () {
+      final series = _series([_point(1, 5.0), _point(11, 5.5)]);
+
+      expect(series.spanInDays, 10);
+    });
+
+    test('a cauda devolve os últimos pontos', () {
+      final series = _series(
+          List.generate(10, (index) => _point(index + 1, 5.0 + index)));
+
+      expect(series.tail(3).map((point) => point.price), [12.0, 13.0, 14.0]);
+    });
+
+    test('a cauda de uma série curta é a série inteira', () {
+      final series = _series([_point(1, 5.0), _point(2, 5.1)]);
+
+      expect(series.tail(10).length, 2);
+    });
+
+    test('série sem pontos válidos fica vazia', () {
+      final series = _series([_point(1, 0)]);
+
+      expect(series.isEmpty, isTrue);
+      expect(series.isNotEmpty, isFalse);
+      expect(series.length, 0);
+    });
+  });
+
+  group('AssetSeries.fromQuoteHistory', () {
+    test('inverte o valor guardado para virar preço', () {
+      // O app guarda 1/cotação: 0,2 dólar por real equivale a R$ 5 por dólar.
+      final history = [
+        Currency(
+            id: "USD",
+            value: 0.2,
+            historicalDate: DateTime(2024, 1, 1).toIso8601String()),
+      ];
+
+      final series = AssetSeries.fromQuoteHistory(
+          code: "USD",
+          kind: AssetKind.currency,
+          quoteCurrency: "BRL",
+          history: history);
+
+      expect(series.lastPrice, closeTo(5, 1e-12));
+    });
+
+    test('uma alta da moeda aparece como alta do preço', () {
+      final history = [
+        Currency(
+            id: "USD",
+            value: 0.2,
+            historicalDate: DateTime(2024, 1, 1).toIso8601String()),
+        Currency(
+            id: "USD",
+            value: 0.1,
+            historicalDate: DateTime(2024, 1, 2).toIso8601String()),
+      ];
+
+      final series = AssetSeries.fromQuoteHistory(
+          code: "USD",
+          kind: AssetKind.currency,
+          quoteCurrency: "BRL",
+          history: history);
+
+      expect(series.prices.last, greaterThan(series.prices.first));
+    });
+
+    test('ignora registros sem valor, sem data ou com data inválida', () {
+      final history = [
+        Currency(
+            id: "USD",
+            value: null,
+            historicalDate: DateTime(2024, 1, 1).toIso8601String()),
+        Currency(id: "USD", value: 0.2, historicalDate: null),
+        Currency(id: "USD", value: 0.2, historicalDate: "não é data"),
+        Currency(id: "USD", value: 0, historicalDate: "2024-01-04"),
+        Currency(id: "USD", value: 0.25, historicalDate: "2024-01-05"),
+      ];
+
+      final series = AssetSeries.fromQuoteHistory(
+          code: "USD",
+          kind: AssetKind.currency,
+          quoteCurrency: "BRL",
+          history: history);
+
+      expect(series.length, 1);
+      expect(series.lastPrice, closeTo(4, 1e-12));
+    });
+
+    test('histórico vazio devolve série vazia', () {
+      final series = AssetSeries.fromQuoteHistory(
+          code: "USD",
+          kind: AssetKind.currency,
+          quoteCurrency: "BRL",
+          history: []);
+
+      expect(series.isEmpty, isTrue);
+    });
+
+    test('guarda o código, o tipo e a moeda de contrapartida', () {
+      final series = AssetSeries.fromQuoteHistory(
+          code: "BTC",
+          kind: AssetKind.cryptocurrency,
+          quoteCurrency: "EUR",
+          history: [
+            Currency(
+                id: "BTC", value: 0.000002, historicalDate: "2024-01-01")
+          ]);
+
+      expect(series.code, "BTC");
+      expect(series.kind, AssetKind.cryptocurrency);
+      expect(series.quoteCurrency, "EUR");
+    });
+  });
+}

--- a/test/util/localizations_test.dart
+++ b/test/util/localizations_test.dart
@@ -57,7 +57,97 @@ List<String?> _allLabels(MyAppLocalizations localizations) => [
       localizations.currencyAlertDeleteTooltip,
       localizations.currencyAlertNotificationTitle,
       localizations.currencyAlertNotificationBody,
+      localizations.aiInsightsBottomNavItemLabel,
+      localizations.aiInsightsSectionLabel,
+      localizations.aiInsightsDescription,
+      localizations.aiInsightsAssetLabel,
+      localizations.aiInsightsHorizonLabel,
+      localizations.aiInsightsHorizonOptionLabel,
+      localizations.aiInsightsAmountLabel,
+      localizations.aiInsightsAnalyzeBtnLabel,
+      localizations.aiInsightsRunningLabel,
+      localizations.aiInsightsEmptyLabel,
+      localizations.aiInsightsNoDataError,
+      localizations.aiInsightsInsufficientDataError,
+      localizations.aiInsightsFailureError,
+      localizations.aiInsightsSummarySectionLabel,
+      localizations.aiInsightsProjectionSectionLabel,
+      localizations.aiInsightsInsightsSectionLabel,
+      localizations.aiInsightsModelSectionLabel,
+      localizations.aiInsightsLastPriceLabel,
+      localizations.aiInsightsWeeklyChangeLabel,
+      localizations.aiInsightsMonthlyChangeLabel,
+      localizations.aiInsightsVolatilityLabel,
+      localizations.aiInsightsRsiLabel,
+      localizations.aiInsightsDrawdownLabel,
+      localizations.aiInsightsTrendLabel,
+      localizations.aiInsightsTrendFitLabel,
+      localizations.aiInsightsProjectedPriceLabel,
+      localizations.aiInsightsProjectedChangeLabel,
+      localizations.aiInsightsConfidenceBandLabel,
+      localizations.aiInsightsAmountProjectionLabel,
+      localizations.aiInsightsAmountProjectionHint,
+      localizations.aiInsightsModelSamplesLabel,
+      localizations.aiInsightsModelSkillLabel,
+      localizations.aiInsightsModelEpochsLabel,
+      localizations.aiInsightsModelUntrainedLabel,
+      localizations.aiInsightsDisclaimerLabel,
+      localizations.aiInsightsChartHistoryLabel,
+      localizations.aiInsightsChartProjectionLabel,
+      localizations.aiInsightTrendUp,
+      localizations.aiInsightTrendDown,
+      localizations.aiInsightTrendSideways,
+      localizations.aiInsightMomentumOverbought,
+      localizations.aiInsightMomentumOversold,
+      localizations.aiInsightMomentumNeutral,
+      localizations.aiInsightVolatilityHigh,
+      localizations.aiInsightVolatilityLow,
+      localizations.aiInsightProjectionUp,
+      localizations.aiInsightProjectionDown,
+      localizations.aiInsightProjectionStable,
+      localizations.aiInsightDrawdown,
+      localizations.aiInsightConfidenceGood,
+      localizations.aiInsightConfidenceLow,
+      localizations.aiInsightDataLimited,
     ];
+
+/// Modelos de frase dos insights que recebem números do motor de análise, com
+/// quantos marcadores cada um espera.
+const Map<String, int> _insightPlaceholderCount = {
+  'aiInsightTrendUp': 2,
+  'aiInsightTrendDown': 2,
+  'aiInsightTrendSideways': 2,
+  'aiInsightMomentumOverbought': 1,
+  'aiInsightMomentumOversold': 1,
+  'aiInsightMomentumNeutral': 1,
+  'aiInsightVolatilityHigh': 1,
+  'aiInsightVolatilityLow': 1,
+  'aiInsightProjectionUp': 3,
+  'aiInsightProjectionDown': 3,
+  'aiInsightProjectionStable': 2,
+  'aiInsightDrawdown': 1,
+  'aiInsightConfidenceGood': 1,
+  'aiInsightDataLimited': 1,
+};
+
+String? _insightTemplate(MyAppLocalizations localizations, String key) =>
+    switch (key) {
+      'aiInsightTrendUp' => localizations.aiInsightTrendUp,
+      'aiInsightTrendDown' => localizations.aiInsightTrendDown,
+      'aiInsightTrendSideways' => localizations.aiInsightTrendSideways,
+      'aiInsightMomentumOverbought' => localizations.aiInsightMomentumOverbought,
+      'aiInsightMomentumOversold' => localizations.aiInsightMomentumOversold,
+      'aiInsightMomentumNeutral' => localizations.aiInsightMomentumNeutral,
+      'aiInsightVolatilityHigh' => localizations.aiInsightVolatilityHigh,
+      'aiInsightVolatilityLow' => localizations.aiInsightVolatilityLow,
+      'aiInsightProjectionUp' => localizations.aiInsightProjectionUp,
+      'aiInsightProjectionDown' => localizations.aiInsightProjectionDown,
+      'aiInsightProjectionStable' => localizations.aiInsightProjectionStable,
+      'aiInsightDrawdown' => localizations.aiInsightDrawdown,
+      'aiInsightConfidenceGood' => localizations.aiInsightConfidenceGood,
+      'aiInsightDataLimited' => localizations.aiInsightDataLimited,
+      _ => null,
+    };
 
 void main() {
   group('MyAppLocalizations', () {
@@ -84,6 +174,19 @@ void main() {
       expect(portuguese, isNot(contains(null)));
       expect(english, isNot(contains(null)));
       expect(portuguese.length, english.length);
+    });
+
+    test('os dois idiomas têm o mesmo número de marcadores nos insights', () {
+      for (var locale in [const Locale("pt"), const Locale("en")]) {
+        var localizations = MyAppLocalizations(locale);
+        _insightPlaceholderCount.forEach((key, expectedCount) {
+          var template = _insightTemplate(localizations, key);
+
+          expect(template, isNotNull, reason: "$key em ${locale.languageCode}");
+          expect("%s".allMatches(template!).length, expectedCount,
+              reason: "$key em ${locale.languageCode}");
+        });
+      }
     });
 
     test('homePageHeadsUpText traz o marcador de moeda', () {

--- a/test/view/ai_insights_page_test.dart
+++ b/test/view/ai_insights_page_test.dart
@@ -1,0 +1,166 @@
+import 'package:cotacao_direta/blocs/ai_insights_bloc.dart';
+import 'package:cotacao_direta/providers/ai_insights_bloc_provider.dart';
+import 'package:cotacao_direta/util/localizations.dart';
+import 'package:cotacao_direta/view/pages/main_menu_items/ai_insights_page.dart';
+import 'package:cotacao_direta/view/widgets/forecast_chart.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../helpers/fakes.dart';
+import '../helpers/series_test_helper.dart';
+
+void main() {
+  late FakeCurrencyRepository repository;
+  late AiInsightsBloc bloc;
+
+  final localizations = MyAppLocalizations(const Locale("pt"));
+
+  setUp(() {
+    repository = FakeCurrencyRepository()
+      ..historicalData = quoteHistoryFromPrices(
+          syntheticPrices(length: 150, dailyDrift: 0.002));
+    bloc = AiInsightsBloc(currencyRepository: repository);
+  });
+
+  tearDown(() => bloc.dispose());
+
+  Future<void> pumpPage(WidgetTester tester) async {
+    // Tela alta: a página é uma lista rolável e os widgets fora da área
+    // visível não entram na árvore, o que esconderia o resultado do find.
+    tester.view.physicalSize = const Size(1000, 3000);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(MaterialApp(
+      locale: const Locale("pt"),
+      localizationsDelegates: [
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+        MyAppLocalizationsDelegate()
+      ],
+      supportedLocales: const [Locale("pt"), Locale("en")],
+      home: Scaffold(
+        body: AiInsightsBlocProvider(bloc: bloc, child: AiInsightsPage()),
+      ),
+    ));
+    await tester.pumpAndSettle();
+  }
+
+  group('AiInsightsPage', () {
+    testWidgets('abre explicando que o modelo roda no aparelho',
+        (WidgetTester tester) async {
+      await pumpPage(tester);
+
+      expect(find.text(localizations.aiInsightsSectionLabel!), findsOneWidget);
+      expect(find.text(localizations.aiInsightsDescription!), findsOneWidget);
+      expect(find.text(localizations.aiInsightsEmptyLabel!), findsOneWidget);
+      expect(find.text(localizations.aiInsightsDisclaimerLabel!),
+          findsOneWidget);
+    });
+
+    testWidgets('não analisa nada antes de o usuário pedir',
+        (WidgetTester tester) async {
+      await pumpPage(tester);
+
+      expect(repository.historicalDataCalls, isEmpty);
+    });
+
+    testWidgets('mostra resumo, projeção e gráfico depois da análise',
+        (WidgetTester tester) async {
+      await pumpPage(tester);
+
+      await tester.tap(find.text(localizations.aiInsightsAnalyzeBtnLabel!));
+      await tester.pumpAndSettle();
+
+      expect(find.text(localizations.aiInsightsSummarySectionLabel!),
+          findsOneWidget);
+      // "Projeção" aparece duas vezes: no título da seção e na legenda do
+      // gráfico.
+      expect(find.text(localizations.aiInsightsProjectionSectionLabel!),
+          findsWidgets);
+      expect(find.text(localizations.aiInsightsInsightsSectionLabel!),
+          findsOneWidget);
+      expect(find.byType(ForecastChart), findsOneWidget);
+    });
+
+    testWidgets('a análise roda no idioma da tela', (WidgetTester tester) async {
+      await pumpPage(tester);
+
+      await tester.tap(find.text(localizations.aiInsightsAnalyzeBtnLabel!));
+      await tester.pumpAndSettle();
+
+      // Em português os números saem com vírgula decimal.
+      expect(
+          bloc.currentState.analysis!.insights
+              .expand((insight) => insight.arguments)
+              .any((argument) => argument.contains(",")),
+          isTrue);
+    });
+
+    testWidgets('sem cotação nenhuma mostra o aviso de falta de dados',
+        (WidgetTester tester) async {
+      repository.historicalData = [];
+      await pumpPage(tester);
+
+      await tester.tap(find.text(localizations.aiInsightsAnalyzeBtnLabel!));
+      await tester.pumpAndSettle();
+
+      expect(find.text(localizations.aiInsightsNoDataError!), findsOneWidget);
+    });
+
+    testWidgets('falha na busca mostra o aviso genérico',
+        (WidgetTester tester) async {
+      repository.failure = Exception("sem rede");
+      await pumpPage(tester);
+
+      await tester.tap(find.text(localizations.aiInsightsAnalyzeBtnLabel!));
+      await tester.pumpAndSettle();
+
+      expect(find.text(localizations.aiInsightsFailureError!), findsOneWidget);
+    });
+
+    testWidgets('o valor digitado aparece como simulação',
+        (WidgetTester tester) async {
+      await pumpPage(tester);
+      await tester.tap(find.text(localizations.aiInsightsAnalyzeBtnLabel!));
+      await tester.pumpAndSettle();
+      expect(find.text(localizations.aiInsightsAmountProjectionLabel!),
+          findsNothing);
+
+      await tester.enterText(find.byType(TextField), "1.000,00");
+      await tester.pumpAndSettle();
+
+      expect(find.text(localizations.aiInsightsAmountProjectionLabel!),
+          findsOneWidget);
+      expect(bloc.simulationAmount, 1000);
+    });
+
+    testWidgets('trocar o horizonte refaz a projeção',
+        (WidgetTester tester) async {
+      await pumpPage(tester);
+      await tester.tap(find.text(localizations.aiInsightsAnalyzeBtnLabel!));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text("30 dias"));
+      await tester.pumpAndSettle();
+
+      expect(bloc.horizonInDays, 30);
+      expect(bloc.currentState.analysis!.forecast.points.length, 30);
+    });
+
+    testWidgets('a moeda de contrapartida fica fora da lista de ativos',
+        (WidgetTester tester) async {
+      await pumpPage(tester);
+
+      // O campo mostra o ativo selecionado; tocar nele abre a lista.
+      await tester.tap(find.text("USD").first);
+      await tester.pumpAndSettle();
+
+      // BRL é a contrapartida das cotações: não há série de BRL contra BRL.
+      expect(find.text("BRL"), findsNothing);
+      expect(find.text("EUR"), findsWidgets);
+    });
+  });
+}


### PR DESCRIPTION
## What changes

A new **AI** tab that analyses a currency or a cryptocurrency and shows a market summary, a projection with a confidence band, a chart and remarks in text form (pt/en). Everything is computed on the phone: no model to download, no native plugin, no call to an AI service. The only network request is still the quote fetch the app already made.

## The model

Two pieces that cover for each other:

- **Neural network** with a single hidden layer (multilayer perceptron) in pure Dart, trained on the spot with the history of the very asset the user opened. Inputs: a window of recent log-returns plus momentum, RSI, distance from the moving average in standard deviations, and volatility acceleration. Output: the next day's return, applied repeatedly to cover the horizon.
- **Statistical drift**: exponentially weighted mean of the log-returns, damped along the horizon so a recent trend is not extrapolated in a straight line.

The weight of each piece comes from how much the network beat the random walk ("tomorrow equals today") on a validation slice taken from the tail of the series and held out of training, capped at 60%. When the network does not beat that rival — the common case, since asset prices are nearly a random walk — the weight goes to zero and the projection becomes the statistical baseline. The number is shown on screen, under "Edge over random walk".

The confidence band comes from the random walk in log-price (`sigma * sqrt(days)`, with the normal quantile). Training is seeded with a fixed value: the same series always produces the same projection, so the screen does not change its answer on every tap.

Cost: a full analysis takes 5 to 20 ms over 90 to 360 points on a development machine — hence running on the UI isolate, which also keeps the feature working on the web.

## Worth a reviewer's eye

- The series is built by inverting `Currency.value` (the app stores 1/quote), so a rise of the asset shows up as a rise in the analysis.
- Volatility thresholds depend on the kind of asset: 40% a year is routine for crypto and would be alarming for the euro.
- The engine already handles stocks (`AssetKind.stock`), but AwesomeAPI only serves fiat and crypto, so the screen lists those two.
- The screen states that these are estimates over past quotes, not investment advice.

## Structure

| Path | Role |
| --- | --- |
| `lib/ai/math/` | statistics and technical indicators (pure Dart) |
| `lib/ai/neural/` | the neural network and its training |
| `lib/ai/local_financial_model.dart` | features, projection and confidence band |
| `lib/ai/insight_engine.dart` | which remarks to make and in what tone |
| `lib/ai/financial_ai_service.dart` | entry point used by the bloc |
| `lib/blocs/ai_insights_bloc.dart`, `lib/view/pages/main_menu_items/ai_insights_page.dart` | state and screen |

Code documentation (doc comments, inline comments and internal error messages) is in English. User-facing strings still come from the translations file in both Portuguese and English, and the test suite keeps the Portuguese descriptions the existing suite uses.

## Tests

`flutter analyze` clean and `flutter test` green with 443 tests (268 before; 175 new, covering statistics, indicators, the neural network, the model, the insight engine, the service, the series, the bloc and the screen). `flutter build web --release` was also run and completed.