### PR TITLE
Lista de ativos da tela de IA no padrão das outras listas do app

### DIFF
--- a/lib/util/currency_visuals.dart
+++ b/lib/util/currency_visuals.dart
@@ -1,3 +1,4 @@
+import 'package:cotacao_direta/enums/cryptocurrency_enum.dart';
 import 'package:cotacao_direta/enums/currency_enum.dart';
 import 'package:cotacao_direta/util/currency_colors.dart';
 import 'package:flutter/material.dart';
@@ -54,3 +55,15 @@ Color currencyAccentColor(Currencies currency) {
 /// Ícone da bolha de [currency] na tela inicial.
 IconData currencyIcon(Currencies currency) =>
     _iconByCurrency[currency] ?? Icons.payments;
+
+/// Cor de destaque de [cryptocurrency], usada no selo do ativo nas listas.
+///
+/// O bitcoin fica com o âmbar que já usava na listagem de histórico; as demais
+/// pegam uma cor da mesma paleta das moedas, pela posição no enum, para que
+/// uma lista com os dois tipos de ativo continue colorida sem repetir cor a
+/// esmo.
+Color cryptocurrencyAccentColor(Cryptocurrencies cryptocurrency) {
+  return cryptocurrency == Cryptocurrencies.BTC
+      ? CurrencyColors.usd
+      : _palette[cryptocurrency.index % _palette.length];
+}

--- a/lib/util/localizations.dart
+++ b/lib/util/localizations.dart
@@ -80,6 +80,8 @@ class MyAppLocalizations {
           'device, over the quotes the app already downloaded, to summarise the '
           'market and project the coming days. No data leaves your phone.',
       'aiInsightsAssetLabel': 'Asset',
+      'aiInsightsAssetPickerTitle': 'Choose an asset',
+      'aiInsightsAssetNotFoundLabel': 'No asset found',
       'aiInsightsHorizonLabel': 'Projection horizon',
       'aiInsightsHorizonOptionLabel': '%s days',
       'aiInsightsAmountLabel': 'Amount to simulate (optional)',
@@ -211,6 +213,8 @@ class MyAppLocalizations {
           'aparelho, sobre as cotações que o app já baixou, para resumir o '
           'mercado e projetar os próximos dias. Nenhum dado sai do seu celular.',
       'aiInsightsAssetLabel': 'Ativo',
+      'aiInsightsAssetPickerTitle': 'Escolha o ativo',
+      'aiInsightsAssetNotFoundLabel': 'Nenhum ativo encontrado',
       'aiInsightsHorizonLabel': 'Horizonte da projeção',
       'aiInsightsHorizonOptionLabel': '%s dias',
       'aiInsightsAmountLabel': 'Valor para simular (opcional)',
@@ -549,6 +553,15 @@ class MyAppLocalizations {
 
   String? get aiInsightsAssetLabel {
     return _localizedValues[locale.languageCode]!['aiInsightsAssetLabel'];
+  }
+
+  String? get aiInsightsAssetPickerTitle {
+    return _localizedValues[locale.languageCode]!['aiInsightsAssetPickerTitle'];
+  }
+
+  String? get aiInsightsAssetNotFoundLabel {
+    return _localizedValues[locale.languageCode]!
+        ['aiInsightsAssetNotFoundLabel'];
   }
 
   String? get aiInsightsHorizonLabel {

--- a/lib/view/pages/main_menu_items/ai_insights_page.dart
+++ b/lib/view/pages/main_menu_items/ai_insights_page.dart
@@ -1,37 +1,17 @@
 import 'package:cotacao_direta/blocs/ai_insights_bloc.dart';
 import 'package:cotacao_direta/enums/cryptocurrency_enum.dart';
 import 'package:cotacao_direta/enums/currency_enum.dart';
-import 'package:cotacao_direta/model/asset_series.dart';
 import 'package:cotacao_direta/model/financial_analysis.dart';
 import 'package:cotacao_direta/providers/ai_insights_bloc_provider.dart';
-import 'package:cotacao_direta/util/cryptocurrency_info.dart';
 import 'package:cotacao_direta/util/localizations.dart';
 import 'package:cotacao_direta/util/quote_format.dart';
 import 'package:cotacao_direta/util/responsive.dart';
-import 'package:cotacao_direta/util/string_utils.dart';
 import 'package:cotacao_direta/view/widgets/ai_insight_text.dart';
+import 'package:cotacao_direta/view/widgets/asset_picker_sheet.dart';
 import 'package:cotacao_direta/view/widgets/forecast_chart.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:sprintf/sprintf.dart';
-
-/// An asset offered in the screen's list.
-class _AssetOption {
-  final String code;
-  final AssetKind kind;
-  final String name;
-
-  const _AssetOption({required this.code, required this.kind, required this.name});
-
-  // DropdownButtonFormField compares the selected value against the list items
-  // by equality, and the list is rebuilt on every build.
-  @override
-  bool operator ==(Object other) =>
-      other is _AssetOption && other.code == code && other.kind == kind;
-
-  @override
-  int get hashCode => Object.hash(code, kind);
-}
 
 /// Screen for the insights produced by the AI model that runs on the device
 /// itself.
@@ -48,23 +28,23 @@ class AiInsightsPage extends StatefulWidget {
 }
 
 class _AiInsightsPageState extends State<AiInsightsPage> {
-  static String _codeOf(Object enumValue) =>
-      EnumValueAsString().getEnumValue(enumValue.toString());
-
-  List<_AssetOption> _assetOptions(String counterCurrency) => [
+  List<AssetOption> _assetOptions(String counterCurrency) => [
         // The counter currency has no series of its own: quoted against
         // itself it would always be 1, and the repository skips the query.
         ...Currencies.values
-            .where((currency) => _codeOf(currency) != counterCurrency)
-            .map((currency) => _AssetOption(
-                code: _codeOf(currency),
-                kind: AssetKind.currency,
-                name: _codeOf(currency))),
-        ...Cryptocurrencies.values.map((cryptocurrency) => _AssetOption(
-            code: _codeOf(cryptocurrency),
-            kind: AssetKind.cryptocurrency,
-            name: cryptocurrencyName(cryptocurrency))),
+            .where((currency) => currency.name != counterCurrency)
+            .map(AssetOption.currency),
+        ...Cryptocurrencies.values.map(AssetOption.cryptocurrency),
       ];
+
+  Future<void> _pickAsset(
+      BuildContext context, AiInsightsBloc bloc, List<AssetOption> options,
+      AssetOption selected) async {
+    final picked = await showAssetPicker(context,
+        assets: options, selectedAsset: selected);
+    if (picked == null || !mounted) return;
+    setState(() => bloc.selectAsset(picked.code, picked.kind));
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -99,7 +79,8 @@ class _AiInsightsPageState extends State<AiInsightsPage> {
               children: [
                 _header(context, localizations, scale),
                 SizedBox(height: 16 * scale),
-                _assetField(context, bloc, localizations, options, selected),
+                _assetField(
+                    context, bloc, localizations, options, selected, scale),
                 SizedBox(height: 16 * scale),
                 _horizonField(context, bloc, localizations, scale),
                 SizedBox(height: 16 * scale),
@@ -168,32 +149,86 @@ class _AiInsightsPageState extends State<AiInsightsPage> {
     );
   }
 
+  /// The selected asset, in the same shape the other asset lists of the app
+  /// use — badge, code and name — and tapping it opens the picker sheet. The
+  /// dropdown this replaced turned forty-odd assets into a column of
+  /// three-letter codes.
   Widget _assetField(
     BuildContext context,
     AiInsightsBloc bloc,
     MyAppLocalizations localizations,
-    List<_AssetOption> options,
-    _AssetOption selected,
+    List<AssetOption> options,
+    AssetOption selected,
+    double scale,
   ) {
-    return DropdownButtonFormField<_AssetOption>(
-      initialValue: selected,
-      isExpanded: true,
-      decoration: InputDecoration(
-        border: const OutlineInputBorder(),
-        labelText: localizations.aiInsightsAssetLabel,
+    final colorScheme = Theme.of(context).colorScheme;
+    final locale = Localizations.localeOf(context);
+
+    return Card(
+      margin: EdgeInsets.zero,
+      elevation: 0,
+      clipBehavior: Clip.antiAlias,
+      color: colorScheme.surfaceContainerLow,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(16 * scale),
+        side: BorderSide(color: colorScheme.outlineVariant),
       ),
-      items: options
-          .map((option) => DropdownMenuItem<_AssetOption>(
-                value: option,
-                child: Text(option.code == option.name
-                    ? option.code
-                    : "${option.code} — ${option.name}"),
-              ))
-          .toList(),
-      onChanged: (option) {
-        if (option == null) return;
-        setState(() => bloc.selectAsset(option.code, option.kind));
-      },
+      child: InkWell(
+        onTap: () => _pickAsset(context, bloc, options, selected),
+        child: Padding(
+          padding: EdgeInsets.fromLTRB(
+              16 * scale, 12 * scale, 12 * scale, 12 * scale),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                localizations.aiInsightsAssetLabel!,
+                style: TextStyle(
+                  fontSize: 12 * scale,
+                  fontWeight: FontWeight.w600,
+                  color: colorScheme.onSurfaceVariant,
+                ),
+              ),
+              SizedBox(height: 8 * scale),
+              Row(
+                children: [
+                  AssetBadge(asset: selected, scale: scale),
+                  SizedBox(width: 12 * scale),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(
+                          selected.code,
+                          style: TextStyle(
+                            fontSize: 16 * scale,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                        Text(
+                          selected.name(locale),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: TextStyle(
+                            fontSize: 12 * scale,
+                            color: colorScheme.onSurfaceVariant,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  Icon(
+                    Icons.unfold_more,
+                    size: 20 * scale,
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
     );
   }
 

--- a/lib/view/widgets/asset_picker_sheet.dart
+++ b/lib/view/widgets/asset_picker_sheet.dart
@@ -1,0 +1,371 @@
+import 'package:cotacao_direta/enums/cryptocurrency_enum.dart';
+import 'package:cotacao_direta/enums/currency_enum.dart';
+import 'package:cotacao_direta/model/asset_series.dart';
+import 'package:cotacao_direta/util/cryptocurrency_info.dart';
+import 'package:cotacao_direta/util/currency_flag.dart';
+import 'package:cotacao_direta/util/currency_name.dart';
+import 'package:cotacao_direta/util/currency_visuals.dart';
+import 'package:cotacao_direta/util/localizations.dart';
+import 'package:cotacao_direta/util/responsive.dart';
+import 'package:cotacao_direta/util/string_utils.dart';
+import 'package:cotacao_direta/view/widgets/bento_card.dart';
+import 'package:flag/flag.dart';
+import 'package:flutter/material.dart';
+
+/// Um ativo que o usuário pode escolher: uma moeda fiduciária ou uma
+/// criptomoeda.
+///
+/// Guarda o próprio valor do enum, e não só o código, para que o nome por
+/// extenso, a bandeira e a cor de destaque saiam daqui em vez de serem
+/// procurados de novo em cada tela.
+class AssetOption {
+  /// Preenchida apenas quando o ativo é moeda fiduciária.
+  final Currencies? currency;
+
+  /// Preenchida apenas quando o ativo é criptomoeda.
+  final Cryptocurrencies? cryptocurrency;
+
+  const AssetOption.currency(Currencies this.currency) : cryptocurrency = null;
+
+  const AssetOption.cryptocurrency(Cryptocurrencies this.cryptocurrency)
+      : currency = null;
+
+  AssetKind get kind =>
+      currency != null ? AssetKind.currency : AssetKind.cryptocurrency;
+
+  bool get isCryptocurrency => currency == null;
+
+  /// Código do ativo: ISO 4217 nas moedas ("USD"), sigla de mercado nas
+  /// criptomoedas ("BTC").
+  String get code => currency?.name ?? cryptocurrency!.name;
+
+  /// Nome por extenso no idioma de [locale]. As criptomoedas têm um nome só,
+  /// que não se traduz.
+  String name(Locale locale) => currency != null
+      ? currencyName(currency!, locale)
+      : cryptocurrencyName(cryptocurrency!);
+
+  Color get accentColor => currency != null
+      ? currencyAccentColor(currency!)
+      : cryptocurrencyAccentColor(cryptocurrency!);
+
+  @override
+  bool operator ==(Object other) =>
+      other is AssetOption &&
+      other.currency == currency &&
+      other.cryptocurrency == cryptocurrency;
+
+  @override
+  int get hashCode => Object.hash(currency, cryptocurrency);
+}
+
+/// Selo do ativo: a bandeira da moeda ou o ícone da criptomoeda dentro da
+/// mesma moldura colorida, para que os dois tipos fiquem alinhados e com o
+/// mesmo peso visual na lista — como já acontece na listagem de histórico.
+class AssetBadge extends StatelessWidget {
+  final AssetOption asset;
+  final double scale;
+
+  const AssetBadge({super.key, required this.asset, required this.scale});
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = asset.accentColor;
+    final currency = asset.currency;
+
+    return Container(
+      width: 46 * scale,
+      height: 40 * scale,
+      alignment: Alignment.center,
+      decoration: BoxDecoration(
+        color: accent.withValues(alpha: 0.18),
+        borderRadius: BorderRadius.circular(12 * scale),
+      ),
+      child: currency != null
+          ? ClipRRect(
+              borderRadius: BorderRadius.circular(6 * scale),
+              child: Flag.fromCode(
+                flagCodeForCurrency(currency),
+                height: 24 * scale,
+                width: 32 * scale,
+                fit: BoxFit.cover,
+              ),
+            )
+          : Icon(
+              iconForCryptocurrency(asset.cryptocurrency!),
+              size: 22 * scale,
+              color: accent,
+            ),
+    );
+  }
+}
+
+/// Abre a folha de escolha de ativo e devolve o ativo escolhido, ou nulo se o
+/// usuário fechar sem escolher.
+///
+/// É a mesma lista rolável com busca do seletor de moeda da conversão, só que
+/// separada em moedas e criptomoedas: são mais de quarenta ativos, e num menu
+/// suspenso eles viravam uma coluna de siglas que o usuário tinha que
+/// percorrer até achar a certa.
+Future<AssetOption?> showAssetPicker(
+  BuildContext context, {
+  required List<AssetOption> assets,
+  required AssetOption selectedAsset,
+}) {
+  return showModalBottomSheet<AssetOption>(
+    context: context,
+    // A lista ocupa boa parte da tela e o teclado da busca sobe por cima: sem
+    // isso a folha ficaria presa a metade da altura.
+    isScrollControlled: true,
+    useSafeArea: true,
+    showDragHandle: true,
+    builder: (sheetContext) =>
+        _AssetPickerSheet(assets: assets, selectedAsset: selectedAsset),
+  );
+}
+
+/// Uma linha da folha: o título de uma seção ou um ativo. As duas convivem na
+/// mesma lista para que a rolagem valha para o conjunto todo.
+sealed class _PickerEntry {}
+
+class _SectionEntry extends _PickerEntry {
+  final String label;
+
+  _SectionEntry(this.label);
+}
+
+class _AssetEntry extends _PickerEntry {
+  final AssetOption asset;
+
+  _AssetEntry(this.asset);
+}
+
+class _AssetPickerSheet extends StatefulWidget {
+  final List<AssetOption> assets;
+  final AssetOption selectedAsset;
+
+  const _AssetPickerSheet({required this.assets, required this.selectedAsset});
+
+  @override
+  State<_AssetPickerSheet> createState() => _AssetPickerSheetState();
+}
+
+class _AssetPickerSheetState extends State<_AssetPickerSheet> {
+  final _searchController = TextEditingController();
+  var _query = "";
+
+  ScrollController? _listController;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    // A lista abre já no ativo que está escolhido, em vez de no começo do
+    // alfabeto: quem abre o seletor quer ver de onde está saindo.
+    _listController ??= ScrollController(
+        initialScrollOffset: _offsetOfSelectedAsset(
+            _entries(context), Responsive.scaleFactor(context)));
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    _listController?.dispose();
+    super.dispose();
+  }
+
+  /// Altura fixa de cada linha: além de deixar a rolagem mais barata, é o que
+  /// permite calcular a posição do ativo escolhido sem medir a lista.
+  double _tileExtent(double scale) => 72 * scale;
+
+  double _sectionExtent(double scale) => 48 * scale;
+
+  double _extentOf(_PickerEntry entry, double scale) => switch (entry) {
+        _SectionEntry() => _sectionExtent(scale),
+        _AssetEntry() => _tileExtent(scale),
+      };
+
+  /// Deixa o ativo escolhido a duas linhas do topo, para os vizinhos de cima
+  /// também aparecerem. O ScrollController corta o que passar do fim da lista.
+  double _offsetOfSelectedAsset(List<_PickerEntry> entries, double scale) {
+    final index = entries.indexWhere((entry) =>
+        entry is _AssetEntry && entry.asset == widget.selectedAsset);
+    if (index < 0) return 0;
+    var offset = 0.0;
+    for (var position = 0; position < index; position++) {
+      offset += _extentOf(entries[position], scale);
+    }
+    return (offset - 2 * _tileExtent(scale)).clamp(0, double.infinity);
+  }
+
+  bool _matchesQuery(AssetOption asset, Locale locale) {
+    final query = withoutAccents(_query.trim());
+    if (query.isEmpty) return true;
+    return withoutAccents(asset.code).contains(query) ||
+        withoutAccents(asset.name(locale)).contains(query);
+  }
+
+  /// As linhas da folha, na ordem em que aparecem: as moedas e, depois, as
+  /// criptomoedas, cada grupo em ordem alfabética de nome e com o próprio
+  /// título — um título só aparece quando sobrou algum ativo do grupo na
+  /// busca.
+  List<_PickerEntry> _entries(BuildContext context) {
+    final localizations = MyAppLocalizations.of(context)!;
+    final locale = Localizations.localeOf(context);
+
+    List<_PickerEntry> group(String label, bool cryptocurrencies) {
+      final assets = widget.assets
+          .where((asset) => asset.isCryptocurrency == cryptocurrencies)
+          .where((asset) => _matchesQuery(asset, locale))
+          .toList()
+        ..sort((first, second) =>
+            first.name(locale).compareTo(second.name(locale)));
+      if (assets.isEmpty) return const [];
+      return [_SectionEntry(label), ...assets.map(_AssetEntry.new)];
+    }
+
+    return [
+      ...group(localizations.currencyHistoryCurrenciesSectionLabel!, false),
+      ...group(
+          localizations.currencyHistoryCryptocurrenciesSectionLabel!, true),
+    ];
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final localizations = MyAppLocalizations.of(context)!;
+    final locale = Localizations.localeOf(context);
+    final scale = Responsive.scaleFactor(context);
+    final textTheme = Theme.of(context).textTheme;
+    final entries = _entries(context);
+
+    return SizedBox(
+      height: MediaQuery.of(context).size.height * 0.8,
+      child: Padding(
+        // O teclado da busca cobriria as últimas linhas da lista.
+        padding:
+            EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Padding(
+              padding:
+                  EdgeInsets.fromLTRB(24 * scale, 0, 24 * scale, 8 * scale),
+              child: Text(
+                localizations.aiInsightsAssetPickerTitle!,
+                style: textTheme.titleMedium,
+              ),
+            ),
+            Padding(
+              padding: EdgeInsets.symmetric(horizontal: 16 * scale),
+              child: TextField(
+                controller: _searchController,
+                autofocus: false,
+                textInputAction: TextInputAction.search,
+                decoration: InputDecoration(
+                  hintText: localizations.conversionCurrencySearchHint,
+                  prefixIcon: const Icon(Icons.search),
+                  suffixIcon: _query.isEmpty
+                      ? null
+                      : IconButton(
+                          icon: const Icon(Icons.close),
+                          onPressed: () {
+                            _searchController.clear();
+                            setState(() => _query = "");
+                          },
+                        ),
+                  border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(28 * scale)),
+                  isDense: true,
+                ),
+                onChanged: (value) {
+                  setState(() => _query = value);
+                  // A lista pode estar rolada no ativo escolhido; os
+                  // resultados da busca começam do topo.
+                  if (_listController?.hasClients ?? false) {
+                    _listController!.jumpTo(0);
+                  }
+                },
+              ),
+            ),
+            SizedBox(height: 8 * scale),
+            Expanded(
+              child: entries.isEmpty
+                  ? Center(
+                      child: Padding(
+                        padding: EdgeInsets.all(24 * scale),
+                        child: Text(
+                          localizations.aiInsightsAssetNotFoundLabel!,
+                          textAlign: TextAlign.center,
+                          style: textTheme.bodyMedium,
+                        ),
+                      ),
+                    )
+                  : ListView.builder(
+                      controller: _listController,
+                      // Altura conhecida linha a linha: a rolagem não precisa
+                      // medir nada e a posição do ativo escolhido bate.
+                      itemExtentBuilder: (index, _) =>
+                          _extentOf(entries[index], scale),
+                      itemCount: entries.length,
+                      itemBuilder: (context, index) {
+                        final entry = entries[index];
+                        return switch (entry) {
+                          _SectionEntry() => BentoSectionTitle(entry.label),
+                          _AssetEntry() => _AssetOptionTile(
+                              asset: entry.asset,
+                              locale: locale,
+                              scale: scale,
+                              isSelected: entry.asset == widget.selectedAsset,
+                              onTap: () =>
+                                  Navigator.of(context).pop(entry.asset),
+                            ),
+                        };
+                      },
+                    ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _AssetOptionTile extends StatelessWidget {
+  final AssetOption asset;
+  final Locale locale;
+  final double scale;
+  final bool isSelected;
+  final VoidCallback onTap;
+
+  const _AssetOptionTile({
+    required this.asset,
+    required this.locale,
+    required this.scale,
+    required this.isSelected,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return ListTile(
+      selected: isSelected,
+      leading: AssetBadge(asset: asset, scale: scale),
+      title: Text(
+        asset.code,
+        style: TextStyle(fontSize: 16 * scale, fontWeight: FontWeight.w600),
+      ),
+      subtitle: Text(
+        asset.name(locale),
+        style: TextStyle(fontSize: 13 * scale),
+        overflow: TextOverflow.ellipsis,
+        maxLines: 1,
+      ),
+      trailing: isSelected
+          ? Icon(Icons.check, color: colorScheme.primary, size: 22 * scale)
+          : null,
+      onTap: onTap,
+    );
+  }
+}

--- a/test/util/localizations_test.dart
+++ b/test/util/localizations_test.dart
@@ -67,6 +67,8 @@ List<String?> _allLabels(MyAppLocalizations localizations) => [
       localizations.aiInsightsSectionLabel,
       localizations.aiInsightsDescription,
       localizations.aiInsightsAssetLabel,
+      localizations.aiInsightsAssetPickerTitle,
+      localizations.aiInsightsAssetNotFoundLabel,
       localizations.aiInsightsHorizonLabel,
       localizations.aiInsightsHorizonOptionLabel,
       localizations.aiInsightsAmountLabel,

--- a/test/view/ai_insights_page_test.dart
+++ b/test/view/ai_insights_page_test.dart
@@ -1,4 +1,5 @@
 import 'package:cotacao_direta/blocs/ai_insights_bloc.dart';
+import 'package:cotacao_direta/model/asset_series.dart';
 import 'package:cotacao_direta/providers/ai_insights_bloc_provider.dart';
 import 'package:cotacao_direta/util/localizations.dart';
 import 'package:cotacao_direta/view/pages/main_menu_items/ai_insights_page.dart';
@@ -9,6 +10,10 @@ import 'package:flutter_test/flutter_test.dart';
 
 import '../helpers/fakes.dart';
 import '../helpers/series_test_helper.dart';
+
+/// A busca da folha de escolha de ativo. A tela por baixo dela também tem um
+/// campo de texto (o valor a simular), então o find vai pela lupa.
+final _assetSearchField = find.widgetWithIcon(TextField, Icons.search);
 
 void main() {
   late FakeCurrencyRepository repository;
@@ -161,6 +166,82 @@ void main() {
       // BRL é a contrapartida das cotações: não há série de BRL contra BRL.
       expect(find.text("BRL"), findsNothing);
       expect(find.text("EUR"), findsWidgets);
+    });
+
+    testWidgets('o campo mostra o código e o nome do ativo escolhido',
+        (WidgetTester tester) async {
+      await pumpPage(tester);
+
+      expect(find.text("USD"), findsOneWidget);
+      expect(find.text("Dólar Americano"), findsOneWidget);
+    });
+
+    testWidgets('a lista abre no ativo escolhido', (WidgetTester tester) async {
+      await pumpPage(tester);
+      await tester.tap(find.text("USD").first);
+      await tester.pumpAndSettle();
+
+      // O visto só existe na linha do ativo escolhido, e a lista só monta o
+      // que está por perto da área visível: achá-lo é achar a linha do USD
+      // sem ter rolado nada.
+      expect(find.byIcon(Icons.check), findsOneWidget);
+    });
+
+    testWidgets('a lista separa moedas de criptomoedas',
+        (WidgetTester tester) async {
+      await pumpPage(tester);
+      await tester.tap(find.text("USD").first);
+      await tester.pumpAndSettle();
+
+      // Cada grupo tem o próprio título, e um título só aparece quando sobrou
+      // algum ativo dele na busca.
+      await tester.enterText(_assetSearchField, "dolar");
+      await tester.pumpAndSettle();
+
+      expect(find.text(localizations.currencyHistoryCurrenciesSectionLabel!),
+          findsOneWidget);
+      expect(
+          find.text(localizations.currencyHistoryCryptocurrenciesSectionLabel!),
+          findsNothing);
+
+      await tester.enterText(_assetSearchField, "bitcoin");
+      await tester.pumpAndSettle();
+
+      expect(
+          find.text(localizations.currencyHistoryCryptocurrenciesSectionLabel!),
+          findsOneWidget);
+      expect(find.text(localizations.currencyHistoryCurrenciesSectionLabel!),
+          findsNothing);
+      expect(find.text("BTC"), findsOneWidget);
+    });
+
+    testWidgets('escolher um ativo na lista troca o ativo da análise',
+        (WidgetTester tester) async {
+      await pumpPage(tester);
+      await tester.tap(find.text("USD").first);
+      await tester.pumpAndSettle();
+
+      await tester.enterText(_assetSearchField, "bitcoin");
+      await tester.pumpAndSettle();
+      await tester.tap(find.text("BTC"));
+      await tester.pumpAndSettle();
+
+      expect(bloc.selectedAssetCode, "BTC");
+      expect(bloc.selectedAssetKind, AssetKind.cryptocurrency);
+      expect(find.text("Bitcoin"), findsOneWidget);
+    });
+
+    testWidgets('busca sem resultado avisa que não há ativo',
+        (WidgetTester tester) async {
+      await pumpPage(tester);
+      await tester.tap(find.text("USD").first);
+      await tester.pumpAndSettle();
+
+      await tester.enterText(_assetSearchField, "moeda que não existe");
+      await tester.pumpAndSettle();
+
+      expect(find.text(localizations.aiInsightsAssetNotFoundLabel!),
+          findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
## O que mudou

Na tela de IA, o ativo era escolhido num `DropdownButtonFormField`: mais de quarenta itens numa coluna de siglas de três letras, sem bandeira, sem nome por extenso e com moeda e criptomoeda misturadas — o oposto das outras listas de ativo do app (histórico, seletor de moeda da conversão, escolha das bolhas da tela inicial).

Agora:

- **Campo do ativo** no formato do seletor de moeda da tela de conversão: selo do ativo, código e nome por extenso, e o ícone que indica que abre uma lista.
- **Folha rolável com busca** (`showAssetPicker`), a mesma da conversão e da escolha das bolhas: busca por nome ou código sem acento, linhas com selo + código + nome, visto na linha do ativo escolhido.
- **Seções de moedas e criptomoedas**, com os títulos que a listagem de histórico já usa; um título só aparece quando sobrou algum ativo do grupo na busca.
- **Selo colorido** (`AssetBadge`) com a bandeira da moeda ou o ícone da criptomoeda dentro da mesma moldura, como na listagem de histórico, para os dois tipos de ativo ficarem alinhados.
- A lista **abre já na linha do ativo escolhido**, como o seletor de moeda da conversão.

## Arquivos

- `lib/view/widgets/asset_picker_sheet.dart` (novo): `AssetOption`, `AssetBadge` e `showAssetPicker`.
- `lib/view/pages/main_menu_items/ai_insights_page.dart`: campo do ativo no lugar do menu suspenso; o `_AssetOption` privado deu lugar ao `AssetOption` compartilhado.
- `lib/util/currency_visuals.dart`: `cryptocurrencyAccentColor`, reaproveitando a paleta que já existia para as moedas.
- `lib/util/localizations.dart`: títulos da folha e aviso de busca sem resultado, em português e inglês.

## Testes

- `flutter analyze`: sem apontamentos.
- `flutter test`: 482 testes passando, incluindo cinco novos em `test/view/ai_insights_page_test.dart` (campo mostra código e nome, lista abre no ativo escolhido, separação das seções pela busca, escolha de um ativo troca a análise, busca sem resultado).
- Conferido também no app rodando (web, largura de celular e de tablet): campo, abertura da folha, busca e troca do ativo.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QqKYZcFB4WxDBEumPaprew)_