### PR TITLE
feat: extend the bento card design to the remaining screens

### DIFF
--- a/lib/view/pages/home.dart
+++ b/lib/view/pages/home.dart
@@ -427,6 +427,10 @@ class HomeState extends State<Home> with TickerProviderStateMixin {
       floatingActionButton: Visibility(
         visible: fabVisibility,
         child: FloatingActionButton.extended(
+          // As abas ficam todas montadas dentro do IndexedStack, então o FAB
+          // desta tela convive com o da tela de alertas na mesma rota. Sem uma
+          // tag própria, os dois disputariam a tag padrão do Hero.
+          heroTag: "homeConversionFab",
           onPressed: () => _openConversionPage(context),
           label: Text(_localization.conversionButtonLabel!),
           icon: Icon(Icons.compare_arrows),

--- a/lib/view/pages/main_menu_items/about_page.dart
+++ b/lib/view/pages/main_menu_items/about_page.dart
@@ -1,5 +1,7 @@
+import 'package:cotacao_direta/util/currency_colors.dart';
 import 'package:cotacao_direta/util/localizations.dart';
 import 'package:cotacao_direta/util/responsive.dart';
+import 'package:cotacao_direta/view/widgets/bento_card.dart';
 import 'package:flutter/material.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -12,71 +14,133 @@ class AboutPage extends StatelessWidget {
   Widget build(BuildContext context) {
     final localization = MyAppLocalizations.of(context)!;
     final scale = Responsive.scaleFactor(context);
+    final colorScheme = Theme.of(context).colorScheme;
 
     return Center(
       child: ConstrainedBox(
-        constraints: BoxConstraints(maxWidth: Responsive.contentMaxWidth(context)),
+        constraints: BoxConstraints(
+          maxWidth: Responsive.contentMaxWidth(context),
+        ),
         child: SingleChildScrollView(
-          padding: EdgeInsets.all(24.0 * scale),
+          padding: EdgeInsets.all(16 * scale),
           child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
+            // O eixo transversal da Column é o horizontal, que aqui é
+            // limitado pela largura da tela: o stretch é seguro (diferente de
+            // uma Row dentro de um scroll, onde a altura é ilimitada).
+            crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              Icon(Icons.attach_money, size: 72 * scale, color: Colors.amber),
-              SizedBox(height: 16 * scale),
-              Text(
-                'Cotação Direta',
-                textAlign: TextAlign.center,
-                style: TextStyle(
-                  fontSize: 24 * scale,
-                  fontWeight: FontWeight.bold,
+              // Cartão de destaque, no mesmo espírito do cartão do dólar na
+              // tela inicial: é o "rosto" da tela.
+              BentoCard(
+                accentColor: CurrencyColors.usd,
+                radius: BentoRadius.hero,
+                padding: EdgeInsets.symmetric(
+                  horizontal: 20 * scale,
+                  vertical: 28 * scale,
+                ),
+                child: Column(
+                  children: [
+                    Icon(Icons.attach_money, size: 56 * scale),
+                    SizedBox(height: 12 * scale),
+                    Text(
+                      'Cotação Direta',
+                      textAlign: TextAlign.center,
+                      style: TextStyle(
+                        fontSize: 24 * scale,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    SizedBox(height: 4 * scale),
+                    FutureBuilder<PackageInfo>(
+                      future: PackageInfo.fromPlatform(),
+                      builder: (context, snapshot) {
+                        final info = snapshot.data;
+                        final version = info == null
+                            ? ''
+                            : '${info.version}+${info.buildNumber}';
+                        return Text(
+                          '${localization.aboutVersionLabel} $version',
+                          textAlign: TextAlign.center,
+                          style: TextStyle(fontSize: 14 * scale),
+                        );
+                      },
+                    ),
+                  ],
                 ),
               ),
-              SizedBox(height: 8 * scale),
-              FutureBuilder<PackageInfo>(
-                future: PackageInfo.fromPlatform(),
-                builder: (context, snapshot) {
-                  final info = snapshot.data;
-                  final version = info == null
-                      ? ''
-                      : '${info.version}+${info.buildNumber}';
-                  return Text(
-                    '${localization.aboutVersionLabel} $version',
-                    textAlign: TextAlign.center,
-                    style: TextStyle(fontSize: 14 * scale),
-                  );
-                },
+              SizedBox(height: 12 * scale),
+              BentoCard(
+                padding: EdgeInsets.all(20 * scale),
+                child: Text(
+                  localization.aboutAppDescription!,
+                  textAlign: TextAlign.center,
+                  style: TextStyle(fontSize: 16 * scale, height: 1.4),
+                ),
               ),
-              SizedBox(height: 24 * scale),
-              Text(
-                localization.aboutAppDescription!,
-                textAlign: TextAlign.center,
-                style: TextStyle(fontSize: 16 * scale),
+              SizedBox(height: 12 * scale),
+              BentoCard(
+                child: Row(
+                  children: [
+                    Icon(Icons.person_outline, size: 20 * scale),
+                    SizedBox(width: 12 * scale),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            localization.aboutDeveloperLabel!,
+                            style: TextStyle(
+                              fontSize: 12 * scale,
+                              color: colorScheme.onSurfaceVariant,
+                            ),
+                          ),
+                          Text(
+                            'hhldiniz',
+                            style: TextStyle(fontSize: 16 * scale),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
               ),
-              SizedBox(height: 24 * scale),
-              Text(
-                '${localization.aboutDeveloperLabel} hhldiniz',
-                textAlign: TextAlign.center,
-                style: TextStyle(fontSize: 14 * scale),
-              ),
-              SizedBox(height: 8 * scale),
-              Text(
-                '${localization.aboutSourceCodeLabel}:',
-                textAlign: TextAlign.center,
-                style: TextStyle(fontSize: 14 * scale),
-              ),
-              InkWell(
+              SizedBox(height: 12 * scale),
+              BentoCard(
                 onTap: () => launchUrl(
                   Uri.parse(_sourceCodeUrl),
                   mode: LaunchMode.externalApplication,
                 ),
-                child: Text(
-                  _sourceCodeUrl,
-                  textAlign: TextAlign.center,
-                  style: TextStyle(
-                    fontSize: 14 * scale,
-                    color: Theme.of(context).colorScheme.primary,
-                    decoration: TextDecoration.underline,
-                  ),
+                child: Row(
+                  children: [
+                    Icon(Icons.code, size: 20 * scale),
+                    SizedBox(width: 12 * scale),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            localization.aboutSourceCodeLabel!,
+                            style: TextStyle(
+                              fontSize: 12 * scale,
+                              color: colorScheme.onSurfaceVariant,
+                            ),
+                          ),
+                          Text(
+                            _sourceCodeUrl,
+                            style: TextStyle(
+                              fontSize: 14 * scale,
+                              color: colorScheme.primary,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    Icon(
+                      Icons.open_in_new,
+                      size: 18 * scale,
+                      color: colorScheme.outline,
+                    ),
+                  ],
                 ),
               ),
             ],

--- a/lib/view/pages/main_menu_items/configurations_page.dart
+++ b/lib/view/pages/main_menu_items/configurations_page.dart
@@ -1,11 +1,15 @@
 import 'package:cotacao_direta/blocs/configurations_page_bloc.dart';
 import 'package:cotacao_direta/enums/currency_enum.dart';
 import 'package:cotacao_direta/providers/configurations_page_bloc_provider.dart';
+import 'package:cotacao_direta/util/currency_colors.dart';
 import 'package:cotacao_direta/util/localizations.dart';
 import 'package:cotacao_direta/util/responsive.dart';
 import 'package:cotacao_direta/util/string_utils.dart';
-import 'package:cotacao_direta/view/widgets/widget_state_helpers/override_currency_state_helper.dart';
+import 'package:cotacao_direta/view/widgets/animated_list_entry.dart';
+import 'package:cotacao_direta/view/widgets/bento_card.dart';
 import 'package:flutter/material.dart';
+
+import 'package:cotacao_direta/view/widgets/widget_state_helpers/override_currency_state_helper.dart';
 
 class ConfigurationsPage extends StatelessWidget {
   @override
@@ -21,98 +25,161 @@ class ConfigurationsPage extends StatelessWidget {
     });
     var _localization = MyAppLocalizations.of(context)!;
     final _scale = Responsive.scaleFactor(context);
+    final _stream =
+        _bloc.overrideDefaultCurrencyValueStream
+            as Stream<OverrideCurrencyStateHelper>?;
+
     return Center(
       child: ConstrainedBox(
         constraints: BoxConstraints(
           maxWidth: Responsive.contentMaxWidth(context),
         ),
         child: ListView(
-          padding: EdgeInsets.symmetric(vertical: 16 * _scale),
+          padding: EdgeInsets.fromLTRB(
+            16 * _scale,
+            0,
+            16 * _scale,
+            24 * _scale,
+          ),
           children: [
-            Padding(
-              padding: EdgeInsets.symmetric(horizontal: 24 * _scale),
-              child: Text(
-                _localization.appConfigurationsSectionLabel!,
-                style: TextStyle(
-                  fontSize: 14 * _scale,
-                  fontWeight: FontWeight.bold,
-                  color: Theme.of(context).colorScheme.primary,
-                ),
+            BentoSectionTitle(_localization.appConfigurationsSectionLabel!),
+
+            // Cada opção vira um tile próprio, como na grade da tela inicial,
+            // em vez de linhas dentro de um cartão único.
+            AnimatedListEntry(
+              index: 0,
+              child: StreamBuilder<OverrideCurrencyStateHelper>(
+                stream: _stream,
+                initialData: _bloc.overrideCurrencyStateHelper,
+                builder: (BuildContext context, snapshot) {
+                  final enabled = snapshot.data!.enableCurrencyOverride;
+                  return BentoCard(
+                    padding: EdgeInsets.all(12 * _scale),
+                    // Tocar o cartão inteiro alterna a opção, como fazia o
+                    // SwitchListTile que estava aqui antes.
+                    onTap: () => _bloc.updateOverrideCurrencySwitch(!enabled),
+                    child: Row(
+                      children: [
+                        _SettingBadge(
+                          icon: Icons.swap_horiz,
+                          color: CurrencyColors.eur,
+                          scale: _scale,
+                        ),
+                        SizedBox(width: 14 * _scale),
+                        Expanded(
+                          child: Text(
+                            _localization.overrideDefaultCurrencySwitchLabel!,
+                            style: TextStyle(fontSize: 16 * _scale),
+                          ),
+                        ),
+                        Switch(
+                          value: enabled,
+                          onChanged: (bool checked) {
+                            _bloc.updateOverrideCurrencySwitch(checked);
+                          },
+                        ),
+                      ],
+                    ),
+                  );
+                },
               ),
             ),
-            SizedBox(height: 8 * _scale),
-            Card(
-              margin: EdgeInsets.symmetric(horizontal: 12 * _scale),
-              child: Column(
-                children: [
-                  StreamBuilder<OverrideCurrencyStateHelper>(
-                    builder: (BuildContext context, snapshot) {
-                      return SwitchListTile(
-                        value: snapshot.data!.enableCurrencyOverride,
-                        onChanged: (bool checked) {
-                          _bloc.updateOverrideCurrencySwitch(checked);
-                        },
-                        title: Text(
-                          _localization.overrideDefaultCurrencySwitchLabel!,
-                          style: TextStyle(fontSize: 16 * _scale),
-                        ),
-                      );
-                    },
-                    stream:
-                        _bloc.overrideDefaultCurrencyValueStream
-                            as Stream<OverrideCurrencyStateHelper>?,
-                    initialData: _bloc.overrideCurrencyStateHelper,
-                  ),
-                  const Divider(height: 1),
-                  StreamBuilder<OverrideCurrencyStateHelper>(
-                    builder: (BuildContext context, switchSnapshot) {
-                      final _enabled =
-                          switchSnapshot.data!.enableCurrencyOverride == true;
-                      return ListTile(
-                        enabled: _enabled,
-                        leading: const Icon(Icons.attach_money),
-                        title: Text(
-                          _localization.selectedOverrideCurrencyLabel!,
-                          style: TextStyle(fontSize: 16 * _scale),
-                        ),
-                        trailing: DropdownButton(
-                          items: List.generate(
-                            _currencyList.length,
-                            (index) => DropdownMenuItem(
-                              value: _currencyList[index],
-                              child: Text(
-                                _currencyList[index],
-                                style: TextStyle(fontSize: 16 * _scale),
-                              ),
+            SizedBox(height: 12 * _scale),
+
+            AnimatedListEntry(
+              index: 1,
+              child: StreamBuilder<OverrideCurrencyStateHelper>(
+                stream: _stream,
+                initialData: _bloc.overrideCurrencyStateHelper,
+                builder: (BuildContext context, switchSnapshot) {
+                  final _enabled =
+                      switchSnapshot.data!.enableCurrencyOverride == true;
+                  final selected =
+                      switchSnapshot.data!.selectedCurrencyOverride!.isEmpty
+                      ? _currencyList[0]
+                      : switchSnapshot.data!.selectedCurrencyOverride;
+                  // Sem o override ligado o seletor não faz nada; deixá-lo
+                  // esmaecido comunica isso antes do toque.
+                  return Opacity(
+                    opacity: _enabled ? 1.0 : 0.45,
+                    child: BentoCard(
+                      padding: EdgeInsets.all(12 * _scale),
+                      child: Row(
+                        children: [
+                          _SettingBadge(
+                            icon: Icons.attach_money,
+                            color: CurrencyColors.usd,
+                            scale: _scale,
+                          ),
+                          SizedBox(width: 14 * _scale),
+                          Expanded(
+                            child: Text(
+                              _localization.selectedOverrideCurrencyLabel!,
+                              style: TextStyle(fontSize: 16 * _scale),
                             ),
                           ),
-                          onChanged: _enabled
-                              ? (dynamic value) {
-                                  _bloc.updateSelectedOverrideCurrency(value);
-                                }
-                              : null,
-                          value:
-                              switchSnapshot
-                                  .data!
-                                  .selectedCurrencyOverride!
-                                  .isEmpty
-                              ? _currencyList[0]
-                              : switchSnapshot.data!.selectedCurrencyOverride,
-                          iconSize: 24 * _scale,
-                        ),
-                      );
-                    },
-                    stream:
-                        _bloc.overrideDefaultCurrencyValueStream
-                            as Stream<OverrideCurrencyStateHelper>?,
-                    initialData: _bloc.overrideCurrencyStateHelper,
-                  ),
-                ],
+                          DropdownButton(
+                            items: List.generate(
+                              _currencyList.length,
+                              (index) => DropdownMenuItem(
+                                value: _currencyList[index],
+                                child: Text(
+                                  _currencyList[index],
+                                  style: TextStyle(fontSize: 16 * _scale),
+                                ),
+                              ),
+                            ),
+                            onChanged: _enabled
+                                ? (dynamic value) {
+                                    _bloc.updateSelectedOverrideCurrency(value);
+                                  }
+                                : null,
+                            value: selected,
+                            iconSize: 24 * _scale,
+                            underline: const SizedBox.shrink(),
+                            borderRadius: BorderRadius.circular(
+                              BentoRadius.standard,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  );
+                },
               ),
             ),
           ],
         ),
       ),
+    );
+  }
+}
+
+/// Quadradinho colorido com o ícone da opção, o mesmo recurso visual que dá
+/// identidade aos cartões de moeda da tela inicial.
+class _SettingBadge extends StatelessWidget {
+  final IconData icon;
+  final Color color;
+  final double scale;
+
+  const _SettingBadge({
+    required this.icon,
+    required this.color,
+    required this.scale,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final size = 42.0 * scale;
+    return Container(
+      width: size,
+      height: size,
+      alignment: Alignment.center,
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.18),
+        borderRadius: BorderRadius.circular(14 * scale),
+      ),
+      child: Icon(icon, color: color, size: 22 * scale),
     );
   }
 }

--- a/lib/view/pages/main_menu_items/currency_alerts_page.dart
+++ b/lib/view/pages/main_menu_items/currency_alerts_page.dart
@@ -6,6 +6,8 @@ import 'package:cotacao_direta/providers/currency_alerts_bloc_provider.dart';
 import 'package:cotacao_direta/util/localizations.dart';
 import 'package:cotacao_direta/util/responsive.dart';
 import 'package:cotacao_direta/util/string_utils.dart';
+import 'package:cotacao_direta/view/widgets/animated_list_entry.dart';
+import 'package:cotacao_direta/view/widgets/bento_card.dart';
 import 'package:flutter/material.dart';
 
 class CurrencyAlertsPage extends StatefulWidget {
@@ -32,6 +34,8 @@ class _CurrencyAlertsPageState extends State<CurrencyAlertsPage> {
 
     return Scaffold(
       floatingActionButton: FloatingActionButton.extended(
+        // Ver a nota no FAB da home: as duas telas coexistem no IndexedStack.
+        heroTag: "addCurrencyAlertFab",
         onPressed: () =>
             _showAddAlertDialog(context, _bloc, _localization, _currencyList),
         label: Text(_localization.addCurrencyAlertBtnLabel!),
@@ -46,52 +50,82 @@ class _CurrencyAlertsPageState extends State<CurrencyAlertsPage> {
             builder: (context, snapshot) {
               var alerts = snapshot.data ?? [];
               if (alerts.isEmpty) {
-                return Center(
-                  child: Padding(
-                    padding: EdgeInsets.all(24 * _scale),
-                    child: Text(
-                      _localization.currencyAlertEmptyListLabel!,
-                      style: TextStyle(fontSize: 16 * _scale),
-                      textAlign: TextAlign.center,
-                    ),
-                  ),
-                );
+                return _emptyState(context, _localization, _scale);
               }
-              return ListView(
-                padding: EdgeInsets.symmetric(vertical: 16 * _scale),
-                children: [
-                  Padding(
-                    padding: EdgeInsets.symmetric(horizontal: 24 * _scale),
-                    child: Text(
+              return ListView.builder(
+                padding: EdgeInsets.fromLTRB(
+                  16 * _scale,
+                  0,
+                  16 * _scale,
+                  // Espaço para o FAB não cobrir o último alerta.
+                  96 * _scale,
+                ),
+                itemCount: alerts.length + 1,
+                itemBuilder: (context, index) {
+                  if (index == 0) {
+                    return BentoSectionTitle(
                       _localization.currencyAlertsSectionLabel!,
-                      style: TextStyle(
-                        fontSize: 14 * _scale,
-                        fontWeight: FontWeight.bold,
-                        color: Theme.of(context).colorScheme.primary,
+                    );
+                  }
+                  final alert = alerts[index - 1];
+                  return AnimatedListEntry(
+                    index: index,
+                    child: Padding(
+                      padding: EdgeInsets.only(bottom: 10 * _scale),
+                      child: _AlertCard(
+                        alert: alert,
+                        localization: _localization,
+                        scale: _scale,
+                        onDelete: () => _bloc.deleteAlert(alert.id!),
                       ),
                     ),
-                  ),
-                  SizedBox(height: 8 * _scale),
-                  Card(
-                    margin: EdgeInsets.symmetric(horizontal: 12 * _scale),
-                    child: Column(
-                      children: [
-                        for (var index = 0; index < alerts.length; index++) ...[
-                          if (index > 0) const Divider(height: 1),
-                          _AlertListTile(
-                            alert: alerts[index],
-                            localization: _localization,
-                            scale: _scale,
-                            onDelete: () => _bloc.deleteAlert(alerts[index].id!),
-                          ),
-                        ],
-                      ],
-                    ),
-                  ),
-                ],
+                  );
+                },
               );
             },
           ),
+        ),
+      ),
+    );
+  }
+
+  Widget _emptyState(
+    BuildContext context,
+    MyAppLocalizations localization,
+    double scale,
+  ) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Center(
+      child: Padding(
+        padding: EdgeInsets.all(24 * scale),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              width: 72 * scale,
+              height: 72 * scale,
+              alignment: Alignment.center,
+              decoration: BoxDecoration(
+                color: colorScheme.primary.withValues(alpha: 0.14),
+                borderRadius: BorderRadius.circular(24 * scale),
+              ),
+              child: Icon(
+                Icons.notifications_none,
+                size: 36 * scale,
+                color: colorScheme.primary,
+              ),
+            ),
+            SizedBox(height: 16 * scale),
+            Text(
+              localization.currencyAlertEmptyListLabel!,
+              style: TextStyle(
+                fontSize: 16 * scale,
+                color: colorScheme.onSurfaceVariant,
+                height: 1.4,
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ],
         ),
       ),
     );
@@ -109,6 +143,9 @@ class _CurrencyAlertsPageState extends State<CurrencyAlertsPage> {
       builder: (dialogContext) {
         return StatefulBuilder(builder: (dialogContext, setState) {
           return AlertDialog(
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(BentoRadius.hero),
+            ),
             title: Text(localization.addCurrencyAlertDialogTitle!),
             content: SingleChildScrollView(
               child: Column(
@@ -157,6 +194,10 @@ class _CurrencyAlertsPageState extends State<CurrencyAlertsPage> {
                     decoration: InputDecoration(
                       labelText: localization.currencyAlertTargetValueLabel,
                       errorText: errorText,
+                      border: OutlineInputBorder(
+                        borderRadius:
+                            BorderRadius.circular(BentoRadius.standard),
+                      ),
                     ),
                   ),
                 ],
@@ -190,13 +231,13 @@ class _CurrencyAlertsPageState extends State<CurrencyAlertsPage> {
   }
 }
 
-class _AlertListTile extends StatelessWidget {
+class _AlertCard extends StatelessWidget {
   final CurrencyAlert alert;
   final MyAppLocalizations localization;
   final double scale;
   final VoidCallback onDelete;
 
-  const _AlertListTile({
+  const _AlertCard({
     required this.alert,
     required this.localization,
     required this.scale,
@@ -205,27 +246,80 @@ class _AlertListTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
     var conditionLabel = alert.condition == CurrencyAlertCondition.above
         ? localization.currencyAlertConditionAbove!
         : localization.currencyAlertConditionBelow!;
     var statusLabel = alert.triggered
         ? localization.currencyAlertTriggeredLabel!
         : localization.currencyAlertActiveLabel!;
+    // Disparado ganha destaque em verde; aguardando fica na cor neutra do
+    // tema, para o olho ir direto no que já aconteceu.
+    final statusColor =
+        alert.triggered ? const Color(0xFF2E9E5B) : colorScheme.outline;
 
-    return ListTile(
-      leading: Icon(
-        alert.triggered ? Icons.notifications_active : Icons.notifications_none,
-        color: alert.triggered ? Colors.green : null,
-      ),
-      title: Text(
-        "${alert.currencyCode} $conditionLabel ${alert.targetValue.toStringAsFixed(4)}",
-        style: TextStyle(fontSize: 16 * scale),
-      ),
-      subtitle: Text(statusLabel, style: TextStyle(fontSize: 12 * scale)),
-      trailing: IconButton(
-        icon: const Icon(Icons.delete_outline),
-        tooltip: localization.currencyAlertDeleteTooltip,
-        onPressed: onDelete,
+    return BentoCard(
+      padding: EdgeInsets.all(12 * scale),
+      child: Row(
+        children: [
+          Container(
+            width: 42 * scale,
+            height: 42 * scale,
+            alignment: Alignment.center,
+            decoration: BoxDecoration(
+              color: statusColor.withValues(alpha: 0.18),
+              borderRadius: BorderRadius.circular(14 * scale),
+            ),
+            child: Icon(
+              alert.triggered
+                  ? Icons.notifications_active
+                  : Icons.notifications_none,
+              color: statusColor,
+              size: 22 * scale,
+            ),
+          ),
+          SizedBox(width: 14 * scale),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  "${alert.currencyCode} $conditionLabel "
+                  "${alert.targetValue.toStringAsFixed(4)}",
+                  style: TextStyle(
+                    fontSize: 15 * scale,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                SizedBox(height: 4 * scale),
+                // Pílula de status, no lugar do subtítulo solto.
+                Container(
+                  padding: EdgeInsets.symmetric(
+                    horizontal: 8 * scale,
+                    vertical: 2 * scale,
+                  ),
+                  decoration: BoxDecoration(
+                    color: statusColor.withValues(alpha: 0.16),
+                    borderRadius: BorderRadius.circular(20),
+                  ),
+                  child: Text(
+                    statusLabel,
+                    style: TextStyle(
+                      fontSize: 11 * scale,
+                      color: statusColor,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          IconButton(
+            icon: const Icon(Icons.delete_outline),
+            tooltip: localization.currencyAlertDeleteTooltip,
+            onPressed: onDelete,
+          ),
+        ],
       ),
     );
   }

--- a/lib/view/pages/main_menu_items/currency_history_menu.dart
+++ b/lib/view/pages/main_menu_items/currency_history_menu.dart
@@ -4,12 +4,14 @@ import 'package:cotacao_direta/enums/currency_enum.dart';
 import 'package:cotacao_direta/providers/currency_history_menu_bloc_provider.dart';
 import 'package:cotacao_direta/providers/selected_currency_details_bloc_provider.dart';
 import 'package:cotacao_direta/util/cryptocurrency_info.dart';
+import 'package:cotacao_direta/util/currency_colors.dart';
 import 'package:cotacao_direta/util/currency_flag.dart';
 import 'package:cotacao_direta/util/localizations.dart';
 import 'package:cotacao_direta/util/responsive.dart';
 import 'package:cotacao_direta/util/string_utils.dart';
 import 'package:cotacao_direta/view/pages/selected_currency_details.dart';
 import 'package:cotacao_direta/view/widgets/animated_list_entry.dart';
+import 'package:cotacao_direta/view/widgets/bento_card.dart';
 import 'package:flag/flag.dart';
 import 'package:flutter/material.dart';
 
@@ -69,101 +71,117 @@ class CurrencyHistory extends StatelessWidget {
           _SectionEntry(localizations.currencyHistoryCurrenciesSectionLabel!),
           ..._currencies.map((currency) => _CurrencyEntry(currency)),
           _SectionEntry(
-              localizations.currencyHistoryCryptocurrenciesSectionLabel!),
-          ...Cryptocurrencies.values
-              .map((cryptocurrency) => _CryptocurrencyEntry(cryptocurrency)),
+            localizations.currencyHistoryCryptocurrenciesSectionLabel!,
+          ),
+          ...Cryptocurrencies.values.map(
+            (cryptocurrency) => _CryptocurrencyEntry(cryptocurrency),
+          ),
         ];
 
-        return ListView.separated(
-          separatorBuilder: (BuildContext context, index) {
-            // O título de seção já se separa do que vem antes pelo próprio
-            // espaçamento; um divisor aí faria a seção parecer parte da lista
-            // anterior.
-            if (_entries[index + 1] is _SectionEntry)
-              return const SizedBox.shrink();
-            return const Divider(height: 1, thickness: 1);
-          },
-          itemBuilder: (BuildContext context, index) {
-            final entry = _entries[index];
-            return AnimatedListEntry(
-              index: index,
-              child: switch (entry) {
-                _SectionEntry() => _sectionTitle(context, entry.label, _scale),
-                _CurrencyEntry() =>
-                  _currencyTile(context, bloc, entry.currency, _scale),
-                _CryptocurrencyEntry() =>
-                  _cryptocurrencyTile(context, entry.cryptocurrency, _scale),
+        return Center(
+          child: ConstrainedBox(
+            constraints: BoxConstraints(
+              maxWidth: Responsive.contentMaxWidth(context),
+            ),
+            child: ListView.builder(
+              padding: EdgeInsets.fromLTRB(
+                16 * _scale,
+                0,
+                16 * _scale,
+                24 * _scale,
+              ),
+              itemBuilder: (BuildContext context, index) {
+                final entry = _entries[index];
+                return AnimatedListEntry(
+                  index: index,
+                  child: switch (entry) {
+                    _SectionEntry() => BentoSectionTitle(entry.label),
+                    _CurrencyEntry() => Padding(
+                      padding: EdgeInsets.only(bottom: 10 * _scale),
+                      child: _currencyTile(context, bloc, entry.currency, _scale),
+                    ),
+                    _CryptocurrencyEntry() => Padding(
+                      padding: EdgeInsets.only(bottom: 10 * _scale),
+                      child: _cryptocurrencyTile(
+                        context,
+                        entry.cryptocurrency,
+                        _scale,
+                      ),
+                    ),
+                  },
+                );
               },
-            );
-          },
-          itemCount: _entries.length,
+              itemCount: _entries.length,
+            ),
+          ),
         );
       },
     );
   }
 
-  Widget _sectionTitle(BuildContext context, String label, double scale) {
-    return Padding(
-      padding:
-          EdgeInsets.fromLTRB(16 * scale, 20 * scale, 16 * scale, 8 * scale),
-      child: Text(
-        label,
-        style: TextStyle(
-          fontSize: 14 * scale,
-          fontWeight: FontWeight.bold,
-          color: Theme.of(context).colorScheme.primary,
-        ),
-      ),
-    );
-  }
-
-  Widget _currencyTile(BuildContext context, CurrencyHistoryMenuBloc bloc,
-      Currencies currency, double scale) {
+  Widget _currencyTile(
+    BuildContext context,
+    CurrencyHistoryMenuBloc bloc,
+    Currencies currency,
+    double scale,
+  ) {
     final currencyCode = _codeOf(currency);
     return _quoteTile(
       context,
       currencyCode: currencyCode,
       scale: scale,
-      badge: Flag.fromCode(
-        flagCodeForCurrency(currency),
-        height: 24 * scale,
-        width: 32 * scale,
+      accent: CurrencyColors.eur,
+      badge: ClipRRect(
+        borderRadius: BorderRadius.circular(6 * scale),
+        child: Flag.fromCode(
+          flagCodeForCurrency(currency),
+          height: 24 * scale,
+          width: 32 * scale,
+        ),
       ),
       subtitle: StreamBuilder<String?>(
         initialData: bloc.cachedCountryName(currencyCode),
         stream: bloc.getCountryNameController(currencyCode),
         builder: (context, snapshot) {
           bloc.getCountryNameByCurrencyCode(currencyCode);
-          return Text(
-            snapshot.data ?? "",
-            style: TextStyle(fontSize: 14 * scale),
-          );
+          return _subtitleText(context, snapshot.data ?? "", scale);
         },
       ),
     );
   }
 
   Widget _cryptocurrencyTile(
-      BuildContext context, Cryptocurrencies cryptocurrency, double scale) {
+    BuildContext context,
+    Cryptocurrencies cryptocurrency,
+    double scale,
+  ) {
     return _quoteTile(
       context,
       currencyCode: _codeOf(cryptocurrency),
       scale: scale,
-      // Mesmas dimensões da bandeira das moedas fiduciárias, para os códigos
-      // ficarem alinhados entre as duas seções.
-      badge: SizedBox(
-        height: 24 * scale,
-        width: 32 * scale,
-        child: Icon(
-          iconForCryptocurrency(cryptocurrency),
-          size: 22 * scale,
-          color: Theme.of(context).colorScheme.primary,
-        ),
+      accent: CurrencyColors.usd,
+      badge: Icon(
+        iconForCryptocurrency(cryptocurrency),
+        size: 22 * scale,
+        color: CurrencyColors.usd,
       ),
-      subtitle: Text(
+      subtitle: _subtitleText(
+        context,
         cryptocurrencyName(cryptocurrency),
-        style: TextStyle(fontSize: 14 * scale),
+        scale,
       ),
+    );
+  }
+
+  Widget _subtitleText(BuildContext context, String text, double scale) {
+    return Text(
+      text,
+      style: TextStyle(
+        fontSize: 13 * scale,
+        color: Theme.of(context).colorScheme.onSurfaceVariant,
+      ),
+      overflow: TextOverflow.ellipsis,
+      maxLines: 1,
     );
   }
 
@@ -172,28 +190,11 @@ class CurrencyHistory extends StatelessWidget {
     required String currencyCode,
     required Widget badge,
     required Widget subtitle,
+    required Color accent,
     required double scale,
   }) {
-    return GestureDetector(
-      child: ListTile(
-        title: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          crossAxisAlignment: CrossAxisAlignment.center,
-          children: [
-            Text(
-              currencyCode,
-              style: TextStyle(fontSize: 16 * scale),
-            ),
-            badge,
-          ],
-        ),
-        subtitle: subtitle,
-        trailing: Icon(
-          Icons.chevron_right,
-          size: 20 * scale,
-          color: Theme.of(context).colorScheme.outline,
-        ),
-      ),
+    return BentoCard(
+      padding: EdgeInsets.all(12 * scale),
       onTap: () {
         Navigator.push(
           context,
@@ -206,6 +207,43 @@ class CurrencyHistory extends StatelessWidget {
           ),
         );
       },
+      child: Row(
+        children: [
+          // Bandeira e ícone ganham a mesma moldura colorida, para os dois
+          // tipos de ativo ficarem alinhados e com o mesmo peso visual.
+          Container(
+            width: 46 * scale,
+            height: 40 * scale,
+            alignment: Alignment.center,
+            decoration: BoxDecoration(
+              color: accent.withValues(alpha: 0.18),
+              borderRadius: BorderRadius.circular(12 * scale),
+            ),
+            child: badge,
+          ),
+          SizedBox(width: 14 * scale),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  currencyCode,
+                  style: TextStyle(
+                    fontSize: 16 * scale,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                subtitle,
+              ],
+            ),
+          ),
+          Icon(
+            Icons.chevron_right,
+            size: 20 * scale,
+            color: Theme.of(context).colorScheme.outline,
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/view/pages/selected_currency_details.dart
+++ b/lib/view/pages/selected_currency_details.dart
@@ -2,6 +2,7 @@ import 'package:cotacao_direta/model/currency.dart';
 import 'package:cotacao_direta/providers/selected_currency_details_bloc_provider.dart';
 import 'package:cotacao_direta/util/localizations.dart';
 import 'package:cotacao_direta/util/responsive.dart';
+import 'package:cotacao_direta/view/widgets/bento_card.dart';
 import 'package:cotacao_direta/view/widgets/charts.dart';
 import 'package:flutter/material.dart';
 
@@ -16,142 +17,179 @@ class SelectedCurrencyDetails extends StatelessWidget {
     final localizations = MyAppLocalizations.of(context)!;
     var bloc = SelectedCurrencyDetailsBlocProvider.of(context);
     final _contentWidth = Responsive.contentMaxWidth(context);
+    final _scale = Responsive.scaleFactor(context);
 
     return Scaffold(
       appBar: AppBar(title: Text(selectedCurrencyCode)),
       floatingActionButton: FloatingActionButton.extended(
+        // Esta tela abre em rota própria, mas a tag explícita evita o mesmo
+        // conflito caso ela passe a ser embutida em outra tela.
+        heroTag: "currencyHistoryFab",
         onPressed: () {
           bloc.getCurrencyHistoryData(selectedCurrencyCode);
         },
+        icon: const Icon(Icons.query_stats),
         label: Text(localizations.getCurrencyHistoryBtnLabel!),
       ),
       body: Center(
         child: ConstrainedBox(
           constraints: BoxConstraints(maxWidth: _contentWidth),
-          child: Column(
-            children: [
-              Row(
-                children: [
-                  Column(
+          child: Padding(
+            padding: EdgeInsets.fromLTRB(
+              16 * _scale,
+              12 * _scale,
+              16 * _scale,
+              16 * _scale,
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                // Os dois seletores de data moram no mesmo cartão: são um
+                // controle só, o intervalo do gráfico.
+                BentoCard(
+                  padding: EdgeInsets.all(12 * _scale),
+                  child: Row(
                     children: [
-                      Container(
-                        width: _contentWidth / 2,
-                        child: Padding(
-                          padding: EdgeInsets.all(8.0),
-                          child: TextField(
-                            controller: bloc.initialDateController,
-                            onTap: () {
-                              FocusScope.of(context).requestFocus(FocusNode());
-                              showDatePicker(
-                                context: context,
-                                initialDate: DateTime.now(),
-                                firstDate: DateTime(1999),
-                                lastDate: DateTime.now(),
-                              ).then((value) {
-                                if (value != null)
-                                  bloc.updateInitialDate(value);
-                              });
-                            },
-                            decoration: InputDecoration(
-                              border: OutlineInputBorder(),
-                              labelText:
-                                  localizations.currencyHistoryFromDateLabel,
-                            ),
-                          ),
+                      Expanded(
+                        child: _dateField(
+                          context,
+                          controller: bloc.initialDateController,
+                          label: localizations.currencyHistoryFromDateLabel!,
+                          scale: _scale,
+                          onPicked: bloc.updateInitialDate,
+                        ),
+                      ),
+                      SizedBox(width: 12 * _scale),
+                      Expanded(
+                        child: _dateField(
+                          context,
+                          controller: bloc.endDateController,
+                          label: localizations.currencyHistoryToDateLabel!,
+                          scale: _scale,
+                          onPicked: bloc.updateFinalDate,
                         ),
                       ),
                     ],
                   ),
-                  Column(
-                    children: [
-                      Container(
-                        width: _contentWidth / 2,
-                        child: Padding(
-                          padding: EdgeInsets.all(8.0),
-                          child: TextField(
-                            controller: bloc.endDateController,
-                            onTap: () {
-                              FocusScope.of(context).requestFocus(FocusNode());
-                              showDatePicker(
-                                context: context,
-                                initialDate: DateTime.now(),
-                                firstDate: DateTime(1999),
-                                lastDate: DateTime.now(),
-                              ).then((value) {
-                                if (value != null) bloc.updateFinalDate(value);
-                              });
-                            },
-                            decoration: InputDecoration(
-                              border: OutlineInputBorder(),
-                              labelText:
-                                  localizations.currencyHistoryToDateLabel,
-                            ),
-                          ),
-                        ),
-                      ),
-                    ],
-                  ),
-                ],
-              ),
-              Expanded(
-                child: Stack(
-                  children: [
-                    StreamBuilder<List<Currency>>(
-                      stream: bloc.currencyHistoryStream,
-                      builder: (context, snapshot) {
-                        final currencyList = snapshot.data;
-                        if (currencyList == null || currencyList.isEmpty) {
-                          return Center(
-                            child: Padding(
-                              padding: const EdgeInsets.all(24.0),
-                              child: Column(
-                                mainAxisSize: MainAxisSize.min,
-                                children: [
-                                  Icon(
-                                    Icons.show_chart,
-                                    size: 48,
-                                    color: Theme.of(
-                                      context,
-                                    ).colorScheme.outline,
-                                  ),
-                                  const SizedBox(height: 12),
-                                  Text(
-                                    localizations.noDataLabel!,
-                                    textAlign: TextAlign.center,
-                                    style: TextStyle(
-                                      color: Theme.of(
-                                        context,
-                                      ).colorScheme.outline,
-                                    ),
-                                  ),
-                                ],
-                              ),
-                            ),
-                          );
-                        }
-                        return Padding(
-                          padding: const EdgeInsets.fromLTRB(8, 24, 24, 8),
-                          child: SimpleLineChart(currencyList: currencyList),
-                        );
-                      },
-                    ),
-                    StreamBuilder<bool>(
-                      stream: bloc.isLoadingStream,
-                      initialData: false,
-                      builder: (context, loadingSnapshot) {
-                        if (loadingSnapshot.data == true) {
-                          return const Center(
-                            child: CircularProgressIndicator(),
-                          );
-                        }
-                        return const SizedBox.shrink();
-                      },
-                    ),
-                  ],
                 ),
-              ),
-            ],
+                SizedBox(height: 12 * _scale),
+                Expanded(
+                  child: BentoCard(
+                    padding: EdgeInsets.fromLTRB(
+                      4 * _scale,
+                      20 * _scale,
+                      16 * _scale,
+                      8 * _scale,
+                    ),
+                    child: Stack(
+                      children: [
+                        StreamBuilder<List<Currency>>(
+                          stream: bloc.currencyHistoryStream,
+                          builder: (context, snapshot) {
+                            final currencyList = snapshot.data;
+                            if (currencyList == null || currencyList.isEmpty) {
+                              return _emptyChartState(
+                                context,
+                                localizations,
+                                _scale,
+                              );
+                            }
+                            return SimpleLineChart(currencyList: currencyList);
+                          },
+                        ),
+                        StreamBuilder<bool>(
+                          stream: bloc.isLoadingStream,
+                          initialData: false,
+                          builder: (context, loadingSnapshot) {
+                            if (loadingSnapshot.data == true) {
+                              return const Center(
+                                child: CircularProgressIndicator(),
+                              );
+                            }
+                            return const SizedBox.shrink();
+                          },
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+            ),
           ),
+        ),
+      ),
+    );
+  }
+
+  Widget _dateField(
+    BuildContext context, {
+    required TextEditingController controller,
+    required String label,
+    required double scale,
+    required void Function(DateTime) onPicked,
+  }) {
+    return TextField(
+      controller: controller,
+      style: TextStyle(fontSize: 14 * scale),
+      onTap: () {
+        // Tira o foco para o teclado não subir: a data vem do seletor.
+        FocusScope.of(context).requestFocus(FocusNode());
+        showDatePicker(
+          context: context,
+          initialDate: DateTime.now(),
+          firstDate: DateTime(1999),
+          lastDate: DateTime.now(),
+        ).then((value) {
+          if (value != null) onPicked(value);
+        });
+      },
+      decoration: InputDecoration(
+        isDense: true,
+        labelText: label,
+        prefixIcon: Icon(Icons.calendar_today, size: 18 * scale),
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(BentoRadius.standard),
+        ),
+      ),
+    );
+  }
+
+  Widget _emptyChartState(
+    BuildContext context,
+    MyAppLocalizations localizations,
+    double scale,
+  ) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Center(
+      child: Padding(
+        padding: EdgeInsets.all(24 * scale),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              width: 72 * scale,
+              height: 72 * scale,
+              alignment: Alignment.center,
+              decoration: BoxDecoration(
+                color: colorScheme.primary.withValues(alpha: 0.14),
+                borderRadius: BorderRadius.circular(24 * scale),
+              ),
+              child: Icon(
+                Icons.show_chart,
+                size: 36 * scale,
+                color: colorScheme.primary,
+              ),
+            ),
+            SizedBox(height: 16 * scale),
+            Text(
+              localizations.noDataLabel!,
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontSize: 15 * scale,
+                color: colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ],
         ),
       ),
     );

--- a/lib/view/widgets/bento_card.dart
+++ b/lib/view/widgets/bento_card.dart
@@ -1,0 +1,162 @@
+import 'package:cotacao_direta/util/color_utils.dart';
+import 'package:cotacao_direta/util/responsive.dart';
+import 'package:flutter/material.dart';
+
+/// Raios usados pelos cartões do app, para que todas as telas terminem com o
+/// mesmo arredondamento da grade da tela inicial.
+class BentoRadius {
+  BentoRadius._();
+
+  /// Cartão de destaque (o maior da grade).
+  static const hero = 24.0;
+
+  /// Cartão comum.
+  static const standard = 18.0;
+}
+
+/// Título de seção no estilo da tela inicial: texto curto, em maiúscula de
+/// frase, na cor primária do tema.
+class BentoSectionTitle extends StatelessWidget {
+  final String label;
+
+  const BentoSectionTitle(this.label, {super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final scale = Responsive.scaleFactor(context);
+    return Padding(
+      padding: EdgeInsets.fromLTRB(
+        24 * scale,
+        20 * scale,
+        24 * scale,
+        8 * scale,
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          fontSize: 14 * scale,
+          fontWeight: FontWeight.w600,
+          color: Theme.of(context).colorScheme.primary,
+        ),
+      ),
+    );
+  }
+}
+
+/// Cartão arredondado usado em todas as telas, no mesmo estilo dos cartões de
+/// cotação da tela inicial.
+///
+/// Sem [accentColor] o cartão usa uma superfície neutra do tema, adequada para
+/// conteúdo denso (listas, formulários). Com [accentColor] ele ganha o fundo
+/// colorido e a sombra tingida dos cartões de moeda — reservado para destaques,
+/// para a cor não virar ruído.
+///
+/// Quando [onTap] é informado, o cartão encolhe levemente ao toque, o mesmo
+/// retorno tátil dos cartões da grade.
+class BentoCard extends StatefulWidget {
+  final Widget child;
+
+  /// Cor de destaque. Nulo = superfície neutra do tema.
+  final Color? accentColor;
+
+  final EdgeInsetsGeometry? padding;
+  final double radius;
+  final VoidCallback? onTap;
+
+  const BentoCard({
+    super.key,
+    required this.child,
+    this.accentColor,
+    this.padding,
+    this.radius = BentoRadius.standard,
+    this.onTap,
+  });
+
+  @override
+  State<BentoCard> createState() => _BentoCardState();
+}
+
+class _BentoCardState extends State<BentoCard> {
+  bool _pressed = false;
+
+  void _setPressed(bool pressed) {
+    if (_pressed == pressed || widget.onTap == null) return;
+    setState(() => _pressed = pressed);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final scale = Responsive.scaleFactor(context);
+    final colorScheme = Theme.of(context).colorScheme;
+    final accent = widget.accentColor;
+    final backgroundColor = accent == null
+        ? colorScheme.surfaceContainerHighest
+        : circleBackgroundColor(context, accent);
+
+    final borderRadius = BorderRadius.circular(widget.radius);
+
+    Widget content = Padding(
+      padding: widget.padding ?? EdgeInsets.all(16 * scale),
+      child: _wrapContent(backgroundColor),
+    );
+
+    if (widget.onTap != null) {
+      content = InkWell(
+        onTap: widget.onTap,
+        // Acompanha o estado de pressionado do próprio Ink, para o cartão
+        // encolher junto com o splash.
+        onHighlightChanged: _setPressed,
+        child: content,
+      );
+    }
+
+    // O cartão precisa ser um Material de verdade, e não só um contêiner
+    // decorado: ListTile, SwitchListTile e InkWell pintam fundo e splash no
+    // Material mais próximo. Com um DecoratedBox no meio, eles pintariam no
+    // Material de trás e esconderiam a cor do cartão.
+    Widget card = Material(
+      color: backgroundColor,
+      borderRadius: borderRadius,
+      clipBehavior: Clip.antiAlias,
+      child: content,
+    );
+
+    // A sombra tingida fica fora do Material, para não ser recortada por ele.
+    if (accent != null) {
+      card = DecoratedBox(
+        decoration: BoxDecoration(
+          borderRadius: borderRadius,
+          boxShadow: [
+            BoxShadow(
+              color: accent.withValues(alpha: 0.35),
+              blurRadius: _pressed ? 4 : 12,
+              offset: Offset(0, _pressed ? 1 : 6),
+            ),
+          ],
+        ),
+        child: card,
+      );
+    }
+
+    return AnimatedScale(
+      scale: _pressed ? 0.97 : 1.0,
+      duration: const Duration(milliseconds: 120),
+      curve: Curves.easeOut,
+      child: card,
+    );
+  }
+
+  /// Em cartões com destaque, o conteúdo herda a cor de texto que contrasta
+  /// com o fundo colorido; sem destaque, segue as cores normais do tema.
+  Widget _wrapContent(Color backgroundColor) {
+    if (widget.accentColor == null) return widget.child;
+    final contentColor = contrastingTextColor(backgroundColor);
+    return DefaultTextStyle.merge(
+      style: TextStyle(color: contentColor),
+      child: IconTheme.merge(
+        data: IconThemeData(color: contentColor),
+        child: widget.child,
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Introduce a shared BentoCard so the styling of the home screen's grid lives in one place instead of being copied per screen. It renders as a real Material, not just a decorated container, because ListTile and InkWell paint their background and splashes onto the nearest Material ancestor and would otherwise hide the card entirely. It exposes an optional accent colour for highlight cards, deriving a contrasting content colour so text stays readable in both themes, plus the shared BentoSectionTitle and BentoRadius values.

Rework the five screens that still used default Material surfaces:

- Settings: each option becomes its own tile with a tinted icon badge and a staggered entrance, instead of two rows sharing one card. The switch row keeps its tap-anywhere behaviour and the currency selector dims while the override is off.
- About: a highlighted header card with the icon, name and version, followed by separate cards for the description, the author and the source link, the last one tappable.
- History: every currency and cryptocurrency is a tappable card with a tinted badge around its flag or icon, replacing the divided list.
- Alerts: alerts become cards with a status-driven badge and a status pill, and the empty list gets an illustrated state.
- Currency details: the date pickers share one card and now split the width evenly rather than assuming half the content width; the chart gets its own card and an illustrated empty state.

Also give every FloatingActionButton an explicit heroTag. The tabs stay mounted inside an IndexedStack, so the home and alerts buttons live in the same route at once and both claimed the default Hero tag.

Presentation only: blocs, streams and navigation are unchanged.