### PR TITLE
Acrescenta o espanhol, em duas traduções: Espanha e América Latina

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,9 +123,15 @@ então, é preciso o build.
 
 ## Idioma da interface
 
-O app tem textos em português e inglês, e sempre seguiu o idioma do aparelho.
-A aba **Opções** agora permite fixar um deles, para quem usa o aparelho em um
-idioma e prefere o app em outro.
+O app tem textos em português, inglês e espanhol, e sempre seguiu o idioma do
+aparelho. A aba **Opções** agora permite fixar um deles, para quem usa o
+aparelho em um idioma e prefere o app em outro.
+
+O espanhol são duas traduções, uma para cada norma: a da Espanha (`es-ES`) e a
+da América Latina (`es-419`, o código que o CLDR usa para a região). O
+vocabulário muda o bastante entre elas — "ajustes" e "móvil" de um lado,
+"configuración" e "celular" do outro — para não caber em um texto só. Por isso
+um idioma é identificado pela etiqueta inteira, e não só pelo código do idioma.
 
 A lista oferecida é exatamente a da build: `AppLocales.supported`, em
 `lib/util/localizations.dart`, é a mesma fonte que alimenta o
@@ -133,16 +139,30 @@ A lista oferecida é exatamente a da build: `AppLocales.supported`, em
 e o seletor da tela de opções — acrescentar um idioma ao mapa de textos e a
 essa lista basta para ele aparecer nas três pontas.
 
+Quem não fixa idioma nenhum é atendido pelo `localeListResolutionCallback` do
+`MaterialApp`: a resolução padrão do Flutter, sem país correspondente, daria a
+primeira variante de espanhol da lista para todo mundo — a da Espanha também
+para quem está no México. `AppLocales.resolve` decide pela região do aparelho:
+sem região, ou em um país que segue a norma europeia, vale a tradução da
+Espanha; o resto fica com a latino-americana.
+
+A região também vai junto na hora de formatar números, e não só de escolher os
+textos: o espanhol da América Latina separa os decimais com ponto ("12.3%"), o
+da Espanha com vírgula ("12,3 %"). Por isso a tela de IA passa o locale inteiro
+(`es_419`) ao `InsightEngine`, em vez de só o código do idioma.
+
 A escolha é gravada na tabela `Configurations` (coluna `languageCode`, migração
-8→9). Coluna vazia — o padrão, e o que os bancos já existentes recebem na
-migração — significa "seguir o aparelho", que é o comportamento anterior. Quem
-precisa do valor é o `MaterialApp` na raiz da árvore, acima dos blocs, então
-ele chega lá pelo `AppLocaleController` (`lib/util/app_locale_controller.dart`),
-um `ValueNotifier<Locale?>` de escopo do app: a tela de opções o atualiza junto
-com a gravação e o app inteiro é reconstruído no idioma novo na hora. Um código
-que a build não conhece — por exemplo ao instalar por cima de uma versão com
-mais traduções — é tratado como "seguir o aparelho", em vez de deixar a
-interface sem textos.
+8→9), com a etiqueta do idioma em caixa baixa (`pt`, `es-419`) — a forma
+canônica é remontada na leitura, por `AppLocales.tagFor`. Coluna vazia — o
+padrão, e o que os bancos já existentes recebem na migração — significa "seguir
+o aparelho", que é o comportamento anterior. Quem precisa do valor é o
+`MaterialApp` na raiz da árvore, acima dos blocs, então ele chega lá pelo
+`AppLocaleController` (`lib/util/app_locale_controller.dart`), um
+`ValueNotifier<Locale?>` de escopo do app: a tela de opções o atualiza junto
+com a gravação e o app inteiro é reconstruído no idioma novo na hora. Uma
+etiqueta que a build não conhece — por exemplo ao instalar por cima de uma
+versão com mais traduções — é tratada como "seguir o aparelho", em vez de
+deixar a interface sem textos.
 
 ## IA local: insights e projeções
 

