### PR TITLE
Permite escolher o idioma da aplicação nas opções

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,29 @@ não com o dart2js dos builds): em desenvolvimento o cache só atrapalharia, com
 o hot restart mostrando código velho. Para testar o comportamento sem rede,
 então, é preciso o build.
 
+## Idioma da interface
+
+O app tem textos em português e inglês, e sempre seguiu o idioma do aparelho.
+A aba **Opções** agora permite fixar um deles, para quem usa o aparelho em um
+idioma e prefere o app em outro.
+
+A lista oferecida é exatamente a da build: `AppLocales.supported`, em
+`lib/util/localizations.dart`, é a mesma fonte que alimenta o
+`supportedLocales` do `MaterialApp`, o `isSupported` do delegate de traduções
+e o seletor da tela de opções — acrescentar um idioma ao mapa de textos e a
+essa lista basta para ele aparecer nas três pontas.
+
+A escolha é gravada na tabela `Configurations` (coluna `languageCode`, migração
+8→9). Coluna vazia — o padrão, e o que os bancos já existentes recebem na
+migração — significa "seguir o aparelho", que é o comportamento anterior. Quem
+precisa do valor é o `MaterialApp` na raiz da árvore, acima dos blocs, então
+ele chega lá pelo `AppLocaleController` (`lib/util/app_locale_controller.dart`),
+um `ValueNotifier<Locale?>` de escopo do app: a tela de opções o atualiza junto
+com a gravação e o app inteiro é reconstruído no idioma novo na hora. Um código
+que a build não conhece — por exemplo ao instalar por cima de uma versão com
+mais traduções — é tratado como "seguir o aparelho", em vez de deixar a
+interface sem textos.
+
 ## IA local: insights e projeções
 
 A aba **IA** analisa um ativo (moeda ou criptomoeda) e mostra um resumo de

--- a/lib/blocs/configurations_page_bloc.dart
+++ b/lib/blocs/configurations_page_bloc.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:cotacao_direta/blocs/base_bloc.dart';
 import 'package:cotacao_direta/model/configuration.dart';
 import 'package:cotacao_direta/repository/configuration_repository.dart';
+import 'package:cotacao_direta/util/app_locale_controller.dart';
 import 'package:cotacao_direta/view/widgets/widget_state_helpers/override_currency_state_helper.dart';
 
 class ConfigurationsPageBloc extends BaseBloc {
@@ -10,10 +11,17 @@ class ConfigurationsPageBloc extends BaseBloc {
       OverrideCurrencyStateHelper();
   final ConfigurationRepository _configurationRepository;
 
+  /// Quem leva o idioma escolhido até o MaterialApp da raiz, que está acima
+  /// deste bloc na árvore e por isso não pode ouvir os streams daqui.
+  final AppLocaleController _localeController;
+
   /// O repositório é injetável para os testes rodarem sem tocar no banco.
-  ConfigurationsPageBloc({ConfigurationRepository? configurationRepository})
+  ConfigurationsPageBloc(
+      {ConfigurationRepository? configurationRepository,
+      AppLocaleController? localeController})
       : _configurationRepository =
-            configurationRepository ?? ConfigurationRepository();
+            configurationRepository ?? ConfigurationRepository(),
+        _localeController = localeController ?? AppLocaleController.instance;
 
   StreamController _currencyOptionsStreamController = StreamController();
 
@@ -30,6 +38,12 @@ class ConfigurationsPageBloc extends BaseBloc {
   List<String> _homeCurrencyCodes =
       List.of(Configuration.defaultHomeCurrencyCodes);
 
+  // Idioma da interface escolhido pelo usuário. Vazio é "seguir o aparelho".
+  StreamController<String> _languageStreamController =
+      StreamController<String>.broadcast();
+
+  String _languageCode = "";
+
   Stream get currencyOptionsStream => _currencyOptionsStreamController.stream;
 
   Stream<List<String>> get homeCurrenciesStream =>
@@ -38,6 +52,12 @@ class ConfigurationsPageBloc extends BaseBloc {
   /// Última lista conhecida, para a tela ter o que mostrar antes de a leitura
   /// do banco terminar.
   List<String> get homeCurrencyCodes => _homeCurrencyCodes;
+
+  Stream<String> get languageStream => _languageStreamController.stream;
+
+  /// Último idioma conhecido, para a tela ter o que mostrar no seletor antes
+  /// de a leitura do banco terminar.
+  String get languageCode => _languageCode;
 
   Stream get overrideDefaultCurrencyValueStream =>
       _overrideDefaultCurrencyValueStreamController.stream;
@@ -59,6 +79,8 @@ class ConfigurationsPageBloc extends BaseBloc {
       overrideDefaultCurrencyValueSink.add(_overrideCurrencyStateHelper);
       _homeCurrencyCodes = List.of(configuration.homeCurrencyCodes);
       _homeCurrenciesStreamController.sink.add(_homeCurrencyCodes);
+      _languageCode = configuration.languageCode;
+      _languageStreamController.sink.add(_languageCode);
     });
   }
 
@@ -74,6 +96,21 @@ class ConfigurationsPageBloc extends BaseBloc {
     _homeCurrenciesStreamController.sink.add(_homeCurrencyCodes);
     var configuration = await _configurationRepository.getConfiguration();
     configuration.homeCurrencyCodes = List.of(currencyCodes);
+    await _configurationRepository.insert(configuration);
+  }
+
+  /// Grava o idioma da interface e o aplica na hora.
+  ///
+  /// [languageCode] nulo ou vazio volta a seguir o aparelho, que é o padrão.
+  /// A troca vai para o controlador antes da gravação: a tela toda é
+  /// reconstruída no idioma novo assim que o usuário escolhe, sem esperar o
+  /// banco.
+  Future<void> updateLanguage(String? languageCode) async {
+    _languageCode = Configuration.parseLanguageCode(languageCode);
+    _languageStreamController.sink.add(_languageCode);
+    _localeController.updateLanguage(_languageCode);
+    var configuration = await _configurationRepository.getConfiguration();
+    configuration.languageCode = _languageCode;
     await _configurationRepository.insert(configuration);
   }
 
@@ -122,5 +159,6 @@ class ConfigurationsPageBloc extends BaseBloc {
     _overrideDefaultCurrencyValueStreamController.close();
     _selectedCurrencyCodeStreamController.close();
     _homeCurrenciesStreamController.close();
+    _languageStreamController.close();
   }
 }

--- a/lib/dao/configuration_dao.dart
+++ b/lib/dao/configuration_dao.dart
@@ -18,7 +18,8 @@ class ConfigurationDao {
           "id",
           "overrideDefaultCurrency",
           "selectedOverrideCurrencyCode",
-          "homeCurrencyCodes"
+          "homeCurrencyCodes",
+          "languageCode"
         ],
         where: "id = ?",
         whereArgs: [configurationId],
@@ -31,6 +32,7 @@ class ConfigurationDao {
               result?.first["overrideDefaultCurrency"] == 1,
           selectedOverrideCurrencyCode:
               result?.first["selectedOverrideCurrencyCode"] as String?,
+          languageCode: result?.first["languageCode"] as String?,
           homeCurrencyCodes: Configuration.parseHomeCurrencyCodes(
               result?.first["homeCurrencyCodes"] as String?));
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:cotacao_direta/providers/currency_alerts_bloc_provider.dart';
 import 'package:cotacao_direta/providers/home_bloc_provider.dart';
+import 'package:cotacao_direta/util/app_locale_controller.dart';
 import 'package:cotacao_direta/util/currency_colors.dart';
 import 'package:cotacao_direta/util/localizations.dart';
 import 'package:cotacao_direta/util/notification_service.dart';
@@ -13,6 +14,9 @@ void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   // Stetho.initialize();
   await NotificationService().initialize();
+  // Antes do primeiro quadro: a tela já abre no idioma escolhido, em vez de
+  // aparecer no do aparelho e trocar em seguida.
+  await AppLocaleController.instance.load();
   return runApp(MyApp());
 }
 
