### PR TITLE
Toque na bolha abre a conversão da moeda, com as moedas da tela inicial no topo do seletor

### DIFF
--- a/lib/blocs/conversion_page_bloc.dart
+++ b/lib/blocs/conversion_page_bloc.dart
@@ -58,8 +58,10 @@ class ConversionResult {
 
 class ConversionPageBloc extends BaseBloc {
   static const initialAmount = 1.0;
-  static const initialFromCurrency = Currencies.BRL;
-  static const initialToCurrency = Currencies.USD;
+
+  /// O par que a tela abre escolhido quando quem a abriu não pediu outro.
+  static const defaultFromCurrency = Currencies.BRL;
+  static const defaultToCurrency = Currencies.USD;
 
   // Broadcast porque mais de um trecho da tela acompanha a mesma informação
   // (a moeda de origem aparece no campo de quantidade e no seletor, por
@@ -76,19 +78,49 @@ class ConversionPageBloc extends BaseBloc {
   /// de fora pertence a quem o passou.
   final bool _ownsExchangeValueBloc;
 
-  ConversionPageBloc({ExchangeValueBloc? exchangeValueBloc})
-      : _exchangeValueBloc = exchangeValueBloc ?? ExchangeValueBloc(),
-        _ownsExchangeValueBloc = exchangeValueBloc == null;
+  /// Moedas que a tela de origem quer ver no topo do seletor — na prática, as
+  /// que estão em bolha na tela inicial. Quem chegou aqui tocando numa bolha
+  /// muito provavelmente vai querer converter para outra das suas moedas, e
+  /// não para uma das mais de trinta que a lista tem.
+  final List<Currencies> priorityCurrencies;
+
+  /// [initialFromCurrency] e [initialToCurrency] são o par que a tela abre já
+  /// escolhido: tocar na bolha do dólar na tela inicial abre esta tela
+  /// convertendo dólar para a contrapartida das cotações, o mesmo que a bolha
+  /// mostrava. Sem eles vale o par padrão (real para dólar).
+  ConversionPageBloc({
+    ExchangeValueBloc? exchangeValueBloc,
+    Currencies? initialFromCurrency,
+    Currencies? initialToCurrency,
+    List<Currencies> priorityCurrencies = const [],
+  })  : _exchangeValueBloc = exchangeValueBloc ?? ExchangeValueBloc(),
+        _ownsExchangeValueBloc = exchangeValueBloc == null,
+        priorityCurrencies = List.unmodifiable(priorityCurrencies),
+        _fromCurrency = initialFromCurrency ?? defaultFromCurrency,
+        _toCurrency = _resolveToCurrency(
+            initialFromCurrency ?? defaultFromCurrency, initialToCurrency) {
+    _result = ConversionResult(
+        status: ConversionStatus.loading,
+        amount: _amount,
+        from: _fromCurrency,
+        to: _toCurrency);
+  }
+
+  /// O destino pedido por quem abriu a tela, desde que ele não seja a própria
+  /// moeda de origem: uma moeda convertida para ela mesma não diria nada. Nesse
+  /// caso vale o outro lado do par padrão, para a tela abrir com uma conversão
+  /// de verdade — tocar na bolha do real com o real de contrapartida abre real
+  /// para dólar.
+  static Currencies _resolveToCurrency(Currencies from, Currencies? candidate) {
+    if (candidate != null && candidate != from) return candidate;
+    return from == defaultToCurrency ? defaultFromCurrency : defaultToCurrency;
+  }
 
   var _amount = initialAmount;
-  var _fromCurrency = initialFromCurrency;
-  var _toCurrency = initialToCurrency;
+  Currencies _fromCurrency;
+  Currencies _toCurrency;
 
-  var _result = const ConversionResult(
-      status: ConversionStatus.loading,
-      amount: initialAmount,
-      from: initialFromCurrency,
-      to: initialToCurrency);
+  late ConversionResult _result;
 
   /// Cada conversão leva um número de ordem para que a resposta de uma
   /// conversão antiga — a busca das cotações é assíncrona — não sobrescreva o

--- a/lib/blocs/home_bloc.dart
+++ b/lib/blocs/home_bloc.dart
@@ -40,6 +40,16 @@ class HomeBloc extends BaseBloc {
     return currencies.isEmpty ? defaultHomeCurrencies : currencies;
   }
 
+  /// Moeda usada como contrapartida das cotações, quando o app a conhece.
+  ///
+  /// É o outro lado de cada bolha: a bolha do dólar mostra quanto vale um dólar
+  /// nela. A tela usa isso para abrir a conversão no mesmo par que a bolha
+  /// tocada mostrava. Nulo se a moeda escolhida nas configurações não estiver
+  /// entre as que o app conhece — aí a tela de conversão fica com o destino
+  /// padrão dela.
+  Future<Currencies?> loadCounterCurrency() async =>
+      currencyForCode(await _currencyRepository.resolveCounterCurrency());
+
   Stream<String?> getNextStreamController() {
     if (_headsUpTextStreamController == null) {
       _headsUpTextStreamController = StreamController();

--- a/lib/providers/conversion_page_bloc_provider.dart
+++ b/lib/providers/conversion_page_bloc_provider.dart
@@ -1,4 +1,5 @@
 import 'package:cotacao_direta/blocs/conversion_page_bloc.dart';
+import 'package:cotacao_direta/enums/currency_enum.dart';
 import 'package:flutter/material.dart';
 
 /// Cria o [ConversionPageBloc] e o mantém vivo enquanto esta parte da árvore existir. Um
@@ -12,8 +13,21 @@ class ConversionPageBlocProvider extends StatefulWidget {
   /// provider só chama dispose no bloc que ele mesmo criou.
   final ConversionPageBloc? bloc;
 
-  ConversionPageBlocProvider({Key? key, required this.child, this.bloc})
-      : super(key: key);
+  /// Par de moedas com que a tela abre e moedas que o seletor mostra primeiro.
+  /// São repassados ao bloc quando é o provider quem o cria; um bloc pronto
+  /// já vem com as suas escolhas feitas.
+  final Currencies? initialFromCurrency;
+  final Currencies? initialToCurrency;
+  final List<Currencies> priorityCurrencies;
+
+  ConversionPageBlocProvider({
+    Key? key,
+    required this.child,
+    this.bloc,
+    this.initialFromCurrency,
+    this.initialToCurrency,
+    this.priorityCurrencies = const [],
+  }) : super(key: key);
 
   @override
   State<ConversionPageBlocProvider> createState() =>
@@ -28,7 +42,12 @@ class ConversionPageBlocProvider extends StatefulWidget {
 
 class _ConversionPageBlocProviderState
     extends State<ConversionPageBlocProvider> {
-  late final ConversionPageBloc _bloc = widget.bloc ?? ConversionPageBloc();
+  late final ConversionPageBloc _bloc = widget.bloc ??
+      ConversionPageBloc(
+        initialFromCurrency: widget.initialFromCurrency,
+        initialToCurrency: widget.initialToCurrency,
+        priorityCurrencies: widget.priorityCurrencies,
+      );
   late final bool _ownsBloc = widget.bloc == null;
 
   @override

--- a/lib/util/localizations.dart
+++ b/lib/util/localizations.dart
@@ -27,6 +27,8 @@ class MyAppLocalizations {
       'conversionCurrencyPickerTitle': 'Choose a currency',
       'conversionCurrencySearchHint': 'Search by name or code',
       'conversionCurrencyNotFoundLabel': 'No currency found',
+      'conversionCurrencyPickerYoursLabel': 'Your currencies',
+      'conversionCurrencyPickerOthersLabel': 'All currencies',
       'conversionRateUnavailableLabel': 'Exchange rate unavailable',
       'conversionCopyResultTooltip': 'Copy result',
       'conversionResultCopiedLabel': 'Result copied',
@@ -177,6 +179,8 @@ class MyAppLocalizations {
       'conversionCurrencyPickerTitle': 'Escolha a moeda',
       'conversionCurrencySearchHint': 'Busque pelo nome ou código',
       'conversionCurrencyNotFoundLabel': 'Nenhuma moeda encontrada',
+      'conversionCurrencyPickerYoursLabel': 'Suas moedas',
+      'conversionCurrencyPickerOthersLabel': 'Todas as moedas',
       'conversionRateUnavailableLabel': 'Cotação indisponível',
       'conversionCopyResultTooltip': 'Copiar o resultado',
       'conversionResultCopiedLabel': 'Resultado copiado',
@@ -370,6 +374,20 @@ class MyAppLocalizations {
   String? get conversionCurrencyNotFoundLabel {
     return _localizedValues[locale.languageCode]!
         ['conversionCurrencyNotFoundLabel'];
+  }
+
+  /// Título da seção do seletor com as moedas da tela inicial, que aparecem
+  /// antes das demais.
+  String? get conversionCurrencyPickerYoursLabel {
+    return _localizedValues[locale.languageCode]!
+        ['conversionCurrencyPickerYoursLabel'];
+  }
+
+  /// Título da seção com o resto da lista, logo abaixo das moedas da tela
+  /// inicial.
+  String? get conversionCurrencyPickerOthersLabel {
+    return _localizedValues[locale.languageCode]!
+        ['conversionCurrencyPickerOthersLabel'];
   }
 
   String? get conversionRateUnavailableLabel {

--- a/lib/view/pages/home.dart
+++ b/lib/view/pages/home.dart
@@ -67,6 +67,12 @@ class HomeState extends State<Home> with TickerProviderStateMixin {
   // termina — é a mesma lista que o app abria antes de a opção existir.
   var _homeCurrencies = HomeBloc.defaultHomeCurrencies;
 
+  // Moeda em que as bolhas expressam suas cotações. Guardada aqui para o toque
+  // numa bolha abrir a conversão no mesmo par que ela mostrava, sem esperar uma
+  // leitura do banco no meio da navegação. Nula até a primeira leitura, e
+  // quando a contrapartida escolhida não é uma moeda que o app conhece.
+  Currencies? _counterCurrency;
+
   late final AnimationController _entranceAnimationController;
   late final AnimationController _refreshIconController;
 
@@ -148,6 +154,7 @@ class HomeState extends State<Home> with TickerProviderStateMixin {
     });
     _refreshIconController.repeat();
     _loadCounterCurrencyName(context);
+    _loadCounterCurrency();
     _loadHomeCurrencies();
     _checkCurrencyAlerts(context);
     await Future.delayed(const Duration(milliseconds: 400));
@@ -158,11 +165,26 @@ class HomeState extends State<Home> with TickerProviderStateMixin {
     setState(() => _isRefreshing = false);
   }
 
-  void _openConversionPage(BuildContext context) {
+  /// Abre a tela de conversão.
+  ///
+  /// Com [fromCurrency], a tela abre convertendo essa moeda para a
+  /// contrapartida das cotações — o mesmo par que a bolha tocada mostrava, para
+  /// o toque continuar de onde o usuário estava olhando em vez de recomeçar no
+  /// par padrão. Pelo botão flutuante, que não fala de nenhuma moeda em
+  /// especial, vale o par padrão da tela de conversão.
+  ///
+  /// As moedas em bolha vão junto para o seletor da outra tela abrir com elas
+  /// no topo.
+  void _openConversionPage(BuildContext context, {Currencies? fromCurrency}) {
+    var homeCurrencies = _homeCurrencies;
+    var counterCurrency = _counterCurrency;
     Navigator.of(context).push(
       MaterialPageRoute(
         builder: (context) {
           return ConversionPageBlocProvider(
+            initialFromCurrency: fromCurrency,
+            initialToCurrency: fromCurrency == null ? null : counterCurrency,
+            priorityCurrencies: homeCurrencies,
             child: ConversionPage(
               MyAppLocalizations.of(context)!.conversionPageTitle,
             ),
@@ -176,6 +198,15 @@ class HomeState extends State<Home> with TickerProviderStateMixin {
   /// da tela, para o texto acima das bolhas.
   void _loadCounterCurrencyName(BuildContext context) {
     _bloc.loadCounterCurrencyName(MyAppLocalizations.of(context)!.locale);
+  }
+
+  /// Lê a contrapartida das cotações, que é o destino da conversão aberta ao
+  /// tocar numa bolha. Relida junto com o resto da tela porque a escolha pode
+  /// ter mudado na aba de opções.
+  Future<void> _loadCounterCurrency() async {
+    var currency = await _bloc.loadCounterCurrency();
+    if (!mounted || currency == _counterCurrency) return;
+    setState(() => _counterCurrency = currency);
   }
 
   /// Primeira carga da tela.
@@ -195,6 +226,8 @@ class HomeState extends State<Home> with TickerProviderStateMixin {
     await _bloc.loadCounterCurrencyName(
       MyAppLocalizations.of(context)!.locale,
     );
+    if (!mounted) return;
+    await _loadCounterCurrency();
     if (!mounted) return;
     setState(() => _ratesRevision++);
   }
@@ -233,6 +266,11 @@ class HomeState extends State<Home> with TickerProviderStateMixin {
       // ela que impede o cartão de uma moeda de reaproveitar o estado (e a
       // cotação já buscada) do cartão de outra.
       key: ValueKey(currency),
+      // Tocar na bolha leva à conversão dessa moeda: ver a cotação e querer
+      // saber quanto dá numa quantidade qualquer é o passo seguinte natural,
+      // e antes disso ele custava abrir a conversão pelo botão flutuante e
+      // escolher a moeda de novo na lista.
+      onTap: () => _openConversionPage(context, fromCurrency: currency),
       hero: hero,
       color: color,
       icon: currencyIcon(currency),
@@ -251,9 +289,9 @@ class HomeState extends State<Home> with TickerProviderStateMixin {
   /// A grade de bolhas: a primeira moeda escolhida em destaque, ocupando a
   /// largura toda, e as demais em pares.
   ///
-  /// A grade mostra só cotações. O caminho para a conversão é o botão
-  /// flutuante da tela — a ação principal fica num lugar só, sempre visível,
-  /// em vez de repetida num tile que rola junto com o conteúdo.
+  /// Cada bolha leva à conversão da sua moeda; o botão flutuante continua
+  /// abrindo a mesma tela no par padrão, para quem quer converter sem partir
+  /// de nenhuma das moedas mostradas.
   Widget _buildBentoGrid(BuildContext context, double scale) {
     final rows = <Widget>[];
     var tileIndex = 0;
@@ -445,6 +483,7 @@ class HomeState extends State<Home> with TickerProviderStateMixin {
           });
           if (index == 0) {
             _loadCounterCurrencyName(context);
+            _loadCounterCurrency();
             // As moedas em bolha podem ter mudado na aba de opções.
             _loadHomeCurrencies();
           }

--- a/lib/view/widgets/conversion_widget.dart
+++ b/lib/view/widgets/conversion_widget.dart
@@ -118,6 +118,9 @@ class ConversionWidgetState extends State<ConversionWidget> {
     var selected = await showCurrencyPicker(
       context,
       selectedCurrency: forOrigin ? bloc.fromCurrency : bloc.toCurrency,
+      // As moedas em bolha na tela inicial abrem a lista: são as que o usuário
+      // acompanha, e por isso as que mais entram numa conversão.
+      priorityCurrencies: bloc.priorityCurrencies,
     );
     if (selected == null) return;
     if (forOrigin) {

--- a/lib/view/widgets/currency_picker_sheet.dart
+++ b/lib/view/widgets/currency_picker_sheet.dart
@@ -13,9 +13,15 @@ import 'package:flutter/material.dart';
 /// Uma lista rolável com busca no lugar do menu suspenso: são mais de trinta
 /// moedas, e num menu suspenso elas viravam uma coluna de siglas de três
 /// letras que o usuário tinha que percorrer até achar a certa.
+///
+/// [priorityCurrencies] são as moedas que aparecem numa seção própria antes do
+/// resto da lista — as escolhidas para a tela inicial. São as moedas que o
+/// usuário acompanha, então são também as que ele mais converte: deixá-las no
+/// alto poupa a busca ou a rolagem pelo alfabeto a cada conversão.
 Future<Currencies?> showCurrencyPicker(
   BuildContext context, {
   required Currencies selectedCurrency,
+  List<Currencies> priorityCurrencies = const [],
 }) {
   return showModalBottomSheet<Currencies>(
     context: context,
@@ -24,15 +30,38 @@ Future<Currencies?> showCurrencyPicker(
     isScrollControlled: true,
     useSafeArea: true,
     showDragHandle: true,
-    builder: (sheetContext) =>
-        _CurrencyPickerSheet(selectedCurrency: selectedCurrency),
+    builder: (sheetContext) => _CurrencyPickerSheet(
+      selectedCurrency: selectedCurrency,
+      priorityCurrencies: priorityCurrencies,
+    ),
   );
+}
+
+/// Uma linha da lista do seletor: ou o título de uma das duas seções, ou uma
+/// moeda. As duas coisas na mesma lista para a rolagem ser contínua — com uma
+/// lista por seção, as moedas do topo rolariam separadas do resto.
+class _PickerEntry {
+  /// Título da seção, nulo nas linhas de moeda.
+  final String? sectionTitle;
+
+  /// Moeda da linha, nula nos títulos de seção.
+  final Currencies? currency;
+
+  const _PickerEntry.section(String this.sectionTitle) : currency = null;
+
+  const _PickerEntry.currency(Currencies this.currency) : sectionTitle = null;
+
+  bool get isSection => sectionTitle != null;
 }
 
 class _CurrencyPickerSheet extends StatefulWidget {
   final Currencies selectedCurrency;
+  final List<Currencies> priorityCurrencies;
 
-  const _CurrencyPickerSheet({required this.selectedCurrency});
+  const _CurrencyPickerSheet({
+    required this.selectedCurrency,
+    this.priorityCurrencies = const [],
+  });
 
   @override
   State<_CurrencyPickerSheet> createState() => _CurrencyPickerSheetState();
@@ -51,7 +80,9 @@ class _CurrencyPickerSheetState extends State<_CurrencyPickerSheet> {
     // alfabeto: quem abre o seletor quer ver de onde está saindo.
     _listController ??= ScrollController(
         initialScrollOffset: _offsetOfSelectedCurrency(
-            Localizations.localeOf(context), Responsive.scaleFactor(context)));
+            _entries(Localizations.localeOf(context),
+                MyAppLocalizations.of(context)!),
+            Responsive.scaleFactor(context)));
   }
 
   @override
@@ -63,15 +94,32 @@ class _CurrencyPickerSheetState extends State<_CurrencyPickerSheet> {
 
   /// Deixa a moeda escolhida a duas linhas do topo, para as vizinhas de cima
   /// também aparecerem. O ScrollController corta o que passar do fim da lista.
-  double _offsetOfSelectedCurrency(Locale locale, double scale) {
-    var index = _matchingCurrencies(locale).indexOf(widget.selectedCurrency);
+  ///
+  /// Com as moedas da tela inicial no alto, a escolhida costuma estar entre
+  /// elas: aí a lista abre no começo, que é onde ela está.
+  double _offsetOfSelectedCurrency(List<_PickerEntry> entries, double scale) {
+    var index =
+        entries.indexWhere((entry) => entry.currency == widget.selectedCurrency);
     if (index < 0) return 0;
-    return ((index - 2) * _tileExtent(scale)).clamp(0, double.infinity);
+    var offset = 0.0;
+    // Duas linhas a menos: as alturas variam (título de seção e moeda), então
+    // a folga é a das duas linhas imediatamente acima, e não duas vezes a
+    // altura de uma moeda.
+    for (var before = 0; before < index - 2; before++) {
+      offset += _entryExtent(entries[before], scale);
+    }
+    return offset;
   }
 
-  /// Altura fixa de cada linha: além de deixar a rolagem mais barata, é o que
-  /// permite calcular a posição da moeda escolhida sem medir a lista.
+  /// Altura de cada tipo de linha. São fixas para a posição da moeda escolhida
+  /// poder ser calculada sem medir a lista, que é como a rolagem inicial sabe
+  /// onde parar.
   double _tileExtent(double scale) => 72 * scale;
+
+  double _sectionExtent(double scale) => 40 * scale;
+
+  double _entryExtent(_PickerEntry entry, double scale) =>
+      entry.isSection ? _sectionExtent(scale) : _tileExtent(scale);
 
   List<Currencies> _matchingCurrencies(Locale locale) {
     var query = withoutAccents(_query.trim());
@@ -86,13 +134,53 @@ class _CurrencyPickerSheetState extends State<_CurrencyPickerSheet> {
         .toList();
   }
 
+  /// A lista já montada: as moedas da tela inicial primeiro, na ordem em que
+  /// aparecem lá, e o resto do alfabeto embaixo.
+  ///
+  /// Sem moedas em destaque — ou quando a busca não deixou nenhuma delas na
+  /// lista — não há o que separar, e a lista sai sem títulos: dois títulos com
+  /// uma seção vazia entre eles só ocupariam espaço.
+  List<_PickerEntry> _entries(Locale locale, MyAppLocalizations localizations) {
+    var matches = _matchingCurrencies(locale);
+    var priority = widget.priorityCurrencies
+        .where(matches.contains)
+        // Uma moeda repetida na configuração viraria duas linhas iguais.
+        .toSet()
+        .toList();
+    if (priority.isEmpty) {
+      return [for (var currency in matches) _PickerEntry.currency(currency)];
+    }
+    return [
+      _PickerEntry.section(localizations.conversionCurrencyPickerYoursLabel!),
+      for (var currency in priority) _PickerEntry.currency(currency),
+      _PickerEntry.section(localizations.conversionCurrencyPickerOthersLabel!),
+      for (var currency in matches)
+        if (!priority.contains(currency)) _PickerEntry.currency(currency),
+    ];
+  }
+
+  Widget _entryTile(_PickerEntry entry, Locale locale, double scale) {
+    var sectionTitle = entry.sectionTitle;
+    if (sectionTitle != null) {
+      return _SectionHeader(title: sectionTitle, scale: scale);
+    }
+    var currency = entry.currency!;
+    return _CurrencyOptionTile(
+      currency: currency,
+      locale: locale,
+      scale: scale,
+      isSelected: currency == widget.selectedCurrency,
+      onTap: () => Navigator.of(context).pop(currency),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final localizations = MyAppLocalizations.of(context)!;
     final locale = Localizations.localeOf(context);
     final scale = Responsive.scaleFactor(context);
     final textTheme = Theme.of(context).textTheme;
-    final currencies = _matchingCurrencies(locale);
+    final entries = _entries(locale, localizations);
 
     return SizedBox(
       height: MediaQuery.of(context).size.height * 0.8,
@@ -143,7 +231,7 @@ class _CurrencyPickerSheetState extends State<_CurrencyPickerSheet> {
             ),
             SizedBox(height: 8 * scale),
             Expanded(
-              child: currencies.isEmpty
+              child: entries.isEmpty
                   ? Center(
                       child: Padding(
                         padding: EdgeInsets.all(24 * scale),
@@ -156,19 +244,47 @@ class _CurrencyPickerSheetState extends State<_CurrencyPickerSheet> {
                     )
                   : ListView.builder(
                       controller: _listController,
-                      itemExtent: _tileExtent(scale),
-                      itemCount: currencies.length,
-                      itemBuilder: (context, index) => _CurrencyOptionTile(
-                        currency: currencies[index],
-                        locale: locale,
-                        scale: scale,
-                        isSelected: currencies[index] == widget.selectedCurrency,
-                        onTap: () =>
-                            Navigator.of(context).pop(currencies[index]),
+                      itemCount: entries.length,
+                      itemBuilder: (context, index) => SizedBox(
+                        // A altura de cada linha vem do mesmo lugar que a
+                        // conta da rolagem inicial: se as duas divergirem, a
+                        // lista abre fora da moeda escolhida.
+                        height: _entryExtent(entries[index], scale),
+                        child: _entryTile(entries[index], locale, scale),
                       ),
                     ),
             ),
           ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Título de uma das duas seções da lista.
+class _SectionHeader extends StatelessWidget {
+  final String title;
+  final double scale;
+
+  const _SectionHeader({required this.title, required this.scale});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Padding(
+      padding:
+          EdgeInsets.fromLTRB(16 * scale, 12 * scale, 16 * scale, 4 * scale),
+      child: Align(
+        alignment: AlignmentDirectional.centerStart,
+        child: Text(
+          title,
+          style: TextStyle(
+            fontSize: 12 * scale,
+            fontWeight: FontWeight.w700,
+            letterSpacing: 0.6,
+            color: colorScheme.primary,
+          ),
         ),
       ),
     );

--- a/test/blocs/conversion_page_bloc_test.dart
+++ b/test/blocs/conversion_page_bloc_test.dart
@@ -177,6 +177,82 @@ void main() {
           () => bloc.conversionResultSink.add(bloc.result), throwsStateError);
     });
 
+    test('abre no par pedido por quem chamou a tela', () async {
+      var bloc = ConversionPageBloc(
+          exchangeValueBloc: exchangeValueBloc,
+          initialFromCurrency: Currencies.USD,
+          initialToCurrency: Currencies.EUR);
+      addTearDown(bloc.dispose);
+
+      expect(bloc.fromCurrency, Currencies.USD);
+      expect(bloc.toCurrency, Currencies.EUR);
+      expect(bloc.result.from, Currencies.USD,
+          reason: "a tela desenha o primeiro quadro a partir do resultado");
+      expect(bloc.result.to, Currencies.EUR);
+    });
+
+    test('só a origem pedida deixa o destino no padrão', () async {
+      var bloc = ConversionPageBloc(
+          exchangeValueBloc: exchangeValueBloc,
+          initialFromCurrency: Currencies.EUR);
+      addTearDown(bloc.dispose);
+
+      expect(bloc.fromCurrency, Currencies.EUR);
+      expect(bloc.toCurrency, Currencies.USD);
+    });
+
+    test('o mesmo par dos dois lados vira uma conversão de verdade', () async {
+      // Acontece com a bolha da própria moeda de contrapartida: a tela inicial
+      // pede real para real.
+      var bloc = ConversionPageBloc(
+          exchangeValueBloc: exchangeValueBloc,
+          initialFromCurrency: Currencies.BRL,
+          initialToCurrency: Currencies.BRL);
+      addTearDown(bloc.dispose);
+
+      expect(bloc.fromCurrency, Currencies.BRL);
+      expect(bloc.toCurrency, Currencies.USD);
+
+      var dollarBloc = ConversionPageBloc(
+          exchangeValueBloc: exchangeValueBloc,
+          initialFromCurrency: Currencies.USD,
+          initialToCurrency: Currencies.USD);
+      addTearDown(dollarBloc.dispose);
+
+      expect(dollarBloc.fromCurrency, Currencies.USD);
+      expect(dollarBloc.toCurrency, Currencies.BRL,
+          reason: "o outro lado do par padrão, para o par não ficar repetido");
+    });
+
+    test('converte o par pedido sem esperar nenhuma escolha', () async {
+      var bloc = ConversionPageBloc(
+          exchangeValueBloc: exchangeValueBloc,
+          initialFromCurrency: Currencies.USD,
+          initialToCurrency: Currencies.BRL);
+      addTearDown(bloc.dispose);
+
+      await bloc.updateResult();
+
+      expect(bloc.result.unitRate, closeTo(5, 0.000001),
+          reason: "um dólar vale cinco reais nas cotações do teste");
+    });
+
+    test('guarda as moedas em destaque para o seletor', () async {
+      var bloc = ConversionPageBloc(
+          exchangeValueBloc: exchangeValueBloc,
+          priorityCurrencies: [Currencies.EUR, Currencies.JPY]);
+      addTearDown(bloc.dispose);
+
+      expect(bloc.priorityCurrencies, [Currencies.EUR, Currencies.JPY]);
+      expect(() => bloc.priorityCurrencies.add(Currencies.USD),
+          throwsUnsupportedError,
+          reason: "a lista é do bloc, não de quem a leu");
+    });
+
+    test('sem moedas em destaque a lista fica vazia', () async {
+      expect(bloc.priorityCurrencies, isEmpty);
+    });
+
     test('não emite resultado depois de descartado', () async {
       exchangeValueBloc.holdLookups = true;
       var conversion = bloc.updateResult();

--- a/test/blocs/home_bloc_test.dart
+++ b/test/blocs/home_bloc_test.dart
@@ -57,6 +57,30 @@ void main() {
     });
   });
 
+  group('HomeBloc.loadCounterCurrency', () {
+    test('devolve o real quando não há moeda sobrescrita', () async {
+      expect(await buildBloc().loadCounterCurrency(), Currencies.BRL);
+    });
+
+    test('devolve a moeda escolhida nas configurações', () async {
+      var bloc = buildBloc(
+          configuration: Configuration(1,
+              overrideDefaultCurrency: true,
+              selectedOverrideCurrencyCode: "JPY"));
+
+      expect(await bloc.loadCounterCurrency(), Currencies.JPY);
+    });
+
+    test('uma moeda que o app não conhece não vira contrapartida', () async {
+      var bloc = buildBloc(
+          configuration: Configuration(1,
+              overrideDefaultCurrency: true,
+              selectedOverrideCurrencyCode: "XYZ"));
+
+      expect(await bloc.loadCounterCurrency(), isNull);
+    });
+  });
+
   group('HomeBloc.loadHomeCurrencies', () {
     HomeBloc buildBlocWithConfiguration(Configuration configuration) => HomeBloc(
         currencyRepository: CurrencyRepository.withDependencies(

--- a/test/util/localizations_test.dart
+++ b/test/util/localizations_test.dart
@@ -19,6 +19,8 @@ List<String?> _allLabels(MyAppLocalizations localizations) => [
       localizations.conversionCurrencyPickerTitle,
       localizations.conversionCurrencySearchHint,
       localizations.conversionCurrencyNotFoundLabel,
+      localizations.conversionCurrencyPickerYoursLabel,
+      localizations.conversionCurrencyPickerOthersLabel,
       localizations.conversionRateUnavailableLabel,
       localizations.conversionCopyResultTooltip,
       localizations.conversionResultCopiedLabel,

--- a/test/view/conversion_widget_test.dart
+++ b/test/view/conversion_widget_test.dart
@@ -157,6 +157,85 @@ void main() {
       expect(find.text("Cotação indisponível"), findsOneWidget);
     });
 
+    testWidgets('o seletor abre com as moedas da tela inicial em destaque',
+        (WidgetTester tester) async {
+      // As bolhas da tela inicial: elas chegam aqui pelo bloc e devem abrir a
+      // lista, antes das outras trinta e tantas moedas.
+      bloc.dispose();
+      bloc = ConversionPageBloc(
+          exchangeValueBloc: _FakeExchangeValueBloc(),
+          priorityCurrencies: [Currencies.EUR, Currencies.BRL]);
+      await pumpConversionPage(tester);
+
+      await tester.tap(find.text("BRL"));
+      await tester.pumpAndSettle();
+
+      expect(find.text("Suas moedas"), findsOneWidget);
+      expect(find.text("Todas as moedas"), findsOneWidget);
+      expect(inCurrencyPicker(find.text("EUR")), findsOneWidget,
+          reason: "a moeda em destaque não se repete no resto da lista");
+      expect(
+          tester.getTopLeft(inCurrencyPicker(find.text("EUR"))).dy,
+          lessThan(tester.getTopLeft(find.text("Todas as moedas")).dy),
+          reason: "as moedas da tela inicial vêm antes do resto da lista");
+    });
+
+    testWidgets('converte com a moeda escolhida na seção de destaque',
+        (WidgetTester tester) async {
+      bloc.dispose();
+      bloc = ConversionPageBloc(
+          exchangeValueBloc: _FakeExchangeValueBloc(),
+          priorityCurrencies: [Currencies.EUR, Currencies.BRL]);
+      await pumpConversionPage(tester);
+
+      await tester.tap(find.text("BRL"));
+      await tester.pumpAndSettle();
+      await tester.tap(inCurrencyPicker(find.text("EUR")));
+      await tester.pumpAndSettle();
+
+      expect(find.text("1 EUR = 2,0000 USD"), findsOneWidget);
+    });
+
+    testWidgets('sem moedas em destaque a lista sai sem seções',
+        (WidgetTester tester) async {
+      await pumpConversionPage(tester);
+
+      await tester.tap(find.text("BRL"));
+      await tester.pumpAndSettle();
+
+      expect(find.text("Suas moedas"), findsNothing);
+      expect(find.text("Todas as moedas"), findsNothing);
+    });
+
+    testWidgets('a busca que não acha nenhuma moeda em destaque tira as seções',
+        (WidgetTester tester) async {
+      bloc.dispose();
+      bloc = ConversionPageBloc(
+          exchangeValueBloc: _FakeExchangeValueBloc(),
+          priorityCurrencies: [Currencies.EUR, Currencies.BRL]);
+      await pumpConversionPage(tester);
+
+      await tester.tap(find.text("BRL"));
+      await tester.pumpAndSettle();
+      await searchInCurrencyPicker(tester, "iene");
+
+      expect(find.text("Suas moedas"), findsNothing,
+          reason: "uma seção vazia só ocuparia espaço");
+      expect(inCurrencyPicker(find.text("JPY")), findsOneWidget);
+    });
+
+    testWidgets('a tela abre no par pedido pela tela inicial',
+        (WidgetTester tester) async {
+      bloc.dispose();
+      bloc = ConversionPageBloc(
+          exchangeValueBloc: _FakeExchangeValueBloc(),
+          initialFromCurrency: Currencies.USD,
+          initialToCurrency: Currencies.BRL);
+      await pumpConversionPage(tester);
+
+      expect(find.text("1 USD = 5,0000 BRL"), findsOneWidget);
+    });
+
     testWidgets('escolher no destino a moeda de origem inverte o par',
         (WidgetTester tester) async {
       await pumpConversionPage(tester);

--- a/test/view/currency_rate_card_test.dart
+++ b/test/view/currency_rate_card_test.dart
@@ -1,0 +1,43 @@
+import 'package:cotacao_direta/view/widgets/currency_rate_card.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// A bolha de cotação da tela inicial. O toque nela é o atalho para a
+/// conversão da moeda que ela mostra, então precisa chegar ao chamador.
+Widget _cardApp(Widget card) => MaterialApp(home: Scaffold(body: card));
+
+void main() {
+  group('CurrencyRateCard', () {
+    testWidgets('avisa o toque a quem passou o cartão',
+        (WidgetTester tester) async {
+      var taps = 0;
+      await tester.pumpWidget(_cardApp(CurrencyRateCard(
+        color: Colors.green,
+        icon: Icons.attach_money,
+        code: "USD",
+        label: "Dólar Americano",
+        valueWidget: const Text("5,00"),
+        onTap: () => taps++,
+      )));
+
+      await tester.tap(find.text("USD"));
+      await tester.pumpAndSettle();
+
+      expect(taps, 1);
+    });
+
+    testWidgets('sem onTap o cartão não reage ao toque',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(_cardApp(CurrencyRateCard(
+        color: Colors.green,
+        icon: Icons.attach_money,
+        code: "USD",
+        label: "Dólar Americano",
+        valueWidget: const Text("5,00"),
+      )));
+
+      expect(find.byType(GestureDetector), findsNothing,
+          reason: "um detector sem ação só atrapalharia a rolagem da grade");
+    });
+  });
+}


### PR DESCRIPTION
## O que muda

Duas melhorias de usabilidade na tela inicial e na de conversão:

1. **Cada bolha da grade Bento leva à conversão da sua moeda.** Tocar na bolha do dólar abre a tela de conversão já convertendo dólar para a contrapartida das cotações — o mesmo par que a bolha mostrava. Antes era preciso abrir a conversão pelo botão flutuante e reencontrar a moeda numa lista de mais de trinta. O botão flutuante continua abrindo a tela no par padrão (real para dólar), para quem quer converter sem partir de nenhuma das moedas mostradas.

2. **As moedas da tela inicial abrem o seletor da tela de conversão.** O seletor ganha uma seção "Suas moedas", com as escolhidas para a tela inicial na ordem em que aparecem lá, e o resto do alfabeto embaixo, sob "Todas as moedas". São as moedas que o usuário acompanha, então são também as que ele mais converte.

## Detalhes de implementação

- `ConversionPageBloc` aceita o par inicial (`initialFromCurrency`/`initialToCurrency`) e a lista de moedas em destaque (`priorityCurrencies`), repassados pelo `ConversionPageBlocProvider` quando é ele quem cria o bloc. Um bloc pronto, fornecido pelo chamador, continua vindo com as suas escolhas feitas.
- Pedir a mesma moeda dos dois lados cai no outro lado do par padrão: a tela nunca abre convertendo uma moeda para ela mesma. Isso acontece de verdade com a bolha da própria moeda de contrapartida, que o usuário pode incluir na tela inicial.
- A tela inicial passa a guardar a moeda de contrapartida (`HomeBloc.loadCounterCurrency`), relida junto com o resto da tela, para o toque numa bolha não esperar uma leitura do banco no meio da navegação.
- No seletor, a rolagem inicial — que deixava a moeda escolhida perto do topo — passa a somar as alturas das linhas em vez de multiplicar pela altura de uma: com os títulos de seção, nem toda linha tem a mesma altura. O `itemExtent` do `ListView` deu lugar a um `SizedBox` por linha, com a altura vinda da mesma função que alimenta a conta da rolagem.
- Uma moeda em destaque não se repete no resto da lista, e uma busca que não deixa nenhuma delas na lista devolve a lista sem títulos: duas seções com uma delas vazia só ocupariam espaço.
- Textos novos nos dois idiomas: "Suas moedas"/"Your currencies" e "Todas as moedas"/"All currencies".

## Testes

`flutter analyze` sem apontamentos e `flutter test` com 502 testes passando (Flutter 3.44.8, a versão do CI). Testes novos:

- `ConversionPageBloc`: abre no par pedido, só a origem pedida deixa o destino no padrão, o mesmo par dos dois lados vira uma conversão de verdade, converte o par pedido sem esperar escolha, e a lista de moedas em destaque não é alterável de fora.
- `ConversionPage`: o seletor abre com as moedas da tela inicial acima do resto, escolher uma delas converte, sem moedas em destaque a lista sai sem seções, uma busca que não acha nenhuma delas também tira as seções, e a tela abre no par pedido.
- `HomeBloc.loadCounterCurrency`: real por padrão, a moeda escolhida nas configurações, e nulo para um código que o app não conhece.
- `CurrencyRateCard`: o toque chega a quem passou o cartão, e sem `onTap` o cartão não reage.

A ligação dentro de `HomeState` (o `onTap` da bolha chamando `_openConversionPage`) não entrou em teste de widget: a tela inicial monta as seis abas de uma vez, com blocs que vão a banco e rede, e o repositório não tem teste de widget para ela por esse motivo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CtxwEU1DrHK3xkZWfYuyC7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CtxwEU1DrHK3xkZWfYuyC7)_