--- a/lib/ai/financial_ai_service.dart
+++ b/lib/ai/financial_ai_service.dart
@@ -30,19 +30,19 @@ class FinancialAiService {
 
   /// Analyses [series] and projects [horizonInDays] days ahead.
   ///
-  /// [languageCode] only affects the formatting of the numbers embedded in the
+  /// [localeName] only affects the formatting of the numbers embedded in the
   /// remarks ("3,2%" or "3.2%").
   FinancialAnalysis analyze(
     AssetSeries series, {
     int horizonInDays = 15,
-    String languageCode = "pt",
+    String localeName = "pt",
   }) {
     if (series.length < minimumPoints)
       throw ArgumentError("series with fewer than $minimumPoints points");
 
     final statistics = computeStatistics(series);
     final forecast = model.forecast(series, horizonInDays: horizonInDays);
-    final insights = InsightEngine(languageCode: languageCode).generate(
+    final insights = InsightEngine(localeName: localeName).generate(
       series: series,
       statistics: statistics,
       forecast: forecast,

--- a/lib/ai/insight_engine.dart
+++ b/lib/ai/insight_engine.dart
@@ -12,11 +12,13 @@ import 'package:intl/intl.dart';
 /// [FinancialInsight.arguments]. That keeps the engine in pure Dart, free of
 /// Flutter, while both app languages are served by the same code.
 class InsightEngine {
-  /// Language the numbers are formatted in ("pt" or "en"): it changes the
-  /// decimal comma and the thousands separator.
-  final String languageCode;
+  /// Locale the numbers are formatted in ("pt", "es_419"…): it changes the
+  /// decimal comma and the thousands separator. The region matters on its own
+  /// — Latin American Spanish separates the decimals with a point, the Spanish
+  /// of Spain with a comma.
+  final String localeName;
 
-  const InsightEngine({this.languageCode = "pt"});
+  const InsightEngine({this.localeName = "pt"});
 
   /// Above this the period's change stops being noise and becomes a trend.
   static const double _trendThreshold = 0.025;
@@ -196,12 +198,12 @@ class InsightEngine {
   }
 
   String _percent(double fraction) =>
-      NumberFormat.decimalPercentPattern(locale: languageCode, decimalDigits: 1)
+      NumberFormat.decimalPercentPattern(locale: localeName, decimalDigits: 1)
           .format(fraction);
 
   String _number(double value, {int decimalDigits = 2}) =>
       NumberFormat.decimalPatternDigits(
-              locale: languageCode, decimalDigits: decimalDigits)
+              locale: localeName, decimalDigits: decimalDigits)
           .format(value);
 
   /// Quote with enough decimal places for the price not to turn into "0.00":

--- a/lib/blocs/ai_insights_bloc.dart
+++ b/lib/blocs/ai_insights_bloc.dart
@@ -80,9 +80,9 @@ class AiInsightsBloc extends BaseBloc {
   /// query comes back).
   int _requestId = 0;
 
-  /// Language of the last analysis requested by the screen, to reuse when the
+  /// Locale of the last analysis requested by the screen, to reuse when the
   /// bloc itself re-runs the analysis (on a horizon change).
-  String _languageCode = "pt";
+  String _localeName = "pt";
 
   AiInsightsBloc({
     CurrencyRepository? currencyRepository,
@@ -130,7 +130,7 @@ class AiInsightsBloc extends BaseBloc {
     // The horizon only changes the projection; redoing the analysis is cheap
     // and needs no network, so the screen answers right away when a result is
     // already there.
-    if (_state.hasAnalysis) analyze(languageCode: _languageCode);
+    if (_state.hasAnalysis) analyze(localeName: _localeName);
   }
 
   /// Amount typed for the simulation, or null when the field is empty or
@@ -155,9 +155,9 @@ class AiInsightsBloc extends BaseBloc {
 
   /// Fetches the history of the selected asset and runs the local model over
   /// it.
-  Future<void> analyze({String languageCode = "pt"}) async {
+  Future<void> analyze({String localeName = "pt"}) async {
     final requestId = ++_requestId;
-    _languageCode = languageCode;
+    _localeName = localeName;
     _emit(const AiInsightsState.loading());
     try {
       final today = DateTime.now();
@@ -192,7 +192,7 @@ class AiInsightsBloc extends BaseBloc {
       final analysis = await Future(() => _aiService.analyze(
             series,
             horizonInDays: _horizonInDays,
-            languageCode: languageCode,
+            localeName: localeName,
           ));
       if (requestId != _requestId) return;
       _emit(AiInsightsState.ready(analysis));

--- a/lib/blocs/configurations_page_bloc.dart
+++ b/lib/blocs/configurations_page_bloc.dart
@@ -101,7 +101,8 @@ class ConfigurationsPageBloc extends BaseBloc {
 
   /// Grava o idioma da interface e o aplica na hora.
   ///
-  /// [languageCode] nulo ou vazio volta a seguir o aparelho, que é o padrão.
+  /// [languageCode] é a etiqueta do idioma ("pt", "es-419"); nula ou vazia
+  /// volta a seguir o aparelho, que é o padrão.
   /// A troca vai para o controlador antes da gravação: a tela toda é
   /// reconstruída no idioma novo assim que o usuário escolhe, sem esperar o
   /// banco.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -70,6 +70,10 @@ class MyApp extends StatelessWidget {
       // opção existir.
       locale: locale,
       supportedLocales: AppLocales.supported,
+      // Duas traduções em espanhol pedem uma escolha que a resolução padrão do
+      // Flutter não faz: sem país correspondente, ela daria a da Espanha
+      // também para quem está no México.
+      localeListResolutionCallback: AppLocales.resolveDeviceLocales,
       title: appName,
       home: HomeBlocProvider(
         child: CurrencyAlertsBlocProvider(

--- a/lib/model/configuration.dart
+++ b/lib/model/configuration.dart
@@ -15,9 +15,9 @@ class Configuration extends BaseModel {
   bool overrideDefaultCurrency;
   String? selectedOverrideCurrencyCode;
 
-  /// Idioma escolhido para a interface, no formato do código do Locale
-  /// ("pt", "en"). Vazio — o padrão da coluna e o que a migração deixa para
-  /// quem já usava o app — significa "seguir o aparelho".
+  /// Idioma escolhido para a interface, na etiqueta do idioma ("pt", "en",
+  /// "es-419"). Vazio — o padrão da coluna e o que a migração deixa para quem
+  /// já usava o app — significa "seguir o aparelho".
   String languageCode;
 
   /// Códigos das moedas que viram bolha na tela inicial, na ordem em que
@@ -34,8 +34,10 @@ class Configuration extends BaseModel {
             homeCurrencyCodes ?? List.of(defaultHomeCurrencyCodes);
 
   /// Normaliza o idioma gravado: espaços e caixa vindos do banco não podem
-  /// virar um código que não bate com nenhum idioma da build, e nulo é o mesmo
-  /// que "seguir o aparelho".
+  /// virar uma etiqueta que não bate com nenhum idioma da build, e nulo é o
+  /// mesmo que "seguir o aparelho". Pôr a etiqueta na forma canônica, com a
+  /// região em maiúsculas, é de quem a mostra — AppLocales.tagFor —, que
+  /// compara sem olhar a caixa.
   static String parseLanguageCode(String? storedValue) =>
       storedValue?.trim().toLowerCase() ?? "";
 

--- a/lib/util/app_locale_controller.dart
+++ b/lib/util/app_locale_controller.dart
@@ -43,10 +43,10 @@ class AppLocaleController extends ValueNotifier<Locale?> {
     }
   }
 
-  /// Aplica o idioma escolhido na tela de opções. Código vazio ou nulo volta a
-  /// seguir o aparelho. A gravação fica com o bloc, que já cuida do resto da
+  /// Aplica o idioma escolhido na tela de opções. Etiqueta vazia ou nula volta
+  /// a seguir o aparelho. A gravação fica com o bloc, que já cuida do resto da
   /// configuração.
-  void updateLanguage(String? languageCode) {
-    value = AppLocales.localeFor(languageCode);
+  void updateLanguage(String? languageTag) {
+    value = AppLocales.localeFor(languageTag);
   }
 }

--- a/lib/util/currency_name.dart
+++ b/lib/util/currency_name.dart
@@ -12,43 +12,174 @@ import 'package:flutter/widgets.dart';
 /// uma lista em branco enquanto a rede não responde — e nenhum nome quando ela
 /// não responde.
 const Map<Currencies, Map<String, String>> _namesByCurrency = {
-  Currencies.AUD: {"pt": "Dólar Australiano", "en": "Australian Dollar"},
-  Currencies.BRL: {"pt": "Real Brasileiro", "en": "Brazilian Real"},
-  Currencies.CAD: {"pt": "Dólar Canadense", "en": "Canadian Dollar"},
-  Currencies.CZK: {"pt": "Coroa Tcheca", "en": "Czech Koruna"},
-  Currencies.DKK: {"pt": "Coroa Dinamarquesa", "en": "Danish Krone"},
-  Currencies.EUR: {"pt": "Euro", "en": "Euro"},
-  Currencies.GBP: {"pt": "Libra Esterlina", "en": "British Pound"},
-  Currencies.HKD: {"pt": "Dólar de Hong Kong", "en": "Hong Kong Dollar"},
-  Currencies.IDR: {"pt": "Rupia Indonésia", "en": "Indonesian Rupiah"},
-  Currencies.ILS: {"pt": "Novo Shekel Israelense", "en": "Israeli New Shekel"},
-  Currencies.INR: {"pt": "Rupia Indiana", "en": "Indian Rupee"},
-  Currencies.ISK: {"pt": "Coroa Islandesa", "en": "Icelandic Króna"},
-  Currencies.JPY: {"pt": "Iene Japonês", "en": "Japanese Yen"},
-  Currencies.USD: {"pt": "Dólar Americano", "en": "US Dollar"},
-  Currencies.PHP: {"pt": "Peso Filipino", "en": "Philippine Peso"},
-  Currencies.HUF: {"pt": "Florim Húngaro", "en": "Hungarian Forint"},
-  Currencies.RON: {"pt": "Leu Romeno", "en": "Romanian Leu"},
-  Currencies.SEK: {"pt": "Coroa Sueca", "en": "Swedish Krona"},
-  Currencies.RUB: {"pt": "Rublo Russo", "en": "Russian Ruble"},
-  Currencies.HRK: {"pt": "Kuna Croata", "en": "Croatian Kuna"},
-  Currencies.THB: {"pt": "Baht Tailandês", "en": "Thai Baht"},
-  Currencies.CHF: {"pt": "Franco Suíço", "en": "Swiss Franc"},
-  Currencies.MYR: {"pt": "Ringgit Malaio", "en": "Malaysian Ringgit"},
-  Currencies.BGN: {"pt": "Lev Búlgaro", "en": "Bulgarian Lev"},
-  Currencies.TRY: {"pt": "Lira Turca", "en": "Turkish Lira"},
-  Currencies.CNY: {"pt": "Yuan Chinês", "en": "Chinese Yuan"},
-  Currencies.NOK: {"pt": "Coroa Norueguesa", "en": "Norwegian Krone"},
-  Currencies.NZD: {"pt": "Dólar Neozelandês", "en": "New Zealand Dollar"},
-  Currencies.ZAR: {"pt": "Rand Sul-Africano", "en": "South African Rand"},
-  Currencies.MXN: {"pt": "Peso Mexicano", "en": "Mexican Peso"},
-  Currencies.SGD: {"pt": "Dólar de Singapura", "en": "Singapore Dollar"},
-  Currencies.KRW: {"pt": "Won Sul-Coreano", "en": "South Korean Won"},
-  Currencies.PLN: {"pt": "Zloty Polonês", "en": "Polish Zloty"},
+  Currencies.AUD: {
+    "pt": "Dólar Australiano",
+    "en": "Australian Dollar",
+    "es": "Dólar australiano"
+  },
+  Currencies.BRL: {
+    "pt": "Real Brasileiro",
+    "en": "Brazilian Real",
+    "es": "Real brasileño"
+  },
+  Currencies.CAD: {
+    "pt": "Dólar Canadense",
+    "en": "Canadian Dollar",
+    "es": "Dólar canadiense"
+  },
+  Currencies.CZK: {
+    "pt": "Coroa Tcheca",
+    "en": "Czech Koruna",
+    "es": "Corona checa"
+  },
+  Currencies.DKK: {
+    "pt": "Coroa Dinamarquesa",
+    "en": "Danish Krone",
+    "es": "Corona danesa"
+  },
+  Currencies.EUR: {"pt": "Euro", "en": "Euro", "es": "Euro"},
+  Currencies.GBP: {
+    "pt": "Libra Esterlina",
+    "en": "British Pound",
+    "es": "Libra esterlina"
+  },
+  Currencies.HKD: {
+    "pt": "Dólar de Hong Kong",
+    "en": "Hong Kong Dollar",
+    "es": "Dólar de Hong Kong"
+  },
+  Currencies.IDR: {
+    "pt": "Rupia Indonésia",
+    "en": "Indonesian Rupiah",
+    "es": "Rupia indonesia"
+  },
+  Currencies.ILS: {
+    "pt": "Novo Shekel Israelense",
+    "en": "Israeli New Shekel",
+    "es": "Nuevo séquel israelí"
+  },
+  Currencies.INR: {
+    "pt": "Rupia Indiana",
+    "en": "Indian Rupee",
+    "es": "Rupia india"
+  },
+  Currencies.ISK: {
+    "pt": "Coroa Islandesa",
+    "en": "Icelandic Króna",
+    "es": "Corona islandesa"
+  },
+  Currencies.JPY: {
+    "pt": "Iene Japonês",
+    "en": "Japanese Yen",
+    "es": "Yen japonés"
+  },
+  Currencies.USD: {
+    "pt": "Dólar Americano",
+    "en": "US Dollar",
+    "es": "Dólar estadounidense"
+  },
+  Currencies.PHP: {
+    "pt": "Peso Filipino",
+    "en": "Philippine Peso",
+    "es": "Peso filipino"
+  },
+  Currencies.HUF: {
+    "pt": "Florim Húngaro",
+    "en": "Hungarian Forint",
+    "es": "Forinto húngaro"
+  },
+  Currencies.RON: {
+    "pt": "Leu Romeno",
+    "en": "Romanian Leu",
+    "es": "Leu rumano"
+  },
+  Currencies.SEK: {
+    "pt": "Coroa Sueca",
+    "en": "Swedish Krona",
+    "es": "Corona sueca"
+  },
+  Currencies.RUB: {
+    "pt": "Rublo Russo",
+    "en": "Russian Ruble",
+    "es": "Rublo ruso"
+  },
+  Currencies.HRK: {
+    "pt": "Kuna Croata",
+    "en": "Croatian Kuna",
+    "es": "Kuna croata"
+  },
+  Currencies.THB: {
+    "pt": "Baht Tailandês",
+    "en": "Thai Baht",
+    "es": "Baht tailandés"
+  },
+  Currencies.CHF: {
+    "pt": "Franco Suíço",
+    "en": "Swiss Franc",
+    "es": "Franco suizo"
+  },
+  Currencies.MYR: {
+    "pt": "Ringgit Malaio",
+    "en": "Malaysian Ringgit",
+    "es": "Ringgit malayo"
+  },
+  Currencies.BGN: {
+    "pt": "Lev Búlgaro",
+    "en": "Bulgarian Lev",
+    "es": "Lev búlgaro"
+  },
+  Currencies.TRY: {
+    "pt": "Lira Turca",
+    "en": "Turkish Lira",
+    "es": "Lira turca"
+  },
+  Currencies.CNY: {
+    "pt": "Yuan Chinês",
+    "en": "Chinese Yuan",
+    "es": "Yuan chino"
+  },
+  Currencies.NOK: {
+    "pt": "Coroa Norueguesa",
+    "en": "Norwegian Krone",
+    "es": "Corona noruega"
+  },
+  Currencies.NZD: {
+    "pt": "Dólar Neozelandês",
+    "en": "New Zealand Dollar",
+    "es": "Dólar neozelandés"
+  },
+  Currencies.ZAR: {
+    "pt": "Rand Sul-Africano",
+    "en": "South African Rand",
+    "es": "Rand sudafricano"
+  },
+  Currencies.MXN: {
+    "pt": "Peso Mexicano",
+    "en": "Mexican Peso",
+    "es": "Peso mexicano"
+  },
+  Currencies.SGD: {
+    "pt": "Dólar de Singapura",
+    "en": "Singapore Dollar",
+    "es": "Dólar de Singapur"
+  },
+  Currencies.KRW: {
+    "pt": "Won Sul-Coreano",
+    "en": "South Korean Won",
+    "es": "Won surcoreano"
+  },
+  Currencies.PLN: {
+    "pt": "Zloty Polonês",
+    "en": "Polish Zloty",
+    "es": "Esloti polaco"
+  },
 };
 
 /// Nome da moeda no idioma de [locale], com o inglês como reserva para um
 /// idioma que ainda não tenha tradução.
+///
+/// A busca é pelo código do idioma, sem a região: o nome de uma moeda é o
+/// mesmo nas duas normas do espanhol que o app fala.
 String currencyName(Currencies currency, Locale locale) {
   var names = _namesByCurrency[currency];
   if (names == null) return currencyCode(currency);

--- a/lib/util/localizations.dart
+++ b/lib/util/localizations.dart
@@ -7,8 +7,18 @@ import 'package:flutter/material.dart';
 /// [MyAppLocalizationsDelegate] aceita e que a tela de opções oferece: com uma
 /// fonte única, acrescentar uma tradução ao mapa de textos é o bastante para
 /// ela aparecer nas três pontas.
+///
+/// O espanhol entra em duas traduções, uma para cada norma: a da Espanha e a
+/// da América Latina — es-419, o código que o CLDR usa para a região. Por isso
+/// um idioma é identificado pela etiqueta inteira ("es-ES", "es-419"), e não
+/// só pelo código do idioma.
 class AppLocales {
-  static const List<Locale> supported = [Locale("en"), Locale("pt")];
+  static const List<Locale> supported = [
+    Locale("en"),
+    Locale("pt"),
+    Locale("es", "ES"),
+    Locale("es", "419"),
+  ];
 
   /// Nome de cada idioma escrito nele mesmo. Quem está com o app em um idioma
   /// que não entende precisa reconhecer o seu na lista para conseguir voltar,
@@ -16,33 +26,120 @@ class AppLocales {
   static const Map<String, String> displayNames = {
     "en": "English",
     "pt": "Português",
+    "es-ES": "Español (España)",
+    "es-419": "Español (Latinoamérica)",
   };
 
-  static bool isSupported(String? languageCode) =>
-      supported.any((locale) => locale.languageCode == languageCode);
+  /// Os países de língua espanhola que seguem a norma da Espanha; o resto do
+  /// mundo hispanofalante fica com a tradução latino-americana. São os mesmos
+  /// que o CLDR pendura em "es" em vez de em "es-419".
+  static const Set<String> _europeanSpanishCountries = {"ES", "GQ", "PH"};
 
-  /// O idioma gravado nas configurações como [Locale], ou nulo para seguir o
-  /// aparelho — o que também vale para um código que esta build não tem, caso
-  /// o app seja instalado por cima de uma versão com mais traduções.
-  static Locale? localeFor(String? languageCode) {
-    if (languageCode == null || languageCode.isEmpty) return null;
-    if (!isSupported(languageCode)) return null;
-    return Locale(languageCode);
+  /// A etiqueta de um idioma da build: o código do idioma, mais a região
+  /// quando ela separa duas traduções ("es-ES", "es-419").
+  static String tagOf(Locale locale) {
+    var countryCode = locale.countryCode;
+    if (countryCode == null || countryCode.isEmpty) return locale.languageCode;
+    return "${locale.languageCode}-$countryCode";
   }
 
-  /// O nome a mostrar para um código de idioma, com o próprio código como
+  /// A etiqueta canônica do que está gravado nas configurações, ou vazio
+  /// quando não é um idioma desta build — o que inclui o valor vazio, que
+  /// significa "seguir o aparelho".
+  ///
+  /// O banco guarda o texto em caixa baixa, e a etiqueta pode chegar com "_"
+  /// no lugar do "-" de quem a montou a partir de um Locale, então a
+  /// comparação não depende nem da caixa nem do separador.
+  static String tagFor(String? storedTag) {
+    if (storedTag == null) return "";
+    var normalized = storedTag.trim().toLowerCase().replaceAll("_", "-");
+    if (normalized.isEmpty) return "";
+    for (var locale in supported) {
+      if (tagOf(locale).toLowerCase() == normalized) return tagOf(locale);
+    }
+    return "";
+  }
+
+  static bool isSupported(String? storedTag) => tagFor(storedTag).isNotEmpty;
+
+  /// O idioma gravado nas configurações como [Locale], ou nulo para seguir o
+  /// aparelho — o que também vale para uma etiqueta que esta build não tem,
+  /// caso o app seja instalado por cima de uma versão com mais traduções.
+  static Locale? localeFor(String? storedTag) {
+    var tag = tagFor(storedTag);
+    if (tag.isEmpty) return null;
+    return supported.firstWhere((locale) => tagOf(locale) == tag);
+  }
+
+  /// O idioma da build que atende [locale], ou nulo quando nenhum atende.
+  ///
+  /// Comparar o código do idioma não basta desde que existem duas traduções em
+  /// espanhol: o aparelho chega aqui como es-MX, es-AR, es-US… e nenhum deles
+  /// é igual a uma das duas. Sem região, ou em um país que segue a norma
+  /// europeia, vale a tradução da Espanha; o resto fica com a
+  /// latino-americana.
+  static Locale? resolve(Locale? locale) {
+    if (locale == null) return null;
+    for (var supportedLocale in supported) {
+      if (supportedLocale == locale) return supportedLocale;
+    }
+    if (locale.languageCode == "es") {
+      var countryCode = locale.countryCode?.toUpperCase() ?? "";
+      return countryCode.isEmpty ||
+              _europeanSpanishCountries.contains(countryCode)
+          ? const Locale("es", "ES")
+          : const Locale("es", "419");
+    }
+    for (var supportedLocale in supported) {
+      if (supportedLocale.languageCode == locale.languageCode) {
+        return supportedLocale;
+      }
+    }
+    return null;
+  }
+
+  /// O idioma a usar entre os que o aparelho pede, na ordem de preferência
+  /// dele, com o primeiro da build como reserva — o mesmo que o Flutter faz
+  /// quando nada corresponde.
+  ///
+  /// Vai no localeListResolutionCallback do MaterialApp: a escolha padrão do
+  /// Flutter, sem país correspondente, daria a primeira variante de espanhol
+  /// da lista para todo mundo, isto é, a da Espanha também para quem está no
+  /// México.
+  static Locale resolveDeviceLocales(
+      List<Locale>? deviceLocales, Iterable<Locale> supportedLocales) {
+    for (var deviceLocale in deviceLocales ?? const <Locale>[]) {
+      var resolved = resolve(deviceLocale);
+      if (resolved != null) return resolved;
+    }
+    return supportedLocales.first;
+  }
+
+  /// O nome a mostrar para uma etiqueta de idioma, com a própria etiqueta como
   /// último recurso.
-  static String displayNameOf(String languageCode) =>
-      displayNames[languageCode] ?? languageCode;
+  static String displayNameOf(String tag) => displayNames[tagFor(tag)] ?? tag;
 }
 
 class MyAppLocalizations {
-  MyAppLocalizations(this.locale);
+  MyAppLocalizations(this.locale) : _values = _valuesFor(locale);
 
   final Locale locale;
 
+  /// Os textos do idioma resolvido, guardados na construção: os getters são
+  /// muitos e são lidos a cada quadro, e o locale de uma instância não muda.
+  final Map<String, String> _values;
+
   static MyAppLocalizations? of(BuildContext context) {
     return Localizations.of<MyAppLocalizations>(context, MyAppLocalizations);
+  }
+
+  /// Os textos do idioma da build que atende [locale]. Um idioma que não está
+  /// na build cai no primeiro da lista, em vez de deixar a interface sem
+  /// nenhum texto — o delegate não carrega um locale desses, mas a classe
+  /// também é construída direto nos testes.
+  static Map<String, String> _valuesFor(Locale locale) {
+    var resolved = AppLocales.resolve(locale) ?? AppLocales.supported.first;
+    return _localizedValues[AppLocales.tagOf(resolved)]!;
   }
 
   static Map<String, Map<String, String>> _localizedValues = {
@@ -354,574 +451,847 @@ class MyAppLocalizations {
           'histórico, então a projeção segue a base estatística.',
       'aiInsightDataLimited': 'Histórico curto (%s janelas): a projeção usa '
           'apenas a base estatística.',
+    },
+    // O espanhol da Espanha. A diferença para o de baixo é de vocabulário —
+    // "ajustes" e "móvil" aqui, "configuración" e "celular" lá — e do tempo
+    // verbal do passado, que na Espanha costuma ser composto.
+    'es-ES': {
+      'conversionButtonLabel': 'Conversiones',
+      'conversionPageTitle': 'Conversión de divisas',
+      'homePageHeadsUpText': 'Cotizaciones en %s',
+      'conversionMultiplierHint': 'Cantidad',
+      'conversionPageExplanationText': 'Introduce la cantidad de la divisa que '
+          'se va a convertir, elige esa divisa y la divisa a la que quieres '
+          'convertirla.',
+      'conversionFromLabel': 'De',
+      'conversionToLabel': 'A',
+      'conversionSwapTooltip': 'Invertir las divisas',
+      'conversionClearAmountTooltip': 'Borrar la cantidad',
+      'conversionInvalidAmountError': 'Introduce un valor válido',
+      'conversionCurrencyPickerTitle': 'Elige una divisa',
+      'conversionCurrencySearchHint': 'Busca por nombre o código',
+      'conversionCurrencyNotFoundLabel': 'No se ha encontrado ninguna divisa',
+      'conversionCurrencyPickerYoursLabel': 'Tus divisas',
+      'conversionCurrencyPickerOthersLabel': 'Todas las divisas',
+      'conversionRateUnavailableLabel': 'Cotización no disponible',
+      'conversionCopyResultTooltip': 'Copiar el resultado',
+      'conversionResultCopiedLabel': 'Resultado copiado',
+      'mainCurrenciesBottomNavItemLabel': 'Divisas',
+      'currencyHistoryBottomNavItemLabel': 'Histórico',
+      'configBottomNavItemLabel': 'Ajustes',
+      'aboutBottomNavItemLabel': 'Acerca de',
+      'currencyHistoryFromDateLabel': 'Desde',
+      'currencyHistoryToDateLabel': 'Hasta',
+      'currencyHistoryCurrenciesSectionLabel': 'Divisas',
+      'currencyHistoryCryptocurrenciesSectionLabel': 'Criptomonedas',
+      'noDataLabel': 'Sin datos',
+      'getCurrencyHistoryBtnLabel': 'Obtener el histórico',
+      'overrideDefaultCurrencySwitchLabel': 'Sustituir la divisa por defecto',
+      'selectedOverrideCurrencyLabel': 'Divisa',
+      'homeCurrenciesSettingLabel': 'Cotizaciones en la pantalla de inicio',
+      'homeCurrenciesPickerTitle': 'Cotizaciones mostradas en burbujas',
+      'homeCurrenciesPickerDescription':
+          'La primera divisa elegida ocupa la burbuja destacada.',
+      'homeCurrenciesSelectedCountLabel': '%s seleccionadas',
+      'homeCurrenciesEmptySelectionLabel': 'Elige al menos una divisa',
+      'homeCurrenciesSaveBtnLabel': 'Guardar',
+      'appLanguageSettingLabel': 'Idioma de la aplicación',
+      'appLanguageSystemOptionLabel': 'Idioma del sistema',
+      'appConfigurationsSectionLabel': 'Ajustes de la aplicación',
+      'pwaInstallSectionLabel': 'Instalar en este dispositivo',
+      'pwaInstallCardLabel': 'Instalar la aplicación',
+      'pwaInstallCardDescription':
+          'Añade Cotação Direta a tu dispositivo y ábrelo desde su propio '
+          'icono, sin la barra del navegador.',
+      'pwaInstallBtnLabel': 'Instalar',
+      'pwaInstallIosCardDescription':
+          'En el iPhone y el iPad la instalación se hace desde el menú de '
+          'compartir de Safari.',
+      'pwaInstallIosBtnLabel': 'Cómo instalar',
+      'pwaInstallIosDialogTitle': 'Añadir a pantalla de inicio',
+      'pwaInstallIosDialogBody':
+          'En Safari, pulsa el botón de compartir, en la parte inferior de la '
+          'pantalla, elige "Añadir a pantalla de inicio" y confirma. Cotação '
+          'Direta aparecerá junto a tus aplicaciones.',
+      'pwaInstallIosDialogCloseBtnLabel': 'Entendido',
+      'pwaInstallAcceptedLabel': 'Aplicación instalada',
+      'pwaInstallDismissedLabel': 'Instalación cancelada',
+      'aboutAppDescription': 'Una aplicación sencilla que muestra la '
+          'cotización de las principales divisas frente al real brasileño.',
+      'aboutVersionLabel': 'Versión',
+      'aboutDeveloperLabel': 'Desarrollado por',
+      'aboutSourceCodeLabel': 'Código fuente',
+      'currencyAlertsBottomNavItemLabel': 'Alertas',
+      'currencyAlertsSectionLabel': 'Alertas de cambio',
+      'currencyAlertEmptyListLabel':
+          'Todavía no hay alertas. Pulsa el botón de abajo para crear una.',
+      'addCurrencyAlertBtnLabel': 'Nueva alerta',
+      'addCurrencyAlertDialogTitle': 'Nueva alerta de cambio',
+      'currencyAlertCurrencyLabel': 'Divisa',
+      'currencyAlertConditionLabel': 'Condición',
+      'currencyAlertConditionAbove': 'Suba por encima de',
+      'currencyAlertConditionBelow': 'Baje por debajo de',
+      'currencyAlertTargetValueLabel': 'Valor objetivo',
+      'currencyAlertInvalidValueError': 'Introduce un valor válido',
+      'currencyAlertSaveBtnLabel': 'Guardar',
+      'currencyAlertCancelBtnLabel': 'Cancelar',
+      'currencyAlertTriggeredLabel': 'Activada',
+      'currencyAlertActiveLabel': 'En espera',
+      'currencyAlertDeleteTooltip': 'Eliminar',
+      'currencyAlertNotificationTitle': 'Alerta de cambio',
+      'currencyAlertNotificationBody': '%s ha alcanzado %s',
+      'aiInsightsBottomNavItemLabel': 'IA',
+      'aiInsightsSectionLabel': 'Análisis con IA en el dispositivo',
+      'aiInsightsDescription': 'Una red neuronal pequeña se entrena en este '
+          'dispositivo, con las cotizaciones que la aplicación ya ha '
+          'descargado, para resumir el mercado y proyectar los próximos días. '
+          'Ningún dato sale de tu móvil.',
+      'aiInsightsAssetLabel': 'Activo',
+      'aiInsightsAssetPickerTitle': 'Elige un activo',
+      'aiInsightsAssetNotFoundLabel': 'No se ha encontrado ningún activo',
+      'aiInsightsHorizonLabel': 'Horizonte de la proyección',
+      'aiInsightsHorizonOptionLabel': '%s días',
+      'aiInsightsAmountLabel': 'Importe a simular (opcional)',
+      'aiInsightsAnalyzeBtnLabel': 'Analizar en el dispositivo',
+      'aiInsightsRunningLabel': 'Entrenando el modelo local…',
+      'aiInsightsEmptyLabel': 'Elige un activo y ejecuta el análisis.',
+      'aiInsightsNoDataError':
+          'No se han encontrado cotizaciones para este activo.',
+      'aiInsightsInsufficientDataError':
+          'No hay histórico suficiente para analizar este activo.',
+      'aiInsightsFailureError': 'No se ha podido completar el análisis.',
+      'aiInsightsSummarySectionLabel': 'Resumen del mercado',
+      'aiInsightsProjectionSectionLabel': 'Proyección',
+      'aiInsightsInsightsSectionLabel': 'Conclusiones',
+      'aiInsightsModelSectionLabel': 'Modelo local',
+      'aiInsightsLastPriceLabel': 'Cotización actual',
+      'aiInsightsWeeklyChangeLabel': 'Variación en 7 días',
+      'aiInsightsMonthlyChangeLabel': 'Variación en 30 días',
+      'aiInsightsVolatilityLabel': 'Volatilidad anualizada',
+      'aiInsightsRsiLabel': 'Momento (RSI 14)',
+      'aiInsightsDrawdownLabel': 'Mayor caída',
+      'aiInsightsTrendLabel': 'Tendencia anualizada',
+      'aiInsightsTrendFitLabel': 'Ajuste de la tendencia (R²)',
+      'aiInsightsProjectedPriceLabel': 'Cotización proyectada en %s días',
+      'aiInsightsProjectedChangeLabel': 'Variación proyectada',
+      'aiInsightsConfidenceBandLabel': 'Rango con %s de confianza',
+      'aiInsightsAmountProjectionLabel': 'Importe simulado',
+      'aiInsightsAmountProjectionHint': '%s invertidos hoy',
+      'aiInsightsModelSamplesLabel': 'Ventanas de entrenamiento',
+      'aiInsightsModelSkillLabel': 'Ventaja sobre el paseo aleatorio',
+      'aiInsightsModelEpochsLabel': 'Épocas',
+      'aiInsightsModelUntrainedLabel':
+          'Histórico corto: la proyección usa solo la base estadística.',
+      'aiInsightsDisclaimerLabel': 'Estimaciones calculadas en tu dispositivo '
+          'a partir de cotizaciones pasadas. No son una recomendación de '
+          'inversión.',
+      'aiInsightsChartHistoryLabel': 'Histórico',
+      'aiInsightsChartProjectionLabel': 'Proyección',
+      'aiInsightTrendUp': 'Tendencia alcista: %s en los últimos %s días.',
+      'aiInsightTrendDown': 'Tendencia bajista: %s en los últimos %s días.',
+      'aiInsightTrendSideways':
+          'Sin tendencia definida: %s en los últimos %s días.',
+      'aiInsightMomentumOverbought':
+          'Momento estirado: RSI en %s, en zona de sobrecompra.',
+      'aiInsightMomentumOversold':
+          'Momento presionado: RSI en %s, en zona de sobreventa.',
+      'aiInsightMomentumNeutral': 'Momento equilibrado: RSI en %s.',
+      'aiInsightVolatilityHigh': 'Volatilidad alta: %s al año, así que la '
+          'proyección tiene un rango amplio.',
+      'aiInsightVolatilityLow': 'Volatilidad baja: %s al año.',
+      'aiInsightProjectionUp':
+          'El modelo proyecta una subida del %s en %s días, hasta %s.',
+      'aiInsightProjectionDown':
+          'El modelo proyecta una bajada del %s en %s días, hasta %s.',
+      'aiInsightProjectionStable':
+          'El modelo proyecta estabilidad en %s días, en torno a %s.',
+      'aiInsightDrawdown':
+          'El activo cayó un %s desde su máximo en el periodo analizado.',
+      'aiInsightConfidenceGood':
+          'La red superó al paseo aleatorio en un %s en la validación.',
+      'aiInsightConfidenceLow': 'La red no superó al paseo aleatorio con este '
+          'histórico, así que la proyección sigue la base estadística.',
+      'aiInsightDataLimited': 'Histórico corto (%s ventanas): la proyección '
+          'usa solo la base estadística.',
+    },
+    // O espanhol da América Latina, o es-419 do CLDR: uma tradução só para as
+    // Américas, já que as diferenças entre os países de lá são menores do que
+    // as que separam qualquer um deles da Espanha.
+    'es-419': {
+      'conversionButtonLabel': 'Conversiones',
+      'conversionPageTitle': 'Conversión de monedas',
+      'homePageHeadsUpText': 'Cotizaciones en %s',
+      'conversionMultiplierHint': 'Cantidad',
+      'conversionPageExplanationText': 'Ingresa la cantidad de la moneda que '
+          'vas a convertir, selecciona esa moneda y la moneda a la que quieres '
+          'convertirla.',
+      'conversionFromLabel': 'De',
+      'conversionToLabel': 'A',
+      'conversionSwapTooltip': 'Invertir las monedas',
+      'conversionClearAmountTooltip': 'Borrar la cantidad',
+      'conversionInvalidAmountError': 'Ingresa un valor válido',
+      'conversionCurrencyPickerTitle': 'Selecciona una moneda',
+      'conversionCurrencySearchHint': 'Busca por nombre o código',
+      'conversionCurrencyNotFoundLabel': 'No se encontró ninguna moneda',
+      'conversionCurrencyPickerYoursLabel': 'Tus monedas',
+      'conversionCurrencyPickerOthersLabel': 'Todas las monedas',
+      'conversionRateUnavailableLabel': 'Cotización no disponible',
+      'conversionCopyResultTooltip': 'Copiar el resultado',
+      'conversionResultCopiedLabel': 'Resultado copiado',
+      'mainCurrenciesBottomNavItemLabel': 'Monedas',
+      'currencyHistoryBottomNavItemLabel': 'Historial',
+      'configBottomNavItemLabel': 'Configuración',
+      'aboutBottomNavItemLabel': 'Acerca de',
+      'currencyHistoryFromDateLabel': 'Desde',
+      'currencyHistoryToDateLabel': 'Hasta',
+      'currencyHistoryCurrenciesSectionLabel': 'Monedas',
+      'currencyHistoryCryptocurrenciesSectionLabel': 'Criptomonedas',
+      'noDataLabel': 'Sin datos',
+      'getCurrencyHistoryBtnLabel': 'Obtener el historial',
+      'overrideDefaultCurrencySwitchLabel':
+          'Reemplazar la moneda predeterminada',
+      'selectedOverrideCurrencyLabel': 'Moneda',
+      'homeCurrenciesSettingLabel': 'Cotizaciones en la pantalla de inicio',
+      'homeCurrenciesPickerTitle': 'Cotizaciones mostradas en burbujas',
+      'homeCurrenciesPickerDescription':
+          'La primera moneda seleccionada ocupa la burbuja destacada.',
+      'homeCurrenciesSelectedCountLabel': '%s seleccionadas',
+      'homeCurrenciesEmptySelectionLabel': 'Selecciona al menos una moneda',
+      'homeCurrenciesSaveBtnLabel': 'Guardar',
+      'appLanguageSettingLabel': 'Idioma de la aplicación',
+      'appLanguageSystemOptionLabel': 'Idioma del sistema',
+      'appConfigurationsSectionLabel': 'Configuración de la aplicación',
+      'pwaInstallSectionLabel': 'Instalar en este dispositivo',
+      'pwaInstallCardLabel': 'Instalar la aplicación',
+      'pwaInstallCardDescription':
+          'Agrega Cotação Direta a tu dispositivo y ábrelo desde su propio '
+          'ícono, sin la barra del navegador.',
+      'pwaInstallBtnLabel': 'Instalar',
+      'pwaInstallIosCardDescription':
+          'En el iPhone y el iPad la instalación se hace desde el menú de '
+          'compartir de Safari.',
+      'pwaInstallIosBtnLabel': 'Cómo instalar',
+      'pwaInstallIosDialogTitle': 'Agregar a la pantalla de inicio',
+      'pwaInstallIosDialogBody':
+          'En Safari, toca el botón de compartir, en la parte de abajo de la '
+          'pantalla, elige "Agregar a la pantalla de inicio" y confirma. '
+          'Cotação Direta va a aparecer junto a tus aplicaciones.',
+      'pwaInstallIosDialogCloseBtnLabel': 'Entendido',
+      'pwaInstallAcceptedLabel': 'Aplicación instalada',
+      'pwaInstallDismissedLabel': 'Instalación cancelada',
+      'aboutAppDescription': 'Una aplicación sencilla que muestra la '
+          'cotización de las principales monedas frente al real brasileño.',
+      'aboutVersionLabel': 'Versión',
+      'aboutDeveloperLabel': 'Desarrollado por',
+      'aboutSourceCodeLabel': 'Código fuente',
+      'currencyAlertsBottomNavItemLabel': 'Alertas',
+      'currencyAlertsSectionLabel': 'Alertas de cambio',
+      'currencyAlertEmptyListLabel':
+          'Todavía no hay alertas. Toca el botón de abajo para crear una.',
+      'addCurrencyAlertBtnLabel': 'Nueva alerta',
+      'addCurrencyAlertDialogTitle': 'Nueva alerta de cambio',
+      'currencyAlertCurrencyLabel': 'Moneda',
+      'currencyAlertConditionLabel': 'Condición',
+      'currencyAlertConditionAbove': 'Suba por encima de',
+      'currencyAlertConditionBelow': 'Baje por debajo de',
+      'currencyAlertTargetValueLabel': 'Valor objetivo',
+      'currencyAlertInvalidValueError': 'Ingresa un valor válido',
+      'currencyAlertSaveBtnLabel': 'Guardar',
+      'currencyAlertCancelBtnLabel': 'Cancelar',
+      'currencyAlertTriggeredLabel': 'Activada',
+      'currencyAlertActiveLabel': 'En espera',
+      'currencyAlertDeleteTooltip': 'Eliminar',
+      'currencyAlertNotificationTitle': 'Alerta de cambio',
+      'currencyAlertNotificationBody': '%s alcanzó %s',
+      'aiInsightsBottomNavItemLabel': 'IA',
+      'aiInsightsSectionLabel': 'Análisis con IA en el dispositivo',
+      'aiInsightsDescription': 'Una red neuronal pequeña se entrena en este '
+          'dispositivo, con las cotizaciones que la aplicación ya descargó, '
+          'para resumir el mercado y proyectar los próximos días. Ningún dato '
+          'sale de tu celular.',
+      'aiInsightsAssetLabel': 'Activo',
+      'aiInsightsAssetPickerTitle': 'Selecciona un activo',
+      'aiInsightsAssetNotFoundLabel': 'No se encontró ningún activo',
+      'aiInsightsHorizonLabel': 'Horizonte de la proyección',
+      'aiInsightsHorizonOptionLabel': '%s días',
+      'aiInsightsAmountLabel': 'Monto para simular (opcional)',
+      'aiInsightsAnalyzeBtnLabel': 'Analizar en el dispositivo',
+      'aiInsightsRunningLabel': 'Entrenando el modelo local…',
+      'aiInsightsEmptyLabel': 'Selecciona un activo y ejecuta el análisis.',
+      'aiInsightsNoDataError':
+          'No se encontraron cotizaciones para este activo.',
+      'aiInsightsInsufficientDataError':
+          'No hay historial suficiente para analizar este activo.',
+      'aiInsightsFailureError': 'No se pudo completar el análisis.',
+      'aiInsightsSummarySectionLabel': 'Resumen del mercado',
+      'aiInsightsProjectionSectionLabel': 'Proyección',
+      'aiInsightsInsightsSectionLabel': 'Conclusiones',
+      'aiInsightsModelSectionLabel': 'Modelo local',
+      'aiInsightsLastPriceLabel': 'Cotización actual',
+      'aiInsightsWeeklyChangeLabel': 'Variación en 7 días',
+      'aiInsightsMonthlyChangeLabel': 'Variación en 30 días',
+      'aiInsightsVolatilityLabel': 'Volatilidad anualizada',
+      'aiInsightsRsiLabel': 'Momento (RSI 14)',
+      'aiInsightsDrawdownLabel': 'Mayor caída',
+      'aiInsightsTrendLabel': 'Tendencia anualizada',
+      'aiInsightsTrendFitLabel': 'Ajuste de la tendencia (R²)',
+      'aiInsightsProjectedPriceLabel': 'Cotización proyectada en %s días',
+      'aiInsightsProjectedChangeLabel': 'Variación proyectada',
+      'aiInsightsConfidenceBandLabel': 'Rango con %s de confianza',
+      'aiInsightsAmountProjectionLabel': 'Monto simulado',
+      'aiInsightsAmountProjectionHint': '%s invertidos hoy',
+      'aiInsightsModelSamplesLabel': 'Ventanas de entrenamiento',
+      'aiInsightsModelSkillLabel': 'Ventaja sobre la caminata aleatoria',
+      'aiInsightsModelEpochsLabel': 'Épocas',
+      'aiInsightsModelUntrainedLabel':
+          'Historial corto: la proyección usa solo la base estadística.',
+      'aiInsightsDisclaimerLabel': 'Estimaciones calculadas en tu dispositivo '
+          'a partir de cotizaciones pasadas. No son una recomendación de '
+          'inversión.',
+      'aiInsightsChartHistoryLabel': 'Historial',
+      'aiInsightsChartProjectionLabel': 'Proyección',
+      'aiInsightTrendUp': 'Tendencia alcista: %s en los últimos %s días.',
+      'aiInsightTrendDown': 'Tendencia bajista: %s en los últimos %s días.',
+      'aiInsightTrendSideways':
+          'Sin tendencia definida: %s en los últimos %s días.',
+      'aiInsightMomentumOverbought':
+          'Momento estirado: RSI en %s, en zona de sobrecompra.',
+      'aiInsightMomentumOversold':
+          'Momento presionado: RSI en %s, en zona de sobreventa.',
+      'aiInsightMomentumNeutral': 'Momento equilibrado: RSI en %s.',
+      'aiInsightVolatilityHigh': 'Volatilidad alta: %s al año, así que la '
+          'proyección tiene un rango amplio.',
+      'aiInsightVolatilityLow': 'Volatilidad baja: %s al año.',
+      'aiInsightProjectionUp':
+          'El modelo proyecta un alza de %s en %s días, hasta %s.',
+      'aiInsightProjectionDown':
+          'El modelo proyecta una baja de %s en %s días, hasta %s.',
+      'aiInsightProjectionStable':
+          'El modelo proyecta estabilidad en %s días, alrededor de %s.',
+      'aiInsightDrawdown':
+          'El activo cayó %s desde su máximo en el período analizado.',
+      'aiInsightConfidenceGood':
+          'La red superó a la caminata aleatoria en %s en la validación.',
+      'aiInsightConfidenceLow': 'La red no superó a la caminata aleatoria con '
+          'este historial, así que la proyección sigue la base estadística.',
+      'aiInsightDataLimited': 'Historial corto (%s ventanas): la proyección '
+          'usa solo la base estadística.',
     }
   };
 
   String? get conversionButtonLabel {
-    return _localizedValues[locale.languageCode]!['conversionButtonLabel'];
+    return _values['conversionButtonLabel'];
   }
 
   String? get conversionPageTitle {
-    return _localizedValues[locale.languageCode]!['conversionPageTitle'];
+    return _values['conversionPageTitle'];
   }
 
   String? get homePageHeadsUpText {
-    return _localizedValues[locale.languageCode]!['homePageHeadsUpText'];
+    return _values['homePageHeadsUpText'];
   }
 
   String? get conversionMultiplierHint {
-    return _localizedValues[locale.languageCode]!['conversionMultiplierHint'];
+    return _values['conversionMultiplierHint'];
   }
 
   String? get conversionPageExplanationText {
-    return _localizedValues[locale.languageCode]!
-        ['conversionPageExplanationText'];
+    return _values['conversionPageExplanationText'];
   }
 
   String? get conversionFromLabel {
-    return _localizedValues[locale.languageCode]!['conversionFromLabel'];
+    return _values['conversionFromLabel'];
   }
 
   String? get conversionToLabel {
-    return _localizedValues[locale.languageCode]!['conversionToLabel'];
+    return _values['conversionToLabel'];
   }
 
   String? get conversionSwapTooltip {
-    return _localizedValues[locale.languageCode]!['conversionSwapTooltip'];
+    return _values['conversionSwapTooltip'];
   }
 
   String? get conversionClearAmountTooltip {
-    return _localizedValues[locale.languageCode]!
-        ['conversionClearAmountTooltip'];
+    return _values['conversionClearAmountTooltip'];
   }
 
   String? get conversionInvalidAmountError {
-    return _localizedValues[locale.languageCode]!
-        ['conversionInvalidAmountError'];
+    return _values['conversionInvalidAmountError'];
   }
 
   String? get conversionCurrencyPickerTitle {
-    return _localizedValues[locale.languageCode]!
-        ['conversionCurrencyPickerTitle'];
+    return _values['conversionCurrencyPickerTitle'];
   }
 
   String? get conversionCurrencySearchHint {
-    return _localizedValues[locale.languageCode]!
-        ['conversionCurrencySearchHint'];
+    return _values['conversionCurrencySearchHint'];
   }
 
   String? get conversionCurrencyNotFoundLabel {
-    return _localizedValues[locale.languageCode]!
-        ['conversionCurrencyNotFoundLabel'];
+    return _values['conversionCurrencyNotFoundLabel'];
   }
 
   /// Título da seção do seletor com as moedas da tela inicial, que aparecem
   /// antes das demais.
   String? get conversionCurrencyPickerYoursLabel {
-    return _localizedValues[locale.languageCode]!
-        ['conversionCurrencyPickerYoursLabel'];
+    return _values['conversionCurrencyPickerYoursLabel'];
   }
 
   /// Título da seção com o resto da lista, logo abaixo das moedas da tela
   /// inicial.
   String? get conversionCurrencyPickerOthersLabel {
-    return _localizedValues[locale.languageCode]!
-        ['conversionCurrencyPickerOthersLabel'];
+    return _values['conversionCurrencyPickerOthersLabel'];
   }
 
   String? get conversionRateUnavailableLabel {
-    return _localizedValues[locale.languageCode]!
-        ['conversionRateUnavailableLabel'];
+    return _values['conversionRateUnavailableLabel'];
   }
 
   String? get conversionCopyResultTooltip {
-    return _localizedValues[locale.languageCode]!
-        ['conversionCopyResultTooltip'];
+    return _values['conversionCopyResultTooltip'];
   }
 
   String? get conversionResultCopiedLabel {
-    return _localizedValues[locale.languageCode]!
-        ['conversionResultCopiedLabel'];
+    return _values['conversionResultCopiedLabel'];
   }
 
   String? get mainCurrenciesBottomNavItemLabel {
-    return _localizedValues[locale.languageCode]!
-        ['mainCurrenciesBottomNavItemLabel'];
+    return _values['mainCurrenciesBottomNavItemLabel'];
   }
 
   String? get currencyHistoryBottomNavItemLabel {
-    return _localizedValues[locale.languageCode]!
-        ['currencyHistoryBottomNavItemLabel'];
+    return _values['currencyHistoryBottomNavItemLabel'];
   }
 
   String? get aboutBottomNavItemLabel {
-    return _localizedValues[locale.languageCode]!['aboutBottomNavItemLabel'];
+    return _values['aboutBottomNavItemLabel'];
   }
 
   String? get currencyHistoryFromDateLabel {
-    return _localizedValues[locale.languageCode]!
-        ['currencyHistoryFromDateLabel'];
+    return _values['currencyHistoryFromDateLabel'];
   }
 
   String? get currencyHistoryToDateLabel {
-    return _localizedValues[locale.languageCode]!['currencyHistoryToDateLabel'];
+    return _values['currencyHistoryToDateLabel'];
   }
 
   String? get currencyHistoryCurrenciesSectionLabel {
-    return _localizedValues[locale.languageCode]!
-        ['currencyHistoryCurrenciesSectionLabel'];
+    return _values['currencyHistoryCurrenciesSectionLabel'];
   }
 
   String? get currencyHistoryCryptocurrenciesSectionLabel {
-    return _localizedValues[locale.languageCode]!
-        ['currencyHistoryCryptocurrenciesSectionLabel'];
+    return _values['currencyHistoryCryptocurrenciesSectionLabel'];
   }
 
   String? get noDataLabel {
-    return _localizedValues[locale.languageCode]!['noDataLabel'];
+    return _values['noDataLabel'];
   }
 
   String? get getCurrencyHistoryBtnLabel {
-    return _localizedValues[locale.languageCode]!['getCurrencyHistoryBtnLabel'];
+    return _values['getCurrencyHistoryBtnLabel'];
   }
 
   String? get getConfigBottomNavItemLabel {
-    return _localizedValues[locale.languageCode]!['configBottomNavItemLabel'];
+    return _values['configBottomNavItemLabel'];
   }
 
   String? get overrideDefaultCurrencySwitchLabel {
-    return _localizedValues[locale.languageCode]!
-        ['overrideDefaultCurrencySwitchLabel'];
+    return _values['overrideDefaultCurrencySwitchLabel'];
   }
 
   String? get selectedOverrideCurrencyLabel {
-    return _localizedValues[locale.languageCode]!
-        ['selectedOverrideCurrencyLabel'];
+    return _values['selectedOverrideCurrencyLabel'];
   }
 
   String? get homeCurrenciesSettingLabel {
-    return _localizedValues[locale.languageCode]!['homeCurrenciesSettingLabel'];
+    return _values['homeCurrenciesSettingLabel'];
   }
 
   String? get homeCurrenciesPickerTitle {
-    return _localizedValues[locale.languageCode]!['homeCurrenciesPickerTitle'];
+    return _values['homeCurrenciesPickerTitle'];
   }
 
   String? get homeCurrenciesPickerDescription {
-    return _localizedValues[locale.languageCode]!
-        ['homeCurrenciesPickerDescription'];
+    return _values['homeCurrenciesPickerDescription'];
   }
 
   String? get homeCurrenciesSelectedCountLabel {
-    return _localizedValues[locale.languageCode]!
-        ['homeCurrenciesSelectedCountLabel'];
+    return _values['homeCurrenciesSelectedCountLabel'];
   }
 
   String? get homeCurrenciesEmptySelectionLabel {
-    return _localizedValues[locale.languageCode]!
-        ['homeCurrenciesEmptySelectionLabel'];
+    return _values['homeCurrenciesEmptySelectionLabel'];
   }
 
   String? get homeCurrenciesSaveBtnLabel {
-    return _localizedValues[locale.languageCode]!
-        ['homeCurrenciesSaveBtnLabel'];
+    return _values['homeCurrenciesSaveBtnLabel'];
   }
 
   String? get appLanguageSettingLabel {
-    return _localizedValues[locale.languageCode]!['appLanguageSettingLabel'];
+    return _values['appLanguageSettingLabel'];
   }
 
   String? get appLanguageSystemOptionLabel {
-    return _localizedValues[locale.languageCode]!
-        ['appLanguageSystemOptionLabel'];
+    return _values['appLanguageSystemOptionLabel'];
   }
 
   String? get appConfigurationsSectionLabel {
-    return _localizedValues[locale.languageCode]!
-        ['appConfigurationsSectionLabel'];
+    return _values['appConfigurationsSectionLabel'];
   }
 
   String? get pwaInstallSectionLabel {
-    return _localizedValues[locale.languageCode]!['pwaInstallSectionLabel'];
+    return _values['pwaInstallSectionLabel'];
   }
 
   String? get pwaInstallCardLabel {
-    return _localizedValues[locale.languageCode]!['pwaInstallCardLabel'];
+    return _values['pwaInstallCardLabel'];
   }
 
   String? get pwaInstallCardDescription {
-    return _localizedValues[locale.languageCode]!['pwaInstallCardDescription'];
+    return _values['pwaInstallCardDescription'];
   }
 
   String? get pwaInstallBtnLabel {
-    return _localizedValues[locale.languageCode]!['pwaInstallBtnLabel'];
+    return _values['pwaInstallBtnLabel'];
   }
 
   String? get pwaInstallIosCardDescription {
-    return _localizedValues[locale.languageCode]!
-        ['pwaInstallIosCardDescription'];
+    return _values['pwaInstallIosCardDescription'];
   }
 
   String? get pwaInstallIosBtnLabel {
-    return _localizedValues[locale.languageCode]!['pwaInstallIosBtnLabel'];
+    return _values['pwaInstallIosBtnLabel'];
   }
 
   String? get pwaInstallIosDialogTitle {
-    return _localizedValues[locale.languageCode]!['pwaInstallIosDialogTitle'];
+    return _values['pwaInstallIosDialogTitle'];
   }
 
   String? get pwaInstallIosDialogBody {
-    return _localizedValues[locale.languageCode]!['pwaInstallIosDialogBody'];
+    return _values['pwaInstallIosDialogBody'];
   }
 
   String? get pwaInstallIosDialogCloseBtnLabel {
-    return _localizedValues[locale.languageCode]!
-        ['pwaInstallIosDialogCloseBtnLabel'];
+    return _values['pwaInstallIosDialogCloseBtnLabel'];
   }
 
   String? get pwaInstallAcceptedLabel {
-    return _localizedValues[locale.languageCode]!['pwaInstallAcceptedLabel'];
+    return _values['pwaInstallAcceptedLabel'];
   }
 
   String? get pwaInstallDismissedLabel {
-    return _localizedValues[locale.languageCode]!['pwaInstallDismissedLabel'];
+    return _values['pwaInstallDismissedLabel'];
   }
 
   String? get aboutAppDescription {
-    return _localizedValues[locale.languageCode]!['aboutAppDescription'];
+    return _values['aboutAppDescription'];
   }
 
   String? get aboutVersionLabel {
-    return _localizedValues[locale.languageCode]!['aboutVersionLabel'];
+    return _values['aboutVersionLabel'];
   }
 
   String? get aboutDeveloperLabel {
-    return _localizedValues[locale.languageCode]!['aboutDeveloperLabel'];
+    return _values['aboutDeveloperLabel'];
   }
 
   String? get aboutSourceCodeLabel {
-    return _localizedValues[locale.languageCode]!['aboutSourceCodeLabel'];
+    return _values['aboutSourceCodeLabel'];
   }
 
   String? get currencyAlertsBottomNavItemLabel {
-    return _localizedValues[locale.languageCode]!
-        ['currencyAlertsBottomNavItemLabel'];
+    return _values['currencyAlertsBottomNavItemLabel'];
   }
 
   String? get currencyAlertsSectionLabel {
-    return _localizedValues[locale.languageCode]!['currencyAlertsSectionLabel'];
+    return _values['currencyAlertsSectionLabel'];
   }
 
   String? get currencyAlertEmptyListLabel {
-    return _localizedValues[locale.languageCode]!['currencyAlertEmptyListLabel'];
+    return _values['currencyAlertEmptyListLabel'];
   }
 
   String? get addCurrencyAlertBtnLabel {
-    return _localizedValues[locale.languageCode]!['addCurrencyAlertBtnLabel'];
+    return _values['addCurrencyAlertBtnLabel'];
   }
 
   String? get addCurrencyAlertDialogTitle {
-    return _localizedValues[locale.languageCode]!
-        ['addCurrencyAlertDialogTitle'];
+    return _values['addCurrencyAlertDialogTitle'];
   }
 
   String? get currencyAlertCurrencyLabel {
-    return _localizedValues[locale.languageCode]!['currencyAlertCurrencyLabel'];
+    return _values['currencyAlertCurrencyLabel'];
   }
 
   String? get currencyAlertConditionLabel {
-    return _localizedValues[locale.languageCode]!
-        ['currencyAlertConditionLabel'];
+    return _values['currencyAlertConditionLabel'];
   }
 
   String? get currencyAlertConditionAbove {
-    return _localizedValues[locale.languageCode]!
-        ['currencyAlertConditionAbove'];
+    return _values['currencyAlertConditionAbove'];
   }
 
   String? get currencyAlertConditionBelow {
-    return _localizedValues[locale.languageCode]!
-        ['currencyAlertConditionBelow'];
+    return _values['currencyAlertConditionBelow'];
   }
 
   String? get currencyAlertTargetValueLabel {
-    return _localizedValues[locale.languageCode]!
-        ['currencyAlertTargetValueLabel'];
+    return _values['currencyAlertTargetValueLabel'];
   }
 
   String? get currencyAlertInvalidValueError {
-    return _localizedValues[locale.languageCode]!
-        ['currencyAlertInvalidValueError'];
+    return _values['currencyAlertInvalidValueError'];
   }
 
   String? get currencyAlertSaveBtnLabel {
-    return _localizedValues[locale.languageCode]!['currencyAlertSaveBtnLabel'];
+    return _values['currencyAlertSaveBtnLabel'];
   }
 
   String? get currencyAlertCancelBtnLabel {
-    return _localizedValues[locale.languageCode]!
-        ['currencyAlertCancelBtnLabel'];
+    return _values['currencyAlertCancelBtnLabel'];
   }
 
   String? get currencyAlertTriggeredLabel {
-    return _localizedValues[locale.languageCode]!['currencyAlertTriggeredLabel'];
+    return _values['currencyAlertTriggeredLabel'];
   }
 
   String? get currencyAlertActiveLabel {
-    return _localizedValues[locale.languageCode]!['currencyAlertActiveLabel'];
+    return _values['currencyAlertActiveLabel'];
   }
 
   String? get currencyAlertDeleteTooltip {
-    return _localizedValues[locale.languageCode]!['currencyAlertDeleteTooltip'];
+    return _values['currencyAlertDeleteTooltip'];
   }
 
   String? get currencyAlertNotificationTitle {
-    return _localizedValues[locale.languageCode]!
-        ['currencyAlertNotificationTitle'];
+    return _values['currencyAlertNotificationTitle'];
   }
 
   String? get currencyAlertNotificationBody {
-    return _localizedValues[locale.languageCode]!
-        ['currencyAlertNotificationBody'];
+    return _values['currencyAlertNotificationBody'];
   }
 
   String? get aiInsightsBottomNavItemLabel {
-    return _localizedValues[locale.languageCode]!
-        ['aiInsightsBottomNavItemLabel'];
+    return _values['aiInsightsBottomNavItemLabel'];
   }
 
   String? get aiInsightsSectionLabel {
-    return _localizedValues[locale.languageCode]!['aiInsightsSectionLabel'];
+    return _values['aiInsightsSectionLabel'];
   }
 
   String? get aiInsightsDescription {
-    return _localizedValues[locale.languageCode]!['aiInsightsDescription'];
+    return _values['aiInsightsDescription'];
   }
 
   String? get aiInsightsAssetLabel {
-    return _localizedValues[locale.languageCode]!['aiInsightsAssetLabel'];
+    return _values['aiInsightsAssetLabel'];
   }
 
   String? get aiInsightsAssetPickerTitle {
-    return _localizedValues[locale.languageCode]!['aiInsightsAssetPickerTitle'];
+    return _values['aiInsightsAssetPickerTitle'];
   }
 
   String? get aiInsightsAssetNotFoundLabel {
-    return _localizedValues[locale.languageCode]!
-        ['aiInsightsAssetNotFoundLabel'];
+    return _values['aiInsightsAssetNotFoundLabel'];
   }
 
   String? get aiInsightsHorizonLabel {
-    return _localizedValues[locale.languageCode]!['aiInsightsHorizonLabel'];
+    return _values['aiInsightsHorizonLabel'];
   }
 
   String? get aiInsightsHorizonOptionLabel {
-    return _localizedValues[locale.languageCode]!
-        ['aiInsightsHorizonOptionLabel'];
+    return _values['aiInsightsHorizonOptionLabel'];
   }
 
   String? get aiInsightsAmountLabel {
-    return _localizedValues[locale.languageCode]!['aiInsightsAmountLabel'];
+    return _values['aiInsightsAmountLabel'];
   }
 
   String? get aiInsightsAnalyzeBtnLabel {
-    return _localizedValues[locale.languageCode]!['aiInsightsAnalyzeBtnLabel'];
+    return _values['aiInsightsAnalyzeBtnLabel'];
   }
 
   String? get aiInsightsRunningLabel {
-    return _localizedValues[locale.languageCode]!['aiInsightsRunningLabel'];
+    return _values['aiInsightsRunningLabel'];
   }
 
   String? get aiInsightsEmptyLabel {
-    return _localizedValues[locale.languageCode]!['aiInsightsEmptyLabel'];
+    return _values['aiInsightsEmptyLabel'];
   }
 
   String? get aiInsightsNoDataError {
-    return _localizedValues[locale.languageCode]!['aiInsightsNoDataError'];
+    return _values['aiInsightsNoDataError'];
   }
 
   String? get aiInsightsInsufficientDataError {
-    return _localizedValues[locale.languageCode]!
-        ['aiInsightsInsufficientDataError'];
+    return _values['aiInsightsInsufficientDataError'];
   }
 
   String? get aiInsightsFailureError {
-    return _localizedValues[locale.languageCode]!['aiInsightsFailureError'];
+    return _values['aiInsightsFailureError'];
   }
 
   String? get aiInsightsSummarySectionLabel {
-    return _localizedValues[locale.languageCode]!
-        ['aiInsightsSummarySectionLabel'];
+    return _values['aiInsightsSummarySectionLabel'];
   }
 
   String? get aiInsightsProjectionSectionLabel {
-    return _localizedValues[locale.languageCode]!
-        ['aiInsightsProjectionSectionLabel'];
+    return _values['aiInsightsProjectionSectionLabel'];
   }
 
   String? get aiInsightsInsightsSectionLabel {
-    return _localizedValues[locale.languageCode]!
-        ['aiInsightsInsightsSectionLabel'];
+    return _values['aiInsightsInsightsSectionLabel'];
   }
 
   String? get aiInsightsModelSectionLabel {
-    return _localizedValues[locale.languageCode]!['aiInsightsModelSectionLabel'];
+    return _values['aiInsightsModelSectionLabel'];
   }
 
   String? get aiInsightsLastPriceLabel {
-    return _localizedValues[locale.languageCode]!['aiInsightsLastPriceLabel'];
+    return _values['aiInsightsLastPriceLabel'];
   }
 
   String? get aiInsightsWeeklyChangeLabel {
-    return _localizedValues[locale.languageCode]!['aiInsightsWeeklyChangeLabel'];
+    return _values['aiInsightsWeeklyChangeLabel'];
   }
 
   String? get aiInsightsMonthlyChangeLabel {
-    return _localizedValues[locale.languageCode]!
-        ['aiInsightsMonthlyChangeLabel'];
+    return _values['aiInsightsMonthlyChangeLabel'];
   }
 
   String? get aiInsightsVolatilityLabel {
-    return _localizedValues[locale.languageCode]!['aiInsightsVolatilityLabel'];
+    return _values['aiInsightsVolatilityLabel'];
   }
 
   String? get aiInsightsRsiLabel {
-    return _localizedValues[locale.languageCode]!['aiInsightsRsiLabel'];
+    return _values['aiInsightsRsiLabel'];
   }
 
   String? get aiInsightsDrawdownLabel {
-    return _localizedValues[locale.languageCode]!['aiInsightsDrawdownLabel'];
+    return _values['aiInsightsDrawdownLabel'];
   }
 
   String? get aiInsightsTrendLabel {
-    return _localizedValues[locale.languageCode]!['aiInsightsTrendLabel'];
+    return _values['aiInsightsTrendLabel'];
   }
 
   String? get aiInsightsTrendFitLabel {
-    return _localizedValues[locale.languageCode]!['aiInsightsTrendFitLabel'];
+    return _values['aiInsightsTrendFitLabel'];
   }
 
   String? get aiInsightsProjectedPriceLabel {
-    return _localizedValues[locale.languageCode]!
-        ['aiInsightsProjectedPriceLabel'];
+    return _values['aiInsightsProjectedPriceLabel'];
   }
 
   String? get aiInsightsProjectedChangeLabel {
-    return _localizedValues[locale.languageCode]!
-        ['aiInsightsProjectedChangeLabel'];
+    return _values['aiInsightsProjectedChangeLabel'];
   }
 
   String? get aiInsightsConfidenceBandLabel {
-    return _localizedValues[locale.languageCode]!
-        ['aiInsightsConfidenceBandLabel'];
+    return _values['aiInsightsConfidenceBandLabel'];
   }
 
   String? get aiInsightsAmountProjectionLabel {
-    return _localizedValues[locale.languageCode]!
-        ['aiInsightsAmountProjectionLabel'];
+    return _values['aiInsightsAmountProjectionLabel'];
   }
 
   String? get aiInsightsAmountProjectionHint {
-    return _localizedValues[locale.languageCode]!
-        ['aiInsightsAmountProjectionHint'];
+    return _values['aiInsightsAmountProjectionHint'];
   }
 
   String? get aiInsightsModelSamplesLabel {
-    return _localizedValues[locale.languageCode]!['aiInsightsModelSamplesLabel'];
+    return _values['aiInsightsModelSamplesLabel'];
   }
 
   String? get aiInsightsModelSkillLabel {
-    return _localizedValues[locale.languageCode]!['aiInsightsModelSkillLabel'];
+    return _values['aiInsightsModelSkillLabel'];
   }
 
   String? get aiInsightsModelEpochsLabel {
-    return _localizedValues[locale.languageCode]!['aiInsightsModelEpochsLabel'];
+    return _values['aiInsightsModelEpochsLabel'];
   }
 
   String? get aiInsightsModelUntrainedLabel {
-    return _localizedValues[locale.languageCode]!
-        ['aiInsightsModelUntrainedLabel'];
+    return _values['aiInsightsModelUntrainedLabel'];
   }
 
   String? get aiInsightsDisclaimerLabel {
-    return _localizedValues[locale.languageCode]!['aiInsightsDisclaimerLabel'];
+    return _values['aiInsightsDisclaimerLabel'];
   }
 
   String? get aiInsightsChartHistoryLabel {
-    return _localizedValues[locale.languageCode]!['aiInsightsChartHistoryLabel'];
+    return _values['aiInsightsChartHistoryLabel'];
   }
 
   String? get aiInsightsChartProjectionLabel {
-    return _localizedValues[locale.languageCode]!
-        ['aiInsightsChartProjectionLabel'];
+    return _values['aiInsightsChartProjectionLabel'];
   }
 
   String? get aiInsightTrendUp {
-    return _localizedValues[locale.languageCode]!['aiInsightTrendUp'];
+    return _values['aiInsightTrendUp'];
   }
 
   String? get aiInsightTrendDown {
-    return _localizedValues[locale.languageCode]!['aiInsightTrendDown'];
+    return _values['aiInsightTrendDown'];
   }
 
   String? get aiInsightTrendSideways {
-    return _localizedValues[locale.languageCode]!['aiInsightTrendSideways'];
+    return _values['aiInsightTrendSideways'];
   }
 
   String? get aiInsightMomentumOverbought {
-    return _localizedValues[locale.languageCode]!
-        ['aiInsightMomentumOverbought'];
+    return _values['aiInsightMomentumOverbought'];
   }
 
   String? get aiInsightMomentumOversold {
-    return _localizedValues[locale.languageCode]!['aiInsightMomentumOversold'];
+    return _values['aiInsightMomentumOversold'];
   }
 
   String? get aiInsightMomentumNeutral {
-    return _localizedValues[locale.languageCode]!['aiInsightMomentumNeutral'];
+    return _values['aiInsightMomentumNeutral'];
   }
 
   String? get aiInsightVolatilityHigh {
-    return _localizedValues[locale.languageCode]!['aiInsightVolatilityHigh'];
+    return _values['aiInsightVolatilityHigh'];
   }
 
   String? get aiInsightVolatilityLow {
-    return _localizedValues[locale.languageCode]!['aiInsightVolatilityLow'];
+    return _values['aiInsightVolatilityLow'];
   }
 
   String? get aiInsightProjectionUp {
-    return _localizedValues[locale.languageCode]!['aiInsightProjectionUp'];
+    return _values['aiInsightProjectionUp'];
   }
 
   String? get aiInsightProjectionDown {
-    return _localizedValues[locale.languageCode]!['aiInsightProjectionDown'];
+    return _values['aiInsightProjectionDown'];
   }
 
   String? get aiInsightProjectionStable {
-    return _localizedValues[locale.languageCode]!['aiInsightProjectionStable'];
+    return _values['aiInsightProjectionStable'];
   }
 
   String? get aiInsightDrawdown {
-    return _localizedValues[locale.languageCode]!['aiInsightDrawdown'];
+    return _values['aiInsightDrawdown'];
   }
 
   String? get aiInsightConfidenceGood {
-    return _localizedValues[locale.languageCode]!['aiInsightConfidenceGood'];
+    return _values['aiInsightConfidenceGood'];
   }
 
   String? get aiInsightConfidenceLow {
-    return _localizedValues[locale.languageCode]!['aiInsightConfidenceLow'];
+    return _values['aiInsightConfidenceLow'];
   }
 
   String? get aiInsightDataLimited {
-    return _localizedValues[locale.languageCode]!['aiInsightDataLimited'];
+    return _values['aiInsightDataLimited'];
   }
 }
 
 class MyAppLocalizationsDelegate
     extends LocalizationsDelegate<MyAppLocalizations> {
   @override
-  bool isSupported(Locale locale) => AppLocales.isSupported(locale.languageCode);
+  bool isSupported(Locale locale) => AppLocales.resolve(locale) != null;
 
   @override
   Future<MyAppLocalizations> load(Locale locale) {

--- a/lib/view/pages/main_menu_items/ai_insights_page.dart
+++ b/lib/view/pages/main_menu_items/ai_insights_page.dart
@@ -283,8 +283,7 @@ class _AiInsightsPageState extends State<AiInsightsPage> {
         return FilledButton.icon(
           onPressed: loading
               ? null
-              : () => bloc.analyze(
-                  languageCode: localizations.locale.languageCode),
+              : () => bloc.analyze(localeName: localizations.locale.toString()),
           icon: const Icon(Icons.psychology_alt),
           label: Text(localizations.aiInsightsAnalyzeBtnLabel!),
         );
@@ -333,7 +332,7 @@ class _AiInsightsPageState extends State<AiInsightsPage> {
           localizations.aiInsightsEmptyLabel!, scale);
     }
 
-    final formatter = _NumberFormatter(localizations.locale.languageCode);
+    final formatter = _NumberFormatter(localizations.locale.toString());
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
@@ -600,20 +599,22 @@ class _AiInsightsPageState extends State<AiInsightsPage> {
   }
 }
 
-/// Formatting of the screen's numbers in the current language.
+/// Formatting of the screen's numbers in the current locale — the region
+/// included, since it is what tells apart the decimal separator of Latin
+/// American Spanish from the one used in Spain.
 class _NumberFormatter {
-  final String languageCode;
+  final String localeName;
 
-  const _NumberFormatter(this.languageCode);
+  const _NumberFormatter(this.localeName);
 
   String decimal(double value, {int digits = 2}) =>
       NumberFormat.decimalPatternDigits(
-              locale: languageCode, decimalDigits: digits)
+              locale: localeName, decimalDigits: digits)
           .format(value);
 
   String percent(double fraction, {int digits = 1}) =>
       NumberFormat.decimalPercentPattern(
-              locale: languageCode, decimalDigits: digits)
+              locale: localeName, decimalDigits: digits)
           .format(fraction);
 
   /// Percentage with an explicit sign: on a change, "+1.2%" and "-1.2%" are

--- a/lib/view/pages/main_menu_items/configurations_page.dart
+++ b/lib/view/pages/main_menu_items/configurations_page.dart
@@ -228,12 +228,10 @@ class ConfigurationsPage extends StatelessWidget {
                 stream: _bloc.languageStream,
                 initialData: _bloc.languageCode,
                 builder: (BuildContext context, snapshot) {
-                  // "" é o idioma do aparelho; um código que esta build não
-                  // tem mais cai no mesmo lugar, senão o seletor ficaria com
-                  // um valor sem item correspondente.
-                  final selected = AppLocales.isSupported(snapshot.data)
-                      ? snapshot.data!
-                      : "";
+                  // "" é o idioma do aparelho; uma etiqueta que esta build
+                  // não tem mais cai no mesmo lugar, senão o seletor ficaria
+                  // com um valor sem item correspondente.
+                  final selected = AppLocales.tagFor(snapshot.data);
                   return BentoCard(
                     padding: EdgeInsets.all(12 * _scale),
                     child: Row(
@@ -261,9 +259,10 @@ class ConfigurationsPage extends StatelessWidget {
                             ),
                             for (var locale in AppLocales.supported)
                               DropdownMenuItem(
-                                value: locale.languageCode,
+                                value: AppLocales.tagOf(locale),
                                 child: Text(
-                                  AppLocales.displayNameOf(locale.languageCode),
+                                  AppLocales.displayNameOf(
+                                      AppLocales.tagOf(locale)),
                                   style: TextStyle(fontSize: 16 * _scale),
                                 ),
                               ),

--- a/test/ai/financial_ai_service_test.dart
+++ b/test/ai/financial_ai_service_test.dart
@@ -103,8 +103,8 @@ void main() {
       final series = seriesFromPrices(
           syntheticPrices(length: 150, dailyDrift: 0.004, noise: 0.002));
 
-      final portugues = service.analyze(series, languageCode: "pt");
-      final ingles = service.analyze(series, languageCode: "en");
+      final portugues = service.analyze(series, localeName: "pt");
+      final ingles = service.analyze(series, localeName: "en");
 
       expect(
           portugues.insights

--- a/test/ai/insight_engine_test.dart
+++ b/test/ai/insight_engine_test.dart
@@ -319,7 +319,7 @@ void main() {
 
   group('InsightEngine formatação dos números', () {
     test('em português o separador decimal é a vírgula', () {
-      final insights = const InsightEngine(languageCode: "pt").generate(
+      final insights = const InsightEngine(localeName: "pt").generate(
           series: series,
           statistics: _statistics(monthlyChange: 0.1234),
           forecast: _forecast());
@@ -329,7 +329,7 @@ void main() {
     });
 
     test('em inglês o separador decimal é o ponto', () {
-      final insights = const InsightEngine(languageCode: "en").generate(
+      final insights = const InsightEngine(localeName: "en").generate(
           series: series,
           statistics: _statistics(monthlyChange: 0.1234),
           forecast: _forecast());
@@ -338,9 +338,28 @@ void main() {
           "12.3%");
     });
 
+    // O espanhol da Espanha separa os decimais com vírgula, o da América
+    // Latina com ponto: é o que faz a região ir junto do idioma até aqui.
+    test('as duas normas do espanhol separam os decimais de formas diferentes',
+        () {
+      final espanha = const InsightEngine(localeName: "es_ES").generate(
+          series: series,
+          statistics: _statistics(monthlyChange: 0.1234),
+          forecast: _forecast());
+      final americaLatina = const InsightEngine(localeName: "es_419").generate(
+          series: series,
+          statistics: _statistics(monthlyChange: 0.1234),
+          forecast: _forecast());
+
+      expect(_insightOf(espanha, InsightCode.trendUp).arguments.first,
+          startsWith("12,3"));
+      expect(_insightOf(americaLatina, InsightCode.trendUp).arguments.first,
+          startsWith("12.3"));
+    });
+
     test('a cotação projetada ganha casas decimais conforme a ordem de '
         'grandeza', () {
-      final insights = const InsightEngine(languageCode: "en").generate(
+      final insights = const InsightEngine(localeName: "en").generate(
           series: cryptoSeries,
           statistics: _statistics(lastPrice: 0.0000017),
           forecast:

--- a/test/util/app_locale_controller_test.dart
+++ b/test/util/app_locale_controller_test.dart
@@ -41,6 +41,16 @@ void main() {
       expect(controller.value, const Locale("en"));
     });
 
+    // A escolha é gravada em caixa baixa; sem isso o app abriria no idioma do
+    // aparelho mesmo com uma variante do espanhol escolhida.
+    test('load reconhece a variante do espanhol gravada', () async {
+      repository.configuration = Configuration(1, languageCode: "es-419");
+
+      await controller.load();
+
+      expect(controller.value, const Locale("es", "419"));
+    });
+
     test('load sem idioma gravado segue o aparelho', () async {
       await controller.load();
 

--- a/test/util/currency_name_test.dart
+++ b/test/util/currency_name_test.dart
@@ -1,5 +1,6 @@
 import 'package:cotacao_direta/enums/currency_enum.dart';
 import 'package:cotacao_direta/util/currency_name.dart';
+import 'package:cotacao_direta/util/localizations.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -11,15 +12,25 @@ void main() {
     });
 
     test('cai no inglês em um idioma sem tradução', () {
-      expect(currencyName(Currencies.BRL, const Locale("es")), "Brazilian Real");
+      expect(currencyName(Currencies.BRL, const Locale("fr")), "Brazilian Real");
     });
 
-    test('toda moeda suportada tem nome nos dois idiomas', () {
+    // O nome da moeda não muda entre as duas normas do espanhol, então as duas
+    // são atendidas pela busca sem região.
+    test('as duas variantes do espanhol têm o mesmo nome', () {
+      expect(currencyName(Currencies.USD, const Locale("es", "ES")),
+          "Dólar estadounidense");
+      expect(currencyName(Currencies.USD, const Locale("es", "419")),
+          "Dólar estadounidense");
+    });
+
+    test('toda moeda suportada tem nome em todos os idiomas', () {
       for (var currency in Currencies.values) {
-        for (var locale in const [Locale("pt"), Locale("en")]) {
+        for (var locale in AppLocales.supported) {
           expect(currencyName(currency, locale), isNotEmpty);
           expect(currencyName(currency, locale), isNot(currencyCode(currency)),
-              reason: "${currency.name} está sem nome em ${locale.languageCode}");
+              reason: "${currency.name} está sem nome em "
+                  "${AppLocales.tagOf(locale)}");
         }
       }
     });

--- a/test/util/localizations_test.dart
+++ b/test/util/localizations_test.dart
@@ -190,24 +190,61 @@ void main() {
       expect(localizations.getConfigBottomNavItemLabel, "Options");
     });
 
-    test('os dois idiomas têm todos os textos preenchidos', () {
-      var portuguese = _allLabels(MyAppLocalizations(const Locale("pt")));
-      var english = _allLabels(MyAppLocalizations(const Locale("en")));
+    test('traduz para o espanhol da Espanha', () {
+      var localizations = MyAppLocalizations(const Locale("es", "ES"));
 
-      expect(portuguese, isNot(contains(null)));
-      expect(english, isNot(contains(null)));
-      expect(portuguese.length, english.length);
+      expect(localizations.conversionPageTitle, "Conversión de divisas");
+      expect(localizations.noDataLabel, "Sin datos");
+      expect(localizations.getConfigBottomNavItemLabel, "Ajustes");
     });
 
-    test('os dois idiomas têm o mesmo número de marcadores nos insights', () {
-      for (var locale in [const Locale("pt"), const Locale("en")]) {
+    test('traduz para o espanhol da América Latina', () {
+      var localizations = MyAppLocalizations(const Locale("es", "419"));
+
+      expect(localizations.conversionPageTitle, "Conversión de monedas");
+      expect(localizations.noDataLabel, "Sin datos");
+      expect(localizations.getConfigBottomNavItemLabel, "Configuración");
+    });
+
+    // As duas normas do espanhol são traduções separadas justamente porque o
+    // vocabulário muda; se as duas tivessem o mesmo texto em toda parte, uma
+    // delas não estaria pagando o que custa.
+    test('as duas normas do espanhol não são a mesma tradução', () {
+      var spain = _allLabels(MyAppLocalizations(const Locale("es", "ES")));
+      var latinAmerica =
+          _allLabels(MyAppLocalizations(const Locale("es", "419")));
+
+      expect(spain, isNot(latinAmerica));
+    });
+
+    test('um idioma do aparelho sem tradução cai no primeiro da build', () {
+      var localizations = MyAppLocalizations(const Locale("fr"));
+
+      expect(localizations.conversionPageTitle, "Currency Conversion");
+    });
+
+    test('todos os idiomas têm todos os textos preenchidos', () {
+      var byLocale = {
+        for (var locale in AppLocales.supported)
+          AppLocales.tagOf(locale): _allLabels(MyAppLocalizations(locale))
+      };
+
+      byLocale.forEach((tag, labels) {
+        expect(labels, isNot(contains(null)), reason: "faltam textos em $tag");
+        expect(labels.length, byLocale.values.first.length, reason: tag);
+      });
+    });
+
+    test('todos os idiomas têm o mesmo número de marcadores nos insights', () {
+      for (var locale in AppLocales.supported) {
         var localizations = MyAppLocalizations(locale);
+        var tag = AppLocales.tagOf(locale);
         _insightPlaceholderCount.forEach((key, expectedCount) {
           var template = _insightTemplate(localizations, key);
 
-          expect(template, isNotNull, reason: "$key em ${locale.languageCode}");
+          expect(template, isNotNull, reason: "$key em $tag");
           expect("%s".allMatches(template!).length, expectedCount,
-              reason: "$key em ${locale.languageCode}");
+              reason: "$key em $tag");
         });
       }
     });
@@ -234,14 +271,28 @@ void main() {
   group('MyAppLocalizationsDelegate', () {
     var delegate = MyAppLocalizationsDelegate();
 
-    test('suporta apenas português e inglês', () {
+    test('suporta apenas os idiomas da build', () {
       expect(delegate.isSupported(const Locale("pt")), isTrue);
       expect(delegate.isSupported(const Locale("en")), isTrue);
-      expect(delegate.isSupported(const Locale("es")), isFalse);
+      expect(delegate.isSupported(const Locale("es")), isTrue);
+      expect(delegate.isSupported(const Locale("fr")), isFalse);
     });
 
-    test('ignora o país ao verificar o suporte', () {
+    test('ignora o país quando ele não separa duas traduções', () {
       expect(delegate.isSupported(const Locale("pt", "BR")), isTrue);
+    });
+
+    test('atende qualquer país de língua espanhola', () {
+      expect(delegate.isSupported(const Locale("es", "MX")), isTrue);
+      expect(delegate.isSupported(const Locale("es", "AR")), isTrue);
+    });
+
+    test('carrega a tradução espanhola da região pedida', () async {
+      var mexico = await delegate.load(const Locale("es", "MX"));
+      var spain = await delegate.load(const Locale("es", "ES"));
+
+      expect(mexico.getConfigBottomNavItemLabel, "Configuración");
+      expect(spain.getConfigBottomNavItemLabel, "Ajustes");
     });
 
     test('carrega as traduções do locale pedido', () async {
@@ -249,6 +300,33 @@ void main() {
 
       expect(localizations.locale, const Locale("pt"));
       expect(localizations.noDataLabel, "Sem Dados");
+    });
+
+    // A resolução do idioma do aparelho é do MaterialApp, e sem o callback do
+    // AppLocales quem está no México abriria o app na tradução da Espanha.
+    testWidgets('um aparelho na América Latina abre no espanhol de lá',
+        (WidgetTester tester) async {
+      tester.platformDispatcher.localesTestValue = const [Locale("es", "MX")];
+      addTearDown(tester.platformDispatcher.clearLocalesTestValue);
+      MyAppLocalizations? found;
+
+      await tester.pumpWidget(MaterialApp(
+        localizationsDelegates: [
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+          MyAppLocalizationsDelegate()
+        ],
+        supportedLocales: AppLocales.supported,
+        localeListResolutionCallback: AppLocales.resolveDeviceLocales,
+        home: Builder(builder: (context) {
+          found = MyAppLocalizations.of(context);
+          return const SizedBox();
+        }),
+      ));
+
+      expect(found!.locale, const Locale("es", "419"));
+      expect(found!.conversionPageTitle, "Conversión de monedas");
     });
 
     test('nunca pede recarga', () {
@@ -281,34 +359,58 @@ void main() {
 
   group('AppLocales', () {
     test('lista os idiomas que existem na build', () {
-      expect(AppLocales.supported,
-          const [Locale("en"), Locale("pt")]);
+      expect(AppLocales.supported, const [
+        Locale("en"),
+        Locale("pt"),
+        Locale("es", "ES"),
+        Locale("es", "419")
+      ]);
     });
 
     // A lista da tela de opções sai daqui: um idioma sem nome apareceria como
-    // um código solto para o usuário.
+    // uma etiqueta solta para o usuário.
     test('todo idioma da build tem um nome para mostrar', () {
       for (var locale in AppLocales.supported) {
-        expect(AppLocales.displayNames[locale.languageCode], isNotNull,
-            reason: "falta o nome de ${locale.languageCode}");
+        var tag = AppLocales.tagOf(locale);
+        expect(AppLocales.displayNames[tag], isNotNull,
+            reason: "falta o nome de $tag");
       }
     });
 
-    test('displayNameOf devolve o próprio código quando não há nome', () {
+    test('tagOf só traz a região quando ela separa duas traduções', () {
+      expect(AppLocales.tagOf(const Locale("pt")), "pt");
+      expect(AppLocales.tagOf(const Locale("es", "419")), "es-419");
+    });
+
+    test('displayNameOf devolve a própria etiqueta quando não há nome', () {
       expect(AppLocales.displayNameOf("pt"), "Português");
+      expect(AppLocales.displayNameOf("es-ES"), "Español (España)");
+      expect(AppLocales.displayNameOf("es-419"), "Español (Latinoamérica)");
       expect(AppLocales.displayNameOf("xx"), "xx");
     });
 
     test('isSupported reconhece só o que está na build', () {
       expect(AppLocales.isSupported("pt"), isTrue);
       expect(AppLocales.isSupported("en"), isTrue);
+      expect(AppLocales.isSupported("es-419"), isTrue);
+      expect(AppLocales.isSupported("es"), isFalse);
       expect(AppLocales.isSupported("fr"), isFalse);
       expect(AppLocales.isSupported(""), isFalse);
       expect(AppLocales.isSupported(null), isFalse);
     });
 
-    test('localeFor converte o código gravado', () {
+    test('localeFor converte a etiqueta gravada', () {
       expect(AppLocales.localeFor("pt"), const Locale("pt"));
+      expect(AppLocales.localeFor("es-ES"), const Locale("es", "ES"));
+      expect(AppLocales.localeFor("es-419"), const Locale("es", "419"));
+    });
+
+    // O banco grava em caixa baixa, e uma etiqueta montada a partir de um
+    // Locale vem com "_" no lugar do "-".
+    test('localeFor não se prende à caixa nem ao separador', () {
+      expect(AppLocales.localeFor("es-es"), const Locale("es", "ES"));
+      expect(AppLocales.localeFor("es_419"), const Locale("es", "419"));
+      expect(AppLocales.localeFor(" PT "), const Locale("pt"));
     });
 
     // Vazio, nulo ou fora da build significam "seguir o aparelho", que é o que
@@ -317,6 +419,59 @@ void main() {
       expect(AppLocales.localeFor(""), isNull);
       expect(AppLocales.localeFor(null), isNull);
       expect(AppLocales.localeFor("fr"), isNull);
+    });
+
+    test('tagFor devolve a forma canônica da etiqueta gravada', () {
+      expect(AppLocales.tagFor("es-es"), "es-ES");
+      expect(AppLocales.tagFor("es_419"), "es-419");
+      expect(AppLocales.tagFor("fr"), "");
+      expect(AppLocales.tagFor(null), "");
+    });
+
+    test('resolve escolhe a tradução do país do aparelho', () {
+      expect(AppLocales.resolve(const Locale("es", "MX")),
+          const Locale("es", "419"));
+      expect(AppLocales.resolve(const Locale("es", "AR")),
+          const Locale("es", "419"));
+      expect(AppLocales.resolve(const Locale("es", "US")),
+          const Locale("es", "419"));
+      expect(AppLocales.resolve(const Locale("es", "ES")),
+          const Locale("es", "ES"));
+    });
+
+    // Sem região não dá para adivinhar o país, e a norma da Espanha é a que o
+    // CLDR pendura em "es".
+    test('resolve manda o espanhol sem região para a Espanha', () {
+      expect(AppLocales.resolve(const Locale("es")), const Locale("es", "ES"));
+      expect(AppLocales.resolve(const Locale("es", "GQ")),
+          const Locale("es", "ES"));
+    });
+
+    test('resolve ignora a região dos idiomas com uma tradução só', () {
+      expect(AppLocales.resolve(const Locale("pt", "BR")), const Locale("pt"));
+      expect(AppLocales.resolve(const Locale("en", "GB")), const Locale("en"));
+    });
+
+    test('resolve devolve nulo para um idioma que não está na build', () {
+      expect(AppLocales.resolve(const Locale("fr")), isNull);
+      expect(AppLocales.resolve(null), isNull);
+    });
+
+    test('resolveDeviceLocales segue a ordem de preferência do aparelho', () {
+      expect(
+          AppLocales.resolveDeviceLocales(
+              const [Locale("fr"), Locale("es", "CO")], AppLocales.supported),
+          const Locale("es", "419"));
+    });
+
+    // O mesmo que o Flutter faz quando nenhum idioma do aparelho corresponde.
+    test('resolveDeviceLocales cai no primeiro idioma da build', () {
+      expect(AppLocales.resolveDeviceLocales(null, AppLocales.supported),
+          const Locale("en"));
+      expect(
+          AppLocales.resolveDeviceLocales(
+              const [Locale("fr")], AppLocales.supported),
+          const Locale("en"));
     });
   });
 }

--- a/test/view/configurations_page_test.dart
+++ b/test/view/configurations_page_test.dart
@@ -175,10 +175,23 @@ void main() {
 
       expect(find.text("Idioma do sistema"), findsWidgets);
       for (var locale in AppLocales.supported) {
-        expect(find.text(AppLocales.displayNameOf(locale.languageCode)),
+        expect(
+            find.text(AppLocales.displayNameOf(AppLocales.tagOf(locale))),
             findsWidgets,
             reason: "todo idioma da build aparece na lista");
       }
+    });
+
+    // As duas variantes do espanhol aparecem como duas escolhas, cada uma com
+    // o nome da sua região: uma "Español" sozinha não diria qual é qual.
+    testWidgets('separa as duas variantes do espanhol',
+        (WidgetTester tester) async {
+      await pumpPage(tester);
+      await tester.tap(languageDropdown);
+      await tester.pumpAndSettle();
+
+      expect(find.text("Español (España)"), findsWidgets);
+      expect(find.text("Español (Latinoamérica)"), findsWidgets);
     });
 
     testWidgets('abre no idioma do aparelho quando nada foi escolhido',
@@ -206,6 +219,29 @@ void main() {
       expect(bloc.languageCode, "en");
       expect(repository.configuration.languageCode, "en");
       expect(localeController.value, const Locale("en"));
+    });
+
+    testWidgets('escolher uma variante do espanhol grava a região',
+        (WidgetTester tester) async {
+      await pumpPage(tester);
+
+      await chooseLanguage(tester, "Español (Latinoamérica)");
+
+      expect(AppLocales.tagFor(repository.configuration.languageCode),
+          "es-419");
+      expect(localeController.value, const Locale("es", "419"));
+    });
+
+    // O que está gravado vem em caixa baixa; sem a forma canônica de volta, o
+    // seletor ficaria com um valor sem item correspondente.
+    testWidgets('mostra a variante do espanhol que está gravada',
+        (WidgetTester tester) async {
+      repository.configuration = Configuration(1, languageCode: "es-ES");
+
+      await pumpPage(tester);
+
+      expect(tester.widget<DropdownButton<String>>(languageDropdown).value,
+          "es-ES");
     });
 
     testWidgets('voltar para o idioma do sistema apaga a escolha',


### PR DESCRIPTION
O app falava português e inglês. Agora fala espanhol também, e não em uma tradução só: o vocabulário muda o bastante entre as duas normas — "ajustes" e "móvil" de um lado, "configuración" e "celular" do outro — para caber em dois textos, `es-ES` e `es-419`, o código que o CLDR usa para a região.

## O que muda

**Um idioma passa a ser uma etiqueta, não um código.** `AppLocales.supported` ganha `Locale("es", "ES")` e `Locale("es", "419")`, e a chave do mapa de textos, dos nomes do seletor e do valor gravado passa a ser a etiqueta inteira (`AppLocales.tagOf`). Os 126 getters de `MyAppLocalizations`, que refaziam a busca no mapa a cada leitura, passam a ler de um mapa resolvido na construção.

**Quem não fixa idioma nenhum é atendido pela região do aparelho.** A resolução padrão do Flutter, sem país correspondente, daria a primeira variante de espanhol da lista para todo mundo — a da Espanha também para quem está no México. `AppLocales.resolve`, ligado ao `localeListResolutionCallback` do `MaterialApp`, decide pela região: sem região, ou em um país que segue a norma europeia (ES, GQ, PH), vale a tradução da Espanha; o resto fica com a latino-americana.

**A região também muda a formatação dos números.** A América Latina separa os decimais com ponto (`12.3%`), a Espanha com vírgula (`12,3 %`) — e o `intl` tem os dados das duas. Por isso a tela de IA passa o locale inteiro ao `InsightEngine`, cujo parâmetro deixa de se chamar `languageCode` e passa a ser `localeName`, que é o que ele sempre foi para o `intl`.

**Sem migração nova.** A escolha continua na coluna `languageCode`, normalizada em caixa baixa na gravação; `AppLocales.tagFor` remonta a forma canônica na leitura, sem se prender à caixa nem ao separador (`es_419` e `es-es` também são lidos).

Os nomes das moedas ganharam o espanhol em `currency_name.dart`, com uma entrada só para as duas normas: o nome de uma moeda não muda entre elas.

## Testes

`flutter analyze` sem apontamentos e 553 testes passando (eram 540). Os novos cobrem: as quatro traduções com todos os textos preenchidos e o mesmo número de marcadores nos insights; as duas normas do espanhol não sendo o mesmo texto; `resolve` escolhendo pela região (MX, AR, US → 419; sem região e GQ → ES); um aparelho na América Latina abrindo na tradução de lá, pelo `MaterialApp` montado como o do app; o seletor mostrando as duas variantes e gravando a região; e a diferença do separador decimal entre `es_ES` e `es_419`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjDr2TL1YtLRAm24X28PAx)_