@@ -21,8 +25,26 @@ class MyApp extends StatelessWidget {
 
   final appName = "Cotação Direta";
 
+  /// O idioma escolhido nas configurações. Injetável para os testes montarem
+  /// o app sem depender do controlador global.
+  final AppLocaleController localeController;
+
+  MyApp({Key? key, AppLocaleController? localeController})
+      : localeController = localeController ?? AppLocaleController.instance,
+        super(key: key);
+
   @override
   Widget build(BuildContext context) {
+    // Escutar aqui, na raiz, é o que faz a troca de idioma valer para o app
+    // inteiro assim que o usuário escolhe.
+    return ValueListenableBuilder<Locale?>(
+      valueListenable: localeController,
+      builder: (BuildContext context, Locale? locale, _) =>
+          _buildApp(context, locale),
+    );
+  }
+
+  Widget _buildApp(BuildContext context, Locale? locale) {
     return MaterialApp(
       localizationsDelegates: [
         GlobalMaterialLocalizations.delegate,
@@ -44,7 +66,10 @@ class MyApp extends StatelessWidget {
         fontFamily: "Roboto",
       ),
       themeMode: ThemeMode.system,
-      supportedLocales: [const Locale("en"), const Locale("pt")],
+      // Nulo deixa o Flutter resolver pelo idioma do aparelho, como antes de a
+      // opção existir.
+      locale: locale,
+      supportedLocales: AppLocales.supported,
       title: appName,
       home: HomeBlocProvider(
         child: CurrencyAlertsBlocProvider(

--- a/lib/model/configuration.dart
+++ b/lib/model/configuration.dart
@@ -15,6 +15,11 @@ class Configuration extends BaseModel {
   bool overrideDefaultCurrency;
   String? selectedOverrideCurrencyCode;
 
+  /// Idioma escolhido para a interface, no formato do código do Locale
+  /// ("pt", "en"). Vazio — o padrão da coluna e o que a migração deixa para
+  /// quem já usava o app — significa "seguir o aparelho".
+  String languageCode;
+
   /// Códigos das moedas que viram bolha na tela inicial, na ordem em que
   /// aparecem — a primeira é a bolha de destaque.
   List<String> homeCurrencyCodes;
@@ -22,9 +27,17 @@ class Configuration extends BaseModel {
   Configuration(this.id,
       {this.overrideDefaultCurrency = false,
       this.selectedOverrideCurrencyCode = "",
+      String? languageCode,
       List<String>? homeCurrencyCodes})
-      : homeCurrencyCodes =
+      : languageCode = parseLanguageCode(languageCode),
+        homeCurrencyCodes =
             homeCurrencyCodes ?? List.of(defaultHomeCurrencyCodes);
+
+  /// Normaliza o idioma gravado: espaços e caixa vindos do banco não podem
+  /// virar um código que não bate com nenhum idioma da build, e nulo é o mesmo
+  /// que "seguir o aparelho".
+  static String parseLanguageCode(String? storedValue) =>
+      storedValue?.trim().toLowerCase() ?? "";
 
   /// Lê a lista guardada em uma única coluna de texto, separada por vírgula.
   ///
@@ -48,6 +61,7 @@ class Configuration extends BaseModel {
       'overrideDefaultCurrency': overrideDefaultCurrency ? 1 : 0,
       'selectedOverrideCurrencyCode': selectedOverrideCurrencyCode,
       'homeCurrencyCodes': homeCurrencyCodes.join(","),
+      'languageCode': languageCode,
     };
   }
 
@@ -58,6 +72,7 @@ class Configuration extends BaseModel {
         "overrideDefaultCurrency: $overrideDefaultCurrency,\n"
         "selectedOverrideCurrencyCode: $selectedOverrideCurrencyCode, \n"
         "homeCurrencyCodes: ${homeCurrencyCodes.join(",")}, \n"
+        "languageCode: $languageCode, \n"
         "}";
   }
 }

--- a/lib/util/app_locale_controller.dart
+++ b/lib/util/app_locale_controller.dart
@@ -1,0 +1,52 @@
+import 'package:cotacao_direta/repository/configuration_repository.dart';
+import 'package:cotacao_direta/util/localizations.dart';
+import 'package:flutter/material.dart';
+
+/// O idioma da interface escolhido nas configurações.
+///
+/// A opção fica gravada no banco como as outras, mas quem precisa dela é o
+/// [MaterialApp] na raiz da árvore — acima dos blocs, que só existem dentro da
+/// home. Um notificador de escopo do app é o caminho mais curto entre a tela
+/// de opções e essa raiz; [ValueNotifier] já basta porque o valor é um só e
+/// muda muito de vez em quando.
+///
+/// Nulo significa "seguir o aparelho": é o que o app sempre fez, e continua
+/// sendo o padrão.
+class AppLocaleController extends ValueNotifier<Locale?> {
+  final ConfigurationRepository _configurationRepository;
+
+  /// A instância que o aplicativo usa. Os testes constroem a sua própria, com
+  /// um repositório de mentira, em vez de mexer nesta.
+  static final AppLocaleController instance = AppLocaleController();
+
+  AppLocaleController({ConfigurationRepository? configurationRepository})
+      : _configurationRepository =
+            configurationRepository ?? ConfigurationRepository(),
+        super(null);
+
+  /// Lê o idioma gravado. Chamada na partida do app, antes do primeiro quadro,
+  /// para a tela já abrir no idioma certo em vez de piscar no do aparelho.
+  ///
+  /// Uma falha de leitura não pode impedir o app de abrir: sem configuração
+  /// legível o idioma continua sendo o do aparelho.
+  Future<void> load() async {
+    try {
+      var configuration = await _configurationRepository.getConfiguration();
+      value = AppLocales.localeFor(configuration.languageCode);
+    } catch (error, stackTrace) {
+      FlutterError.reportError(FlutterErrorDetails(
+          exception: error,
+          stack: stackTrace,
+          library: "cotacao_direta",
+          context: ErrorDescription("lendo o idioma escolhido")));
+      value = null;
+    }
+  }
+
+  /// Aplica o idioma escolhido na tela de opções. Código vazio ou nulo volta a
+  /// seguir o aparelho. A gravação fica com o bloc, que já cuida do resto da
+  /// configuração.
+  void updateLanguage(String? languageCode) {
+    value = AppLocales.localeFor(languageCode);
+  }
+}

--- a/lib/util/database.dart
+++ b/lib/util/database.dart
@@ -84,6 +84,14 @@ class AppDatabase {
     "ALTER TABLE Configurations ADD homeCurrencyCodes TEXT NOT NULL DEFAULT ''"
   ];
 
+  // O idioma da interface passa a ser escolhido nas configurações, em vez de
+  // vir sempre do aparelho. A coluna guarda o código do Locale ("pt", "en");
+  // vazia — o que os bancos já existentes recebem aqui — significa "seguir o
+  // aparelho", que é o comportamento que o app sempre teve.
+  var migrationsScripts8_9 = [
+    "ALTER TABLE Configurations ADD languageCode TEXT NOT NULL DEFAULT ''"
+  ];
+
   /// Scripts a aplicar para chegar em cada versão, na ordem.
   Map<int, List<String>> get _migrationsByVersion => {
         2: migrationsScripts1_2,
@@ -93,6 +101,7 @@ class AppDatabase {
         6: migrationsScripts5_6,
         7: migrationsScripts6_7,
         8: migrationsScripts7_8,
+        9: migrationsScripts8_9,
       };
 
   /// A abertura em andamento. Guardar o Future (e não só o Database pronto) é o
@@ -113,7 +122,7 @@ class AppDatabase {
         await db.execute(
             "CREATE TABLE Currency(id TEXT, value REAL, timestamp TEXT, historicalDate TEXT, friendlyName TEXT NOT NULL DEFAULT '', counterCurrency TEXT NOT NULL DEFAULT 'BRL', PRIMARY KEY(id, historicalDate, counterCurrency))");
         await db.execute(
-            "CREATE TABLE Configurations(id INT PRIMARY KEY, overrideDefaultCurrency INTEGER, selectedOverrideCurrencyCode TEXT, homeCurrencyCodes TEXT NOT NULL DEFAULT '')");
+            "CREATE TABLE Configurations(id INT PRIMARY KEY, overrideDefaultCurrency INTEGER, selectedOverrideCurrencyCode TEXT, homeCurrencyCodes TEXT NOT NULL DEFAULT '', languageCode TEXT NOT NULL DEFAULT '')");
         await db.execute(
             "CREATE TABLE CurrencyAlerts(id INTEGER PRIMARY KEY AUTOINCREMENT, currencyCode TEXT NOT NULL, targetValue REAL NOT NULL, condition TEXT NOT NULL, triggered INTEGER NOT NULL DEFAULT 0, active INTEGER NOT NULL DEFAULT 1)");
       }, onUpgrade: (database, oldVersion, newVersion) async {
@@ -124,7 +133,7 @@ class AppDatabase {
             await database.execute(script);
           }
         }
-      }, version: 8);
+      }, version: 9);
     return _database;
   }
 }

