### PR TITLE
Remove atalho de conversão duplicado da tela inicial

### DIFF
--- a/lib/util/localizations.dart
+++ b/lib/util/localizations.dart
@@ -15,7 +15,6 @@ class MyAppLocalizations {
       'conversionButtonLabel': 'Conversions',
       'conversionPageTitle': "Currency Conversion",
       'homePageHeadsUpText': 'Exchange rates in %s',
-      'convertActionBtnLabel': 'Convert',
       'conversionMultiplierHint': 'Amount',
       'conversionPageExplanationText': 'Insert the amount value of the currency '
           'that will be converted, selected a currency to be converted and the '
@@ -147,7 +146,6 @@ class MyAppLocalizations {
       'conversionButtonLabel': "Conversões",
       'conversionPageTitle': "Conversão de Moedas",
       'homePageHeadsUpText': "Cotações em %s",
-      'convertActionBtnLabel': "Converter",
       'conversionMultiplierHint': 'Quantidade',
       'conversionPageExplanationText': 'Insira a quantidade da moeda que será '
           'convertida, selecionada a moeda que será convertida e a moeda para '
@@ -287,10 +285,6 @@ class MyAppLocalizations {
 
   String? get homePageHeadsUpText {
     return _localizedValues[locale.languageCode]!['homePageHeadsUpText'];
-  }
-
-  String? get convertActionBtnLabel {
-    return _localizedValues[locale.languageCode]!['convertActionBtnLabel'];
   }
 
   String? get conversionMultiplierHint {

--- a/lib/view/pages/home.dart
+++ b/lib/view/pages/home.dart
@@ -248,49 +248,12 @@ class HomeState extends State<Home> with TickerProviderStateMixin {
     );
   }
 
-  /// Último "tile" do bento: não é uma cotação, é um atalho para a conversão.
-  /// O InkWell/Material dá o mesmo tipo de feedback tátil ao toque que os
-  /// cartões de cotação têm, sem duplicar a lógica deles.
-  Widget _convertShortcutTile(BuildContext context, double scale) {
-    final colorScheme = Theme.of(context).colorScheme;
-    return Material(
-      color: colorScheme.secondaryContainer,
-      borderRadius: BorderRadius.circular(18),
-      child: InkWell(
-        borderRadius: BorderRadius.circular(18),
-        onTap: () => _openConversionPage(context),
-        child: Padding(
-          padding: EdgeInsets.symmetric(
-            horizontal: 16 * scale,
-            vertical: 14 * scale,
-          ),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Icon(
-                Icons.compare_arrows,
-                color: colorScheme.onSecondaryContainer,
-                size: 20 * scale,
-              ),
-              SizedBox(height: 10 * scale),
-              Text(
-                MyAppLocalizations.of(context)!.convertActionBtnLabel!,
-                style: TextStyle(
-                  color: colorScheme.onSecondaryContainer,
-                  fontSize: 16 * scale,
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-
   /// A grade de bolhas: a primeira moeda escolhida em destaque, ocupando a
-  /// largura toda, e as demais em pares, com o atalho da conversão no fim.
+  /// largura toda, e as demais em pares.
+  ///
+  /// A grade mostra só cotações. O caminho para a conversão é o botão
+  /// flutuante da tela — a ação principal fica num lugar só, sempre visível,
+  /// em vez de repetida num tile que rola junto com o conteúdo.
   Widget _buildBentoGrid(BuildContext context, double scale) {
     final rows = <Widget>[];
     var tileIndex = 0;
@@ -306,7 +269,6 @@ class HomeState extends State<Home> with TickerProviderStateMixin {
     final pairedTiles = <Widget>[
       for (var currency in _homeCurrencies.skip(1))
         _currencyCard(context, currency, hero: false, scale: scale),
-      _convertShortcutTile(context, scale),
     ];
 
     for (var first = 0; first < pairedTiles.length; first += 2) {
@@ -403,7 +365,10 @@ class HomeState extends State<Home> with TickerProviderStateMixin {
                   child: pageHeader,
                 ),
                 bentoGrid,
-                SizedBox(height: 16 * _scale),
+                // Espaço para o botão flutuante: ele paira sobre o fim da
+                // lista, e sem esta folga cobriria o último cartão de cotação
+                // quando a grade cabe inteira na tela.
+                SizedBox(height: 96 * _scale),
               ],
             ),
           ),

--- a/test/util/localizations_test.dart
+++ b/test/util/localizations_test.dart
@@ -9,7 +9,6 @@ List<String?> _allLabels(MyAppLocalizations localizations) => [
       localizations.conversionButtonLabel,
       localizations.conversionPageTitle,
       localizations.homePageHeadsUpText,
-      localizations.convertActionBtnLabel,
       localizations.conversionMultiplierHint,
       localizations.conversionPageExplanationText,
       localizations.conversionFromLabel,


### PR DESCRIPTION
## Problema

A tela inicial oferecia **dois** caminhos idênticos para a página de conversão:

1. o `FloatingActionButton.extended` ("Conversões"), e
2. um tile "Converter" fechando o bento grid.

Ambos chamavam `_openConversionPage`. Duas affordances para a mesma ação na mesma tela obrigam o usuário a decidir qual usar e contrariam a regra de uma ação principal por tela.

## O que mudou

Fica o **botão flutuante** e sai o tile do grid:

- o FAB é o lugar canônico da ação principal no Material 3 — permanece visível enquanto a lista rola e está ao alcance do polegar;
- o tile misturava um item de navegação numa grade cujos demais cartões são todos dados de cotação, quebrando a leitura da grade;
- por rolar junto com o conteúdo, o tile podia sair da tela, enquanto o FAB não.

Alterações:

- `lib/view/pages/home.dart`: removido `_convertShortcutTile` e sua entrada em `pairedTiles`; o espaçador do fim da lista passa a reservar altura para o FAB, que antes pairava sobre o tile e agora cobriria o último cartão de cotação quando a grade cabe inteira na tela.
- `lib/util/localizations.dart`: `convertActionBtnLabel` existia só para esse tile — removido dos dois idiomas junto com o getter.
- `test/util/localizations_test.dart`: removida a linha correspondente da lista de textos.

O comportamento da página de conversão em si não foi tocado.

## Verificação

Não há toolchain Flutter/Dart no ambiente desta sessão, então `flutter analyze` e `flutter test` não foram executados. Confirmei por busca que não restam referências a `_convertShortcutTile` nem a `convertActionBtnLabel` em `lib/` e `test/`, e que o teste de localização não depende de contagem fixa de textos (compara apenas pt × en).

---
_Generated by [Claude Code](https://claude.ai/code/session_014gmd3ZjK2Htz1grxKUFt1b)_