--- a/lib/util/localizations.dart
+++ b/lib/util/localizations.dart
@@ -1,6 +1,41 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
+/// Os idiomas que entram na build do aplicativo.
+///
+/// É a mesma lista que o MaterialApp declara em supportedLocales, que o
+/// [MyAppLocalizationsDelegate] aceita e que a tela de opções oferece: com uma
+/// fonte única, acrescentar uma tradução ao mapa de textos é o bastante para
+/// ela aparecer nas três pontas.
+class AppLocales {
+  static const List<Locale> supported = [Locale("en"), Locale("pt")];
+
+  /// Nome de cada idioma escrito nele mesmo. Quem está com o app em um idioma
+  /// que não entende precisa reconhecer o seu na lista para conseguir voltar,
+  /// então estes nomes não são traduzidos.
+  static const Map<String, String> displayNames = {
+    "en": "English",
+    "pt": "Português",
+  };
+
+  static bool isSupported(String? languageCode) =>
+      supported.any((locale) => locale.languageCode == languageCode);
+
+  /// O idioma gravado nas configurações como [Locale], ou nulo para seguir o
+  /// aparelho — o que também vale para um código que esta build não tem, caso
+  /// o app seja instalado por cima de uma versão com mais traduções.
+  static Locale? localeFor(String? languageCode) {
+    if (languageCode == null || languageCode.isEmpty) return null;
+    if (!isSupported(languageCode)) return null;
+    return Locale(languageCode);
+  }
+
+  /// O nome a mostrar para um código de idioma, com o próprio código como
+  /// último recurso.
+  static String displayNameOf(String languageCode) =>
+      displayNames[languageCode] ?? languageCode;
+}
+
 class MyAppLocalizations {
   MyAppLocalizations(this.locale);
 
@@ -51,6 +86,8 @@ class MyAppLocalizations {
       'homeCurrenciesSelectedCountLabel': '%s selected',
       'homeCurrenciesEmptySelectionLabel': 'Choose at least one currency',
       'homeCurrenciesSaveBtnLabel': 'Save',
+      'appLanguageSettingLabel': 'App language',
+      'appLanguageSystemOptionLabel': 'System language',
       'appConfigurationsSectionLabel': 'App Configurations',
       'pwaInstallSectionLabel': 'Install on this device',
       'pwaInstallCardLabel': 'Install app',
@@ -203,6 +240,8 @@ class MyAppLocalizations {
       'homeCurrenciesSelectedCountLabel': '%s escolhidas',
       'homeCurrenciesEmptySelectionLabel': 'Escolha pelo menos uma moeda',
       'homeCurrenciesSaveBtnLabel': 'Salvar',
+      'appLanguageSettingLabel': 'Idioma do aplicativo',
+      'appLanguageSystemOptionLabel': 'Idioma do sistema',
       'appConfigurationsSectionLabel': 'Configurações do Aplicativo',
       'pwaInstallSectionLabel': 'Instalar no aparelho',
       'pwaInstallCardLabel': 'Instalar aplicativo',
@@ -486,6 +525,15 @@ class MyAppLocalizations {
   String? get homeCurrenciesSaveBtnLabel {
     return _localizedValues[locale.languageCode]!
         ['homeCurrenciesSaveBtnLabel'];
+  }
+
+  String? get appLanguageSettingLabel {
+    return _localizedValues[locale.languageCode]!['appLanguageSettingLabel'];
+  }
+
+  String? get appLanguageSystemOptionLabel {
+    return _localizedValues[locale.languageCode]!
+        ['appLanguageSystemOptionLabel'];
   }
 
   String? get appConfigurationsSectionLabel {
@@ -873,7 +921,7 @@ class MyAppLocalizations {
 class MyAppLocalizationsDelegate
     extends LocalizationsDelegate<MyAppLocalizations> {
   @override
-  bool isSupported(Locale locale) => ["en", "pt"].contains(locale.languageCode);
+  bool isSupported(Locale locale) => AppLocales.isSupported(locale.languageCode);
 
   @override
   Future<MyAppLocalizations> load(Locale locale) {

--- a/lib/view/pages/main_menu_items/configurations_page.dart
+++ b/lib/view/pages/main_menu_items/configurations_page.dart
@@ -218,6 +218,71 @@ class ConfigurationsPage extends StatelessWidget {
                 },
               ),
             ),
+            SizedBox(height: 12 * _scale),
+
+            // O app seguia o idioma do aparelho e pronto; aqui o usuário pode
+            // fixar um dos idiomas que existem nesta build.
+            AnimatedListEntry(
+              index: 3,
+              child: StreamBuilder<String>(
+                stream: _bloc.languageStream,
+                initialData: _bloc.languageCode,
+                builder: (BuildContext context, snapshot) {
+                  // "" é o idioma do aparelho; um código que esta build não
+                  // tem mais cai no mesmo lugar, senão o seletor ficaria com
+                  // um valor sem item correspondente.
+                  final selected = AppLocales.isSupported(snapshot.data)
+                      ? snapshot.data!
+                      : "";
+                  return BentoCard(
+                    padding: EdgeInsets.all(12 * _scale),
+                    child: Row(
+                      children: [
+                        _SettingBadge(
+                          icon: Icons.translate,
+                          color: CurrencyColors.cad,
+                          scale: _scale,
+                        ),
+                        SizedBox(width: 14 * _scale),
+                        Expanded(
+                          child: Text(
+                            _localization.appLanguageSettingLabel!,
+                            style: TextStyle(fontSize: 16 * _scale),
+                          ),
+                        ),
+                        DropdownButton<String>(
+                          items: [
+                            DropdownMenuItem(
+                              value: "",
+                              child: Text(
+                                _localization.appLanguageSystemOptionLabel!,
+                                style: TextStyle(fontSize: 16 * _scale),
+                              ),
+                            ),
+                            for (var locale in AppLocales.supported)
+                              DropdownMenuItem(
+                                value: locale.languageCode,
+                                child: Text(
+                                  AppLocales.displayNameOf(locale.languageCode),
+                                  style: TextStyle(fontSize: 16 * _scale),
+                                ),
+                              ),
+                          ],
+                          onChanged: (String? value) =>
+                              _bloc.updateLanguage(value),
+                          value: selected,
+                          iconSize: 24 * _scale,
+                          underline: const SizedBox.shrink(),
+                          borderRadius: BorderRadius.circular(
+                            BentoRadius.standard,
+                          ),
+                        ),
+                      ],
+                    ),
+                  );
+                },
+              ),
+            ),
           ],
         ),
       ),

--- a/test/blocs/configurations_page_bloc_test.dart
+++ b/test/blocs/configurations_page_bloc_test.dart
@@ -1,19 +1,29 @@
 import 'package:cotacao_direta/blocs/configurations_page_bloc.dart';
 import 'package:cotacao_direta/model/configuration.dart';
+import 'package:cotacao_direta/util/app_locale_controller.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../helpers/fakes.dart';
 
 void main() {
   late FakeConfigurationRepository repository;
+  late AppLocaleController localeController;
   late ConfigurationsPageBloc bloc;
 
   setUp(() {
     repository = FakeConfigurationRepository();
-    bloc = ConfigurationsPageBloc(configurationRepository: repository);
+    localeController =
+        AppLocaleController(configurationRepository: repository);
+    bloc = ConfigurationsPageBloc(
+        configurationRepository: repository,
+        localeController: localeController);
   });
 
-  tearDown(() => bloc.dispose());
+  tearDown(() {
+    bloc.dispose();
+    localeController.dispose();
+  });
 
   group('ConfigurationsPageBloc e as moedas da tela inicial', () {
     test('começa nas moedas padrão', () {
@@ -62,6 +72,77 @@ void main() {
       expect(configuration.overrideDefaultCurrency, isTrue);
       expect(configuration.selectedOverrideCurrencyCode, "EUR");
       expect(configuration.homeCurrencyCodes, ["GBP"]);
+    });
+  });
+
+  group('ConfigurationsPageBloc e o idioma da interface', () {
+    test('começa seguindo o idioma do aparelho', () {
+      expect(bloc.languageCode, "");
+      expect(localeController.value, isNull);
+    });
+
+    test('publica o idioma escolhido, grava e aplica na interface', () async {
+      var published = bloc.languageStream.first;
+
+      await bloc.updateLanguage("en");
+
+      expect(await published, "en");
+      expect(bloc.languageCode, "en");
+      expect(repository.inserted.single.languageCode, "en");
+      expect(localeController.value, const Locale("en"));
+    });
+
+    // Voltar para o idioma do aparelho é a opção padrão da lista, e precisa
+    // apagar a escolha gravada em vez de deixá-la no banco.
+    test('código vazio volta a seguir o aparelho', () async {
+      await bloc.updateLanguage("pt");
+
+      await bloc.updateLanguage("");
+
+      expect(bloc.languageCode, "");
+      expect(repository.configuration.languageCode, "");
+      expect(localeController.value, isNull);
+    });
+
+    test('nulo é lido como o idioma do aparelho', () async {
+      await bloc.updateLanguage(null);
+
+      expect(bloc.languageCode, "");
+      expect(localeController.value, isNull);
+    });
+
+    // Um idioma que esta build não tem — vindo de uma versão anterior com mais
+    // traduções — não pode deixar a interface sem textos.
+    test('um idioma fora da build cai no do aparelho', () async {
+      await bloc.updateLanguage("fr");
+
+      expect(localeController.value, isNull,
+          reason: "o app não tem tradução para esse código");
+    });
+
+    test('não mexe nas outras configurações ao gravar o idioma', () async {
+      repository.configuration = Configuration(1,
+          overrideDefaultCurrency: true,
+          selectedOverrideCurrencyCode: "EUR",
+          homeCurrencyCodes: ["GBP"]);
+
+      await bloc.updateLanguage("en");
+
+      var configuration = repository.configuration;
+      expect(configuration.overrideDefaultCurrency, isTrue);
+      expect(configuration.selectedOverrideCurrencyCode, "EUR");
+      expect(configuration.homeCurrencyCodes, ["GBP"]);
+      expect(configuration.languageCode, "en");
+    });
+
+    test('loadCurrentConfiguration publica o idioma gravado', () async {
+      repository.configuration = Configuration(1, languageCode: "en");
+      var published = bloc.languageStream.first;
+
+      bloc.loadCurrentConfiguration();
+
+      expect(await published, "en");
+      expect(bloc.languageCode, "en");
     });
   });
 }

--- a/test/model/configuration_test.dart
+++ b/test/model/configuration_test.dart
@@ -17,6 +17,8 @@ void main() {
       expect(configuration.homeCurrencyCodes,
           Configuration.defaultHomeCurrencyCodes,
           reason: "quem nunca escolheu vê as moedas que a tela já mostrava");
+      expect(configuration.languageCode, "",
+          reason: "sem escolha, a interface segue o idioma do aparelho");
     });
 
     test('aceita os valores informados', () {
@@ -37,7 +39,8 @@ void main() {
         'id': 1,
         'overrideDefaultCurrency': 1,
         'selectedOverrideCurrencyCode': "JPY",
-        'homeCurrencyCodes': "USD,EUR,CAD,JPY"
+        'homeCurrencyCodes': "USD,EUR,CAD,JPY",
+        'languageCode': ""
       });
     });
 
@@ -85,6 +88,26 @@ void main() {
           Configuration.defaultHomeCurrencyCodes);
     });
 
+    test('aceita o idioma escolhido para a interface', () {
+      expect(Configuration(1, languageCode: "pt").languageCode, "pt");
+    });
+
+    // O que vem do banco pode ter espaço ou caixa diferente; um "PT " não
+    // bateria com nenhum idioma da build e cairia no do aparelho.
+    test('parseLanguageCode normaliza espaços e caixa', () {
+      expect(Configuration.parseLanguageCode(" PT "), "pt");
+      expect(Configuration(1, languageCode: " EN").languageCode, "en");
+    });
+
+    test('parseLanguageCode lê nulo como o idioma do aparelho', () {
+      expect(Configuration.parseLanguageCode(null), "");
+    });
+
+    test('toMap guarda o idioma escolhido', () {
+      expect(Configuration(1, languageCode: "en").toMap()['languageCode'],
+          "en");
+    });
+
     test('toString expõe todos os campos', () {
       var text = Configuration(1,
               overrideDefaultCurrency: true,
@@ -95,6 +118,7 @@ void main() {
       expect(text, contains("overrideDefaultCurrency: true"));
       expect(text, contains("selectedOverrideCurrencyCode: GBP"));
       expect(text, contains("homeCurrencyCodes: USD,EUR,CAD,JPY"));
+      expect(text, contains("languageCode:"));
     });
   });
 }

--- a/test/util/app_locale_controller_test.dart
+++ b/test/util/app_locale_controller_test.dart
@@ -1,0 +1,87 @@
+import 'package:cotacao_direta/model/configuration.dart';
+import 'package:cotacao_direta/repository/configuration_repository.dart';
+import 'package:cotacao_direta/util/app_locale_controller.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../helpers/fakes.dart';
+
+/// Repositório que falha na leitura, para conferir que o app ainda abre quando
+/// a configuração não pode ser lida.
+class _BrokenConfigurationRepository implements ConfigurationRepository {
+  @override
+  Future<Configuration> getConfiguration() async =>
+      throw StateError("banco indisponível");
+
+  @override
+  Future<void> insert(Configuration configuration) async {}
+}
+
+void main() {
+  late FakeConfigurationRepository repository;
+  late AppLocaleController controller;
+
+  setUp(() {
+    repository = FakeConfigurationRepository();
+    controller = AppLocaleController(configurationRepository: repository);
+  });
+
+  tearDown(() => controller.dispose());
+
+  group('AppLocaleController', () {
+    test('começa no idioma do aparelho', () {
+      expect(controller.value, isNull);
+    });
+
+    test('load lê o idioma gravado', () async {
+      repository.configuration = Configuration(1, languageCode: "en");
+
+      await controller.load();
+
+      expect(controller.value, const Locale("en"));
+    });
+
+    test('load sem idioma gravado segue o aparelho', () async {
+      await controller.load();
+
+      expect(controller.value, isNull);
+    });
+
+    // Instalar por cima de uma versão com mais traduções deixaria um código
+    // que esta build não sabe mostrar.
+    test('load ignora um idioma que não está na build', () async {
+      repository.configuration = Configuration(1, languageCode: "fr");
+
+      await controller.load();
+
+      expect(controller.value, isNull);
+    });
+
+    test('uma falha de leitura não impede o app de abrir', () async {
+      var broken = AppLocaleController(
+          configurationRepository: _BrokenConfigurationRepository());
+      addTearDown(broken.dispose);
+      // O erro é reportado, e não deve ir parar na saída do teste.
+      var reportados = <FlutterErrorDetails>[];
+      var onError = FlutterError.onError;
+      FlutterError.onError = reportados.add;
+      addTearDown(() => FlutterError.onError = onError);
+
+      await broken.load();
+
+      expect(broken.value, isNull,
+          reason: "sem configuração legível, vale o idioma do aparelho");
+      expect(reportados, hasLength(1));
+    });
+
+    test('updateLanguage avisa quem estiver ouvindo', () async {
+      var notificacoes = <Locale?>[];
+      controller.addListener(() => notificacoes.add(controller.value));
+
+      controller.updateLanguage("pt");
+      controller.updateLanguage("");
+
+      expect(notificacoes, [const Locale("pt"), null]);
+    });
+  });
+}

--- a/test/util/database_test.dart
+++ b/test/util/database_test.dart
@@ -46,12 +46,12 @@ void main() {
       expect(identical(AppDatabase(), AppDatabase()), isTrue);
     });
 
-    test('abre o banco na versão 8', () async {
+    test('abre o banco na versão 9', () async {
       var db = await AppDatabase().openAppDatabase();
 
       expect(db, isNotNull);
       expect(db!.isOpen, isTrue);
-      expect(await db.getVersion(), 8);
+      expect(await db.getVersion(), 9);
     });
 
     test('reaproveita a mesma conexão em chamadas seguintes', () async {
@@ -162,7 +162,7 @@ void main() {
       expect(await reopened.query("Currency"), isEmpty);
     });
 
-    test('migra um banco da versão 1 até a 8, passando por todas as etapas',
+    test('migra um banco da versão 1 até a 9, passando por todas as etapas',
         () async {
       var path = await _createLegacyDatabase(version: 1, tables: [
         "CREATE TABLE Currency(id TEXT PRIMARY KEY, value REAL, timestamp TEXT)"
@@ -177,7 +177,7 @@ void main() {
 
       var db = (await AppDatabase().openAppDatabase())!;
 
-      expect(await db.getVersion(), 8);
+      expect(await db.getVersion(), 9);
       expect(await _columnsOf(db, "Currency"),
           containsAll(["historicalDate", "friendlyName"]));
       expect(await _columnsOf(db, "Configurations"),
@@ -189,12 +189,15 @@ void main() {
       expect(await _columnsOf(db, "Configurations"),
           containsAll(["homeCurrencyCodes"]),
           reason: "a etapa 7→8 não pode ser pulada");
+      expect(await _columnsOf(db, "Configurations"),
+          containsAll(["languageCode"]),
+          reason: "a etapa 8→9 não pode ser pulada");
       var row = (await db.query("Currency")).single;
       expect(row["id"], "USD");
       expect(row["value"], 5.0);
     });
 
-    test('migra um banco da versão 4 para a 8 acrescentando o friendlyName e '
+    test('migra um banco da versão 4 para a 9 acrescentando o friendlyName e '
         'os alertas', () async {
       var path = await _createLegacyDatabase(version: 4, tables: [
         "CREATE TABLE Currency(id TEXT, value REAL, timestamp TEXT, historicalDate TEXT, PRIMARY KEY(id, historicalDate))",
@@ -211,7 +214,7 @@ void main() {
 
       var db = (await AppDatabase().openAppDatabase())!;
 
-      expect(await db.getVersion(), 8);
+      expect(await db.getVersion(), 9);
       var row = (await db.query("Currency")).single;
       expect(row["historicalDate"], "2024-01-01T00:00:00.000");
       expect(row["friendlyName"], "",
@@ -321,6 +324,31 @@ void main() {
           reason: "a configuração que já existia não pode se perder");
     });
 
+    test('a migração 8→9 deixa o idioma em branco, seguindo o aparelho',
+        () async {
+      var path = await _createLegacyDatabase(version: 8, tables: [
+        "CREATE TABLE Currency(id TEXT, historicalDate TEXT, value REAL, timestamp TEXT, friendlyName TEXT NOT NULL DEFAULT '', counterCurrency TEXT NOT NULL DEFAULT 'BRL', PRIMARY KEY(id, historicalDate, counterCurrency))",
+        "CREATE TABLE Configurations(id INT PRIMARY KEY, overrideDefaultCurrency INTEGER, selectedOverrideCurrencyCode TEXT, homeCurrencyCodes TEXT NOT NULL DEFAULT '')",
+        "CREATE TABLE CurrencyAlerts(id INTEGER PRIMARY KEY AUTOINCREMENT, currencyCode TEXT NOT NULL, targetValue REAL NOT NULL, condition TEXT NOT NULL, triggered INTEGER NOT NULL DEFAULT 0, active INTEGER NOT NULL DEFAULT 1)"
+      ], rows: {
+        "Configurations": {
+          "id": 1,
+          "overrideDefaultCurrency": 0,
+          "selectedOverrideCurrencyCode": "",
+          "homeCurrencyCodes": "GBP,CHF"
+        }
+      });
+      AppDatabase.databasePathOverride = path;
+
+      var db = (await AppDatabase().openAppDatabase())!;
+
+      var row = (await db.query("Configurations")).single;
+      expect(row["languageCode"], "",
+          reason: "quem já usava o app continua no idioma do aparelho");
+      expect(row["homeCurrencyCodes"], "GBP,CHF",
+          reason: "a configuração que já existia não pode se perder");
+    });
+
     test('os dados sobrevivem à reabertura quando o banco é um arquivo',
         () async {
       var directory =
@@ -338,7 +366,7 @@ void main() {
       await AppDatabase.reset();
 
       var reopened = (await AppDatabase().openAppDatabase())!;
-      expect(await reopened.getVersion(), 8,
+      expect(await reopened.getVersion(), 9,
           reason: "reabrir não deve disparar onCreate/onUpgrade de novo");
       expect((await reopened.query("Currency")).single["id"], "USD");
     });

--- a/test/util/localizations_test.dart
+++ b/test/util/localizations_test.dart
@@ -42,6 +42,8 @@ List<String?> _allLabels(MyAppLocalizations localizations) => [
       localizations.homeCurrenciesSelectedCountLabel,
       localizations.homeCurrenciesEmptySelectionLabel,
       localizations.homeCurrenciesSaveBtnLabel,
+      localizations.appLanguageSettingLabel,
+      localizations.appLanguageSystemOptionLabel,
       localizations.appConfigurationsSectionLabel,
       localizations.pwaInstallSectionLabel,
       localizations.pwaInstallCardLabel,
@@ -274,6 +276,47 @@ void main() {
 
       expect(found, isNotNull);
       expect(found!.conversionPageTitle, "Conversão de Moedas");
+    });
+  });
+
+  group('AppLocales', () {
+    test('lista os idiomas que existem na build', () {
+      expect(AppLocales.supported,
+          const [Locale("en"), Locale("pt")]);
+    });
+
+    // A lista da tela de opções sai daqui: um idioma sem nome apareceria como
+    // um código solto para o usuário.
+    test('todo idioma da build tem um nome para mostrar', () {
+      for (var locale in AppLocales.supported) {
+        expect(AppLocales.displayNames[locale.languageCode], isNotNull,
+            reason: "falta o nome de ${locale.languageCode}");
+      }
+    });
+
+    test('displayNameOf devolve o próprio código quando não há nome', () {
+      expect(AppLocales.displayNameOf("pt"), "Português");
+      expect(AppLocales.displayNameOf("xx"), "xx");
+    });
+
+    test('isSupported reconhece só o que está na build', () {
+      expect(AppLocales.isSupported("pt"), isTrue);
+      expect(AppLocales.isSupported("en"), isTrue);
+      expect(AppLocales.isSupported("fr"), isFalse);
+      expect(AppLocales.isSupported(""), isFalse);
+      expect(AppLocales.isSupported(null), isFalse);
+    });
+
+    test('localeFor converte o código gravado', () {
+      expect(AppLocales.localeFor("pt"), const Locale("pt"));
+    });
+
+    // Vazio, nulo ou fora da build significam "seguir o aparelho", que é o que
+    // um locale nulo faz no MaterialApp.
+    test('localeFor devolve nulo quando não há idioma a fixar', () {
+      expect(AppLocales.localeFor(""), isNull);
+      expect(AppLocales.localeFor(null), isNull);
+      expect(AppLocales.localeFor("fr"), isNull);
     });
   });
 }

--- a/test/view/configurations_page_test.dart
+++ b/test/view/configurations_page_test.dart
@@ -1,8 +1,10 @@
 import 'package:cotacao_direta/blocs/configurations_page_bloc.dart';
 import 'package:cotacao_direta/model/configuration.dart';
 import 'package:cotacao_direta/providers/configurations_page_bloc_provider.dart';
+import 'package:cotacao_direta/util/app_locale_controller.dart';
 import 'package:cotacao_direta/util/localizations.dart';
 import 'package:cotacao_direta/view/pages/main_menu_items/configurations_page.dart';
+import 'package:cotacao_direta/view/widgets/bento_card.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -28,14 +30,22 @@ void main() {
   // Um repositório em memória no lugar do banco: em teste de widget o relógio
   // é simulado, e esperar por E/S de verdade travaria o teste.
   late FakeConfigurationRepository repository;
+  late AppLocaleController localeController;
   late ConfigurationsPageBloc bloc;
 
   setUp(() {
     repository = FakeConfigurationRepository();
-    bloc = ConfigurationsPageBloc(configurationRepository: repository);
+    localeController =
+        AppLocaleController(configurationRepository: repository);
+    bloc = ConfigurationsPageBloc(
+        configurationRepository: repository,
+        localeController: localeController);
   });
 
-  tearDown(() => bloc.dispose());
+  tearDown(() {
+    bloc.dispose();
+    localeController.dispose();
+  });
 
   Future<void> pumpPage(WidgetTester tester) async {
     await tester.pumpWidget(_configurationsApp(bloc));
@@ -133,6 +143,81 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(bloc.homeCurrencyCodes, Configuration.defaultHomeCurrencyCodes);
+    });
+  });
+
+  group('ConfigurationsPage e o idioma da interface', () {
+    // A moeda de contrapartida também é escolhida por um DropdownButton de
+    // String; o do idioma é o que está no cartão com o rótulo dele.
+    final languageDropdown = find.descendant(
+        of: find.ancestor(
+            of: find.text("Idioma do aplicativo"),
+            matching: find.byType(BentoCard)),
+        matching: find.byType(DropdownButton<String>));
+
+    /// Abre a lista suspensa do idioma e escolhe o item pedido.
+    Future<void> chooseLanguage(WidgetTester tester, String label) async {
+      await tester.tap(languageDropdown);
+      await tester.pumpAndSettle();
+      // O item escolhido também fica desenhado no botão fechado; o do menu
+      // aberto é o último a ser construído.
+      await tester.tap(find.text(label).last);
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('oferece o aparelho e os idiomas da build',
+        (WidgetTester tester) async {
+      await pumpPage(tester);
+
+      expect(find.text("Idioma do aplicativo"), findsOneWidget);
+      await tester.tap(languageDropdown);
+      await tester.pumpAndSettle();
+
+      expect(find.text("Idioma do sistema"), findsWidgets);
+      for (var locale in AppLocales.supported) {
+        expect(find.text(AppLocales.displayNameOf(locale.languageCode)),
+            findsWidgets,
+            reason: "todo idioma da build aparece na lista");
+      }
+    });
+
+    testWidgets('abre no idioma do aparelho quando nada foi escolhido',
+        (WidgetTester tester) async {
+      await pumpPage(tester);
+
+      expect(tester.widget<DropdownButton<String>>(languageDropdown).value, "");
+    });
+
+    testWidgets('mostra o idioma gravado', (WidgetTester tester) async {
+      repository.configuration = Configuration(1, languageCode: "en");
+
+      await pumpPage(tester);
+
+      expect(
+          tester.widget<DropdownButton<String>>(languageDropdown).value, "en");
+    });
+
+    testWidgets('escolher um idioma grava e aplica na hora',
+        (WidgetTester tester) async {
+      await pumpPage(tester);
+
+      await chooseLanguage(tester, "English");
+
+      expect(bloc.languageCode, "en");
+      expect(repository.configuration.languageCode, "en");
+      expect(localeController.value, const Locale("en"));
+    });
+
+    testWidgets('voltar para o idioma do sistema apaga a escolha',
+        (WidgetTester tester) async {
+      repository.configuration = Configuration(1, languageCode: "en");
+      await pumpPage(tester);
+
+      await chooseLanguage(tester, "Idioma do sistema");
+
+      expect(bloc.languageCode, "");
+      expect(repository.configuration.languageCode, "");
+      expect(localeController.value, isNull);
     });
   });
 }


### PR DESCRIPTION
## O que muda

O app sempre seguiu o idioma do aparelho. A aba **Opções** ganha um seletor de idioma, oferecendo exatamente as opções que existem na build:

- **Idioma do sistema** (padrão — o comportamento anterior);
- **English**;
- **Português**.

A troca vale para o app inteiro assim que o usuário escolhe, sem reiniciar.

## Como foi feito

- `AppLocales` (`lib/util/localizations.dart`) passa a ser a fonte única dos idiomas da build: alimenta o `supportedLocales` do `MaterialApp`, o `isSupported` do delegate de traduções e a lista do seletor. Acrescentar uma tradução vira uma mudança só.
- A escolha é gravada na coluna `languageCode` de `Configurations` (migração 8→9). Coluna vazia — o padrão, e o que os bancos existentes recebem na migração — significa "seguir o aparelho".
- Quem precisa do valor é o `MaterialApp` da raiz, acima dos blocs, então ele chega lá pelo `AppLocaleController`, um `ValueNotifier<Locale?>` de escopo do app. A tela de opções o atualiza junto com a gravação; o `MaterialApp` escuta e reconstrói.
- O idioma gravado é lido antes do primeiro quadro, na partida, para a tela já abrir no idioma certo em vez de piscar no do aparelho. Uma falha de leitura é reportada e cai no idioma do aparelho, sem impedir o app de abrir.
- Um código que a build não conhece (instalação por cima de uma versão com mais traduções) também cai no idioma do aparelho, em vez de deixar a interface sem textos.
- Os nomes dos idiomas aparecem em si mesmos ("English", "Português"): quem está com o app num idioma que não entende precisa reconhecer o seu para conseguir voltar.

## Testes

`flutter analyze` sem apontamentos e `flutter test` com 531 testes passando (Flutter 3.44.8, a versão fixada no CI). Novos testes cobrindo:

- `AppLocales`: lista da build, nomes, `isSupported`, `localeFor`;
- `AppLocaleController`: leitura do gravado, idioma fora da build, falha de leitura, notificação de mudança;
- `ConfigurationsPageBloc.updateLanguage`: publica, grava, aplica no controlador e não mexe nas outras configurações;
- `ConfigurationsPage`: opções oferecidas, valor inicial, escolha e volta para o idioma do sistema;
- `Configuration`/`ConfigurationDao`/migração 8→9.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QuC7NnViLtJzmTJYBibpdA)_