### PR TITLE
Mostra o gráfico dos últimos 7 dias na tela de conversão

### DIFF
--- a/lib/blocs/conversion_page_bloc.dart
+++ b/lib/blocs/conversion_page_bloc.dart
@@ -2,6 +2,10 @@ import 'dart:async';
 
 import 'package:cotacao_direta/blocs/base_bloc.dart';
 import 'package:cotacao_direta/enums/currency_enum.dart';
+import 'package:cotacao_direta/model/currency.dart';
+import 'package:cotacao_direta/repository/currency_repository.dart';
+import 'package:cotacao_direta/util/string_utils.dart';
+import 'package:intl/intl.dart';
 
 import 'exchange_value_bloc.dart';
 
@@ -56,8 +60,64 @@ class ConversionResult {
   bool get isLoading => status == ConversionStatus.loading;
 }
 
+/// Em que pé está o histórico do par mostrado no gráfico.
+enum ConversionHistoryStatus {
+  /// Buscando as séries das duas moedas.
+  loading,
+
+  /// Há pontos suficientes para desenhar a linha.
+  ready,
+
+  /// Faltou histórico de alguma das moedas, ou vieram pontos de menos para
+  /// uma linha dizer alguma coisa.
+  unavailable,
+}
+
+/// A cotação do par em um dia: quantas unidades da moeda de destino valia uma
+/// unidade da de origem, a mesma taxa que a tela mostra em "1 BRL = 0,20 USD".
+class ConversionRatePoint {
+  final DateTime date;
+  final double rate;
+
+  const ConversionRatePoint({required this.date, required this.rate});
+}
+
+/// O histórico do par junto do par a que ele pertence, pelo mesmo motivo de
+/// [ConversionResult]: uma linha desenhada com as moedas erradas ao lado seria
+/// uma informação falsa, e é o que aconteceria se os pontos chegassem à tela
+/// separados das moedas.
+class ConversionHistory {
+  final ConversionHistoryStatus status;
+  final Currencies from;
+  final Currencies to;
+
+  /// Um ponto por dia com cotação, do mais antigo para o mais recente.
+  final List<ConversionRatePoint> points;
+
+  const ConversionHistory({
+    required this.status,
+    required this.from,
+    required this.to,
+    this.points = const [],
+  });
+
+  bool get isLoading => status == ConversionHistoryStatus.loading;
+
+  bool get hasPoints => points.isNotEmpty;
+}
+
 class ConversionPageBloc extends BaseBloc {
   static const initialAmount = 1.0;
+
+  /// Dias de histórico que o gráfico da tela mostra. É um período fixo: aqui o
+  /// gráfico é um apoio à conversão — para onde a cotação vinha andando na
+  /// última semana —, e não a tela de histórico, que é onde se escolhe o
+  /// intervalo.
+  static const historyWindowInDays = 7;
+
+  /// Menos que isto não é uma linha, é um ponto: a tela mostra o mesmo aviso
+  /// de quando não veio histórico nenhum.
+  static const _minimumHistoryPoints = 2;
 
   /// O par que a tela abre escolhido quando quem a abriu não pediu outro.
   static const defaultFromCurrency = Currencies.BRL;
@@ -71,8 +131,17 @@ class ConversionPageBloc extends BaseBloc {
   final _currencyToController = StreamController<Currencies>.broadcast();
   final _conversionResultController =
       StreamController<ConversionResult>.broadcast();
+  final _conversionHistoryController =
+      StreamController<ConversionHistory>.broadcast();
 
   final ExchangeValueBloc _exchangeValueBloc;
+
+  /// De onde saem as séries do gráfico. É o mesmo repositório que a tela de
+  /// histórico usa, então o que já foi baixado por lá serve aqui.
+  final CurrencyRepository _currencyRepository;
+
+  final _enumValueAsStringUtil = EnumValueAsString();
+  final _apiDateFormatter = DateFormat("yyyy-MM-dd");
 
   /// Só descarta o bloc de cotações se foi ele quem o criou: um bloc recebido
   /// de fora pertence a quem o passou.
@@ -90,11 +159,13 @@ class ConversionPageBloc extends BaseBloc {
   /// mostrava. Sem eles vale o par padrão (real para dólar).
   ConversionPageBloc({
     ExchangeValueBloc? exchangeValueBloc,
+    CurrencyRepository? currencyRepository,
     Currencies? initialFromCurrency,
     Currencies? initialToCurrency,
     List<Currencies> priorityCurrencies = const [],
   })  : _exchangeValueBloc = exchangeValueBloc ?? ExchangeValueBloc(),
         _ownsExchangeValueBloc = exchangeValueBloc == null,
+        _currencyRepository = currencyRepository ?? CurrencyRepository(),
         priorityCurrencies = List.unmodifiable(priorityCurrencies),
         _fromCurrency = initialFromCurrency ?? defaultFromCurrency,
         _toCurrency = _resolveToCurrency(
@@ -102,6 +173,10 @@ class ConversionPageBloc extends BaseBloc {
     _result = ConversionResult(
         status: ConversionStatus.loading,
         amount: _amount,
+        from: _fromCurrency,
+        to: _toCurrency);
+    _history = ConversionHistory(
+        status: ConversionHistoryStatus.loading,
         from: _fromCurrency,
         to: _toCurrency);
   }
@@ -121,11 +196,15 @@ class ConversionPageBloc extends BaseBloc {
   Currencies _toCurrency;
 
   late ConversionResult _result;
+  late ConversionHistory _history;
 
   /// Cada conversão leva um número de ordem para que a resposta de uma
   /// conversão antiga — a busca das cotações é assíncrona — não sobrescreva o
   /// resultado de uma conversão pedida depois dela.
   var _lastRequestId = 0;
+
+  /// O mesmo, para a busca do histórico, que é independente da conversão.
+  var _lastHistoryRequestId = 0;
 
   var _disposed = false;
 
@@ -147,6 +226,12 @@ class ConversionPageBloc extends BaseBloc {
   Sink<ConversionResult> get conversionResultSink =>
       _conversionResultController.sink;
 
+  Stream<ConversionHistory> get conversionHistoryStream =>
+      _conversionHistoryController.stream;
+
+  Sink<ConversionHistory> get conversionHistorySink =>
+      _conversionHistoryController.sink;
+
   /// Estado atual, para a tela desenhar o primeiro quadro sem esperar a
   /// primeira emissão das streams.
   double get amount => _amount;
@@ -156,6 +241,8 @@ class ConversionPageBloc extends BaseBloc {
   Currencies get toCurrency => _toCurrency;
 
   ConversionResult get result => _result;
+
+  ConversionHistory get history => _history;
 
   /// Quantidade a converter. Um texto vazio ou inválido na tela vira zero, que
   /// converte para zero em vez de deixar o resultado anterior no lugar.
@@ -173,6 +260,7 @@ class ConversionPageBloc extends BaseBloc {
     _fromCurrency = value;
     _currencyFromController.add(value);
     updateResult();
+    loadHistory();
   }
 
   void updateToCurrency(Currencies value) {
@@ -180,6 +268,7 @@ class ConversionPageBloc extends BaseBloc {
     _toCurrency = value;
     _currencyToController.add(value);
     updateResult();
+    loadHistory();
   }
 
   void switchCurrencies() {
@@ -189,6 +278,7 @@ class ConversionPageBloc extends BaseBloc {
     _currencyFromController.add(_fromCurrency);
     _currencyToController.add(_toCurrency);
     updateResult();
+    loadHistory();
   }
 
   Future<void> updateResult() async {
@@ -210,6 +300,114 @@ class ConversionPageBloc extends BaseBloc {
       unitRate: rate,
       convertedAmount: rate == null ? null : amount * rate,
     ));
+  }
+
+  /// Busca os últimos [historyWindowInDays] dias de cotação do par para o
+  /// gráfico.
+  ///
+  /// A API cota cada moeda frente à contrapartida, e não uma moeda frente à
+  /// outra, então a série do par é montada aqui: a razão entre as duas séries,
+  /// dia a dia, é a mesma conta que [_unitRate] faz com a cotação do momento.
+  Future<void> loadHistory() async {
+    var requestId = ++_lastHistoryRequestId;
+    var from = _fromCurrency;
+    var to = _toCurrency;
+    _emitHistory(ConversionHistory(
+        status: ConversionHistoryStatus.loading,
+        from: from,
+        to: to,
+        // O gráfico anterior continua na tela enquanto o novo não chega, desde
+        // que seja do mesmo par; trocar de moeda apaga a linha antiga, que é
+        // de outra cotação.
+        points: _history.from == from && _history.to == to
+            ? _history.points
+            : const []));
+
+    List<ConversionRatePoint> points;
+    try {
+      points = await _pairHistory(from, to);
+    } catch (exception) {
+      // Sem rede e sem nada salvo a busca falha; para a tela é o mesmo que não
+      // ter histórico.
+      points = const [];
+    }
+
+    if (_disposed || requestId != _lastHistoryRequestId) return;
+    var enoughPoints = points.length >= _minimumHistoryPoints;
+    _emitHistory(ConversionHistory(
+      status: enoughPoints
+          ? ConversionHistoryStatus.ready
+          : ConversionHistoryStatus.unavailable,
+      from: from,
+      to: to,
+      // Um ponto solto não é uma linha: a tela mostra o mesmo aviso de quando
+      // não veio nada, em vez de um gráfico com um ponto só.
+      points: enoughPoints ? points : const [],
+    ));
+  }
+
+  Future<List<ConversionRatePoint>> _pairHistory(
+      Currencies from, Currencies to) async {
+    if (from == to) return const [];
+    var counterCurrency = await _currencyRepository.resolveCounterCurrency();
+    var today = DateTime.now();
+    var initialDate = _apiDateFormatter
+        .format(today.subtract(const Duration(days: historyWindowInDays - 1)));
+    var finalDate = _apiDateFormatter.format(today);
+
+    var fromSeries =
+        await _dailyValues(from, counterCurrency, initialDate, finalDate);
+    var toSeries =
+        await _dailyValues(to, counterCurrency, initialDate, finalDate);
+
+    // Só os dias em que as duas moedas têm cotação: inventar o valor que falta
+    // desenharia uma variação que não houve. Uma série nula é a da própria
+    // contrapartida, que vale uma unidade dela mesma todo dia e por isso não
+    // tira nenhum dia da conta.
+    var days = <DateTime>{...?fromSeries?.keys, ...?toSeries?.keys}
+        .where((day) =>
+            (fromSeries?.containsKey(day) ?? true) &&
+            (toSeries?.containsKey(day) ?? true))
+        .toList()
+      ..sort();
+
+    return days
+        .map((day) => ConversionRatePoint(
+            date: day, rate: (toSeries?[day] ?? 1) / (fromSeries?[day] ?? 1)))
+        .toList();
+  }
+
+  /// A cotação da moeda em cada dia do período, ou nulo quando ela é a própria
+  /// contrapartida — que não tem série (ver
+  /// [CurrencyRepository.getCurrencyHistoricalData]) porque vale sempre uma
+  /// unidade.
+  Future<Map<DateTime, double>?> _dailyValues(Currencies currency,
+      String counterCurrency, String initialDate, String finalDate) async {
+    var currencyCode =
+        _enumValueAsStringUtil.getEnumValue(currency.toString());
+    if (currencyCode == counterCurrency) return null;
+
+    var history = await _currencyRepository
+        .getCurrencyHistoricalData([currencyCode], initialDate, finalDate);
+    var valueByDay = <DateTime, double>{};
+    for (var quote in history) {
+      var day = _dayOf(quote);
+      var value = quote.value;
+      if (day == null || value == null || value <= 0) continue;
+      // Mais de uma cotação no mesmo dia: fica a mais recente, que é a última
+      // da lista devolvida pelo repositório (ordenada por data).
+      valueByDay[day] = value;
+    }
+    return valueByDay;
+  }
+
+  /// O dia da cotação, sem a hora: as duas séries precisam casar por dia, e
+  /// cada uma vem com o horário do seu fechamento.
+  DateTime? _dayOf(Currency quote) {
+    var historicalDate = quote.historicalDate;
+    if (historicalDate == null) return null;
+    var date = DateTime.tryParse(historicalDate);
+    return date == null ? null : DateTime(date.year, date.month, date.day);
   }
 
   /// Quantas unidades de [to] valem uma unidade de [from], ou nulo quando
@@ -254,6 +452,11 @@ class ConversionPageBloc extends BaseBloc {
     _conversionResultController.add(result);
   }
 
+  void _emitHistory(ConversionHistory history) {
+    _history = history;
+    _conversionHistoryController.add(history);
+  }
+
   @override
   void dispose() {
     _disposed = true;
@@ -261,6 +464,7 @@ class ConversionPageBloc extends BaseBloc {
     _currencyFromController.close();
     _currencyToController.close();
     _conversionResultController.close();
+    _conversionHistoryController.close();
     if (_ownsExchangeValueBloc) _exchangeValueBloc.dispose();
   }
 }

--- a/lib/util/localizations.dart
+++ b/lib/util/localizations.dart
@@ -167,6 +167,8 @@ class MyAppLocalizations {
       'conversionRateUnavailableLabel': 'Exchange rate unavailable',
       'conversionCopyResultTooltip': 'Copy result',
       'conversionResultCopiedLabel': 'Result copied',
+      'conversionHistorySectionLabel': 'Last %s days',
+      'conversionHistoryUnavailableLabel': 'No history for this period',
       'mainCurrenciesBottomNavItemLabel': 'Currencies',
       'currencyHistoryBottomNavItemLabel': 'History',
       'configBottomNavItemLabel': 'Options',
@@ -325,6 +327,8 @@ class MyAppLocalizations {
       'conversionRateUnavailableLabel': 'Cotação indisponível',
       'conversionCopyResultTooltip': 'Copiar o resultado',
       'conversionResultCopiedLabel': 'Resultado copiado',
+      'conversionHistorySectionLabel': 'Últimos %s dias',
+      'conversionHistoryUnavailableLabel': 'Sem histórico para o período',
       'mainCurrenciesBottomNavItemLabel': 'Moedas',
       'currencyHistoryBottomNavItemLabel': 'Histórico',
       'configBottomNavItemLabel': 'Opções',
@@ -487,6 +491,8 @@ class MyAppLocalizations {
       'conversionRateUnavailableLabel': 'Cotización no disponible',
       'conversionCopyResultTooltip': 'Copiar el resultado',
       'conversionResultCopiedLabel': 'Resultado copiado',
+      'conversionHistorySectionLabel': 'Últimos %s días',
+      'conversionHistoryUnavailableLabel': 'Sin historial para el periodo',
       'mainCurrenciesBottomNavItemLabel': 'Divisas',
       'currencyHistoryBottomNavItemLabel': 'Histórico',
       'configBottomNavItemLabel': 'Ajustes',
@@ -653,6 +659,8 @@ class MyAppLocalizations {
       'conversionRateUnavailableLabel': 'Cotización no disponible',
       'conversionCopyResultTooltip': 'Copiar el resultado',
       'conversionResultCopiedLabel': 'Resultado copiado',
+      'conversionHistorySectionLabel': 'Últimos %s días',
+      'conversionHistoryUnavailableLabel': 'Sin historial para el período',
       'mainCurrenciesBottomNavItemLabel': 'Monedas',
       'currencyHistoryBottomNavItemLabel': 'Historial',
       'configBottomNavItemLabel': 'Configuración',
@@ -883,6 +891,16 @@ class MyAppLocalizations {
 
   String? get conversionResultCopiedLabel {
     return _values['conversionResultCopiedLabel'];
+  }
+
+  /// Título do gráfico da tela de conversão. Traz o marcador do número de dias
+  /// mostrados, que é fixo na tela mas mora no bloc.
+  String? get conversionHistorySectionLabel {
+    return _values['conversionHistorySectionLabel'];
+  }
+
+  String? get conversionHistoryUnavailableLabel {
+    return _values['conversionHistoryUnavailableLabel'];
   }
 
   String? get mainCurrenciesBottomNavItemLabel {

--- a/lib/view/widgets/charts.dart
+++ b/lib/view/widgets/charts.dart
@@ -4,23 +4,35 @@ import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
-/// Gráfico de linha simples com o histórico de valores de uma moeda ao longo
-/// do tempo, uma [Currency] por dia.
+/// Um ponto do gráfico: o valor de um dia.
+typedef ChartPoint = ({DateTime date, double value});
+
+/// Gráfico de linha simples com o histórico de valores de uma série ao longo
+/// do tempo, um ponto por dia.
 class SimpleLineChart extends StatelessWidget {
-  final List<Currency> currencyList;
+  final List<ChartPoint> points;
 
-  SimpleLineChart({required this.currencyList});
+  /// A partir do histórico de uma moeda, uma [Currency] por dia.
+  SimpleLineChart({required List<Currency> currencyList})
+      : points = currencyList
+            .map((currency) => (
+                  date: DateTime.parse(currency.historicalDate!),
+                  value: currency.value ?? 0
+                ))
+            .toList();
 
-  final DateFormat _axisDateFormatter = DateFormat("dd/MM");
+  /// A partir de uma série montada por quem chama — a cotação de um par de
+  /// moedas, por exemplo, que não é o valor de uma [Currency] só.
+  const SimpleLineChart.fromPoints({required this.points});
+
+  static final DateFormat _axisDateFormatter = DateFormat("dd/MM");
 
   @override
   Widget build(BuildContext context) {
-    final dates = currencyList
-        .map((currency) => DateTime.parse(currency.historicalDate!))
-        .toList();
+    final dates = points.map((point) => point.date).toList();
     final spots = List.generate(
-      currencyList.length,
-      (index) => FlSpot(index.toDouble(), currencyList[index].value ?? 0),
+      points.length,
+      (index) => FlSpot(index.toDouble(), points[index].value),
     );
     final color = Theme.of(context).colorScheme.primary;
 

--- a/lib/view/widgets/conversion_widget.dart
+++ b/lib/view/widgets/conversion_widget.dart
@@ -7,10 +7,12 @@ import 'package:cotacao_direta/util/currency_name.dart';
 import 'package:cotacao_direta/util/localizations.dart';
 import 'package:cotacao_direta/util/quote_format.dart';
 import 'package:cotacao_direta/util/responsive.dart';
+import 'package:cotacao_direta/view/widgets/charts.dart';
 import 'package:cotacao_direta/view/widgets/currency_picker_sheet.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:intl/intl.dart';
+import 'package:sprintf/sprintf.dart';
 
 /// A tela de conversão: uma quantidade na moeda de origem em cima, o valor
 /// convertido embaixo e a cotação usada logo abaixo dos dois.
@@ -52,8 +54,11 @@ class ConversionWidgetState extends State<ConversionWidget> {
     _initializedBloc = bloc;
     _amountController.text = _formatAmount(bloc.amount);
     // A tela já abre com uma conversão pronta em vez de um campo de resultado
-    // vazio esperando a primeira interação.
-    WidgetsBinding.instance.addPostFrameCallback((_) => bloc.updateResult());
+    // vazio esperando a primeira interação, e com o gráfico do par a caminho.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      bloc.updateResult();
+      bloc.loadHistory();
+    });
   }
 
   @override
@@ -165,6 +170,8 @@ class ConversionWidgetState extends State<ConversionWidget> {
                 _destinationCard(localizations, scale),
                 SizedBox(height: 16 * scale),
                 _rateCard(localizations, scale),
+                SizedBox(height: 16 * scale),
+                _historyCard(localizations, scale),
                 SizedBox(height: 24 * scale),
                 _explanation(localizations, scale),
               ],
@@ -388,6 +395,104 @@ class ConversionWidgetState extends State<ConversionWidget> {
           ),
         );
       },
+    );
+  }
+
+  /// O mesmo gráfico da tela de histórico, aqui com o período fixo na última
+  /// semana: mostra para onde a cotação do par vinha andando, que é o que
+  /// falta à conversão de hoje para se decidir entre converter agora ou
+  /// esperar.
+  Widget _historyCard(MyAppLocalizations localizations, double scale) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return StreamBuilder<ConversionHistory>(
+      initialData: bloc.history,
+      stream: bloc.conversionHistoryStream,
+      builder: (context, snapshot) {
+        var history = snapshot.data!;
+
+        return Card(
+          margin: EdgeInsets.zero,
+          color: colorScheme.surfaceContainerHighest,
+          elevation: 0,
+          child: Padding(
+            padding: EdgeInsets.all(16 * scale),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Row(
+                  children: <Widget>[
+                    Icon(Icons.query_stats,
+                        size: 18 * scale, color: colorScheme.primary),
+                    SizedBox(width: 8 * scale),
+                    Expanded(
+                      child: Text(
+                        sprintf(localizations.conversionHistorySectionLabel!,
+                            [ConversionPageBloc.historyWindowInDays]),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          fontSize: 15 * scale,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                    ),
+                    Text(
+                      "1 ${currencyCode(history.from)} → ${currencyCode(history.to)}",
+                      style: TextStyle(
+                        fontSize: 12 * scale,
+                        color: colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ],
+                ),
+                SizedBox(height: 12 * scale),
+                SizedBox(
+                  height: 160 * scale,
+                  // O gráfico do par anterior fica esmaecido enquanto o novo
+                  // não chega, do mesmo jeito que o valor convertido.
+                  child: AnimatedOpacity(
+                    opacity: history.isLoading && history.hasPoints ? 0.4 : 1,
+                    duration: const Duration(milliseconds: 200),
+                    child: _historyChart(history, localizations, scale),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _historyChart(ConversionHistory history,
+      MyAppLocalizations localizations, double scale) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    if (history.hasPoints) {
+      return Padding(
+        // Uma folga para a linha e o último rótulo do eixo não encostarem na
+        // borda do cartão.
+        padding: EdgeInsets.only(right: 8 * scale, top: 4 * scale),
+        child: SimpleLineChart.fromPoints(
+          points: history.points
+              .map((point) => (date: point.date, value: point.rate))
+              .toList(),
+        ),
+      );
+    }
+    if (history.isLoading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    return Center(
+      child: Text(
+        localizations.conversionHistoryUnavailableLabel!,
+        textAlign: TextAlign.center,
+        style: TextStyle(
+          fontSize: 14 * scale,
+          color: colorScheme.onSurfaceVariant,
+        ),
+      ),
     );
   }
 

--- a/test/blocs/conversion_page_bloc_test.dart
+++ b/test/blocs/conversion_page_bloc_test.dart
@@ -3,7 +3,11 @@ import 'dart:async';
 import 'package:cotacao_direta/blocs/conversion_page_bloc.dart';
 import 'package:cotacao_direta/blocs/exchange_value_bloc.dart';
 import 'package:cotacao_direta/enums/currency_enum.dart';
+import 'package:cotacao_direta/model/currency.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/intl.dart';
+
+import '../helpers/fakes.dart';
 
 /// Cotações fixas por moeda, no lugar da busca real (rede e banco).
 ///
@@ -33,8 +37,22 @@ class _FakeExchangeValueBloc extends ExchangeValueBloc {
   }
 }
 
+/// Uma cotação de um dia, na convenção do CurrencyRepository.
+Currency _quote(String currencyCode, DateTime date, double value) => Currency(
+    id: currencyCode,
+    value: value,
+    historicalDate: date.toIso8601String(),
+    counterCurrency: "BRL");
+
+DateTime _daysAgo(int days) {
+  var today = DateTime.now();
+  return DateTime(today.year, today.month, today.day)
+      .subtract(Duration(days: days));
+}
+
 void main() {
   late _FakeExchangeValueBloc exchangeValueBloc;
+  late FakeCurrencyRepository currencyRepository;
   late ConversionPageBloc bloc;
 
   setUp(() {
@@ -44,7 +62,10 @@ void main() {
       Currencies.EUR: 0.1,
       Currencies.JPY: null,
     });
-    bloc = ConversionPageBloc(exchangeValueBloc: exchangeValueBloc);
+    currencyRepository = FakeCurrencyRepository();
+    bloc = ConversionPageBloc(
+        exchangeValueBloc: exchangeValueBloc,
+        currencyRepository: currencyRepository);
   });
 
   tearDown(() => bloc.dispose());
@@ -166,7 +187,8 @@ void main() {
 
     test('descartar fecha as streams', () async {
       var bloc = ConversionPageBloc(
-          exchangeValueBloc: _FakeExchangeValueBloc({Currencies.BRL: 1}));
+          exchangeValueBloc: _FakeExchangeValueBloc({Currencies.BRL: 1}),
+          currencyRepository: currencyRepository);
 
       bloc.dispose();
 
@@ -175,11 +197,14 @@ void main() {
       expect(() => bloc.currencyToSink.add(Currencies.USD), throwsStateError);
       expect(
           () => bloc.conversionResultSink.add(bloc.result), throwsStateError);
+      expect(() => bloc.conversionHistorySink.add(bloc.history),
+          throwsStateError);
     });
 
     test('abre no par pedido por quem chamou a tela', () async {
       var bloc = ConversionPageBloc(
           exchangeValueBloc: exchangeValueBloc,
+          currencyRepository: currencyRepository,
           initialFromCurrency: Currencies.USD,
           initialToCurrency: Currencies.EUR);
       addTearDown(bloc.dispose);
@@ -194,6 +219,7 @@ void main() {
     test('só a origem pedida deixa o destino no padrão', () async {
       var bloc = ConversionPageBloc(
           exchangeValueBloc: exchangeValueBloc,
+          currencyRepository: currencyRepository,
           initialFromCurrency: Currencies.EUR);
       addTearDown(bloc.dispose);
 
@@ -206,6 +232,7 @@ void main() {
       // pede real para real.
       var bloc = ConversionPageBloc(
           exchangeValueBloc: exchangeValueBloc,
+          currencyRepository: currencyRepository,
           initialFromCurrency: Currencies.BRL,
           initialToCurrency: Currencies.BRL);
       addTearDown(bloc.dispose);
@@ -215,6 +242,7 @@ void main() {
 
       var dollarBloc = ConversionPageBloc(
           exchangeValueBloc: exchangeValueBloc,
+          currencyRepository: currencyRepository,
           initialFromCurrency: Currencies.USD,
           initialToCurrency: Currencies.USD);
       addTearDown(dollarBloc.dispose);
@@ -227,6 +255,7 @@ void main() {
     test('converte o par pedido sem esperar nenhuma escolha', () async {
       var bloc = ConversionPageBloc(
           exchangeValueBloc: exchangeValueBloc,
+          currencyRepository: currencyRepository,
           initialFromCurrency: Currencies.USD,
           initialToCurrency: Currencies.BRL);
       addTearDown(bloc.dispose);
@@ -240,6 +269,7 @@ void main() {
     test('guarda as moedas em destaque para o seletor', () async {
       var bloc = ConversionPageBloc(
           exchangeValueBloc: exchangeValueBloc,
+          currencyRepository: currencyRepository,
           priorityCurrencies: [Currencies.EUR, Currencies.JPY]);
       addTearDown(bloc.dispose);
 
@@ -265,6 +295,217 @@ void main() {
 
       // Emitir numa stream fechada lançaria, e o erro chegaria aqui.
       await conversion;
+    });
+  });
+
+  group('ConversionPageBloc: histórico do par', () {
+    final apiDateFormatter = DateFormat("yyyy-MM-dd");
+
+    ConversionPageBloc buildBloc(
+        {Currencies? initialFromCurrency, Currencies? initialToCurrency}) {
+      var bloc = ConversionPageBloc(
+          exchangeValueBloc: exchangeValueBloc,
+          currencyRepository: currencyRepository,
+          initialFromCurrency: initialFromCurrency,
+          initialToCurrency: initialToCurrency);
+      addTearDown(bloc.dispose);
+      return bloc;
+    }
+
+    test('a série do par é a razão entre as séries das duas moedas', () async {
+      // A API cota cada moeda frente ao real; a cotação de euro em dólar não
+      // vem pronta de lugar nenhum.
+      currencyRepository.historicalDataByCode["EUR"] = [
+        _quote("EUR", _daysAgo(2), 0.1),
+        _quote("EUR", _daysAgo(1), 0.1),
+      ];
+      currencyRepository.historicalDataByCode["USD"] = [
+        _quote("USD", _daysAgo(2), 0.2),
+        _quote("USD", _daysAgo(1), 0.25),
+      ];
+      var bloc = buildBloc(
+          initialFromCurrency: Currencies.EUR,
+          initialToCurrency: Currencies.USD);
+
+      await bloc.loadHistory();
+
+      expect(bloc.history.status, ConversionHistoryStatus.ready);
+      expect(bloc.history.from, Currencies.EUR);
+      expect(bloc.history.to, Currencies.USD);
+      expect(bloc.history.points.map((point) => point.rate),
+          [closeTo(2, 0.000001), closeTo(2.5, 0.000001)],
+          reason: "um euro valia dois dólares e passou a valer dois e meio");
+      expect(bloc.history.points.first.date.isBefore(bloc.history.points.last.date),
+          isTrue,
+          reason: "o gráfico é desenhado do dia mais antigo para o mais novo");
+    });
+
+    test('a contrapartida das cotações vale uma unidade todo dia', () async {
+      // BRL é a contrapartida: ela não tem série própria (o repositório pula a
+      // consulta), e sem tratamento o gráfico do par mais comum ficaria vazio.
+      currencyRepository.historicalDataByCode["USD"] = [
+        _quote("USD", _daysAgo(2), 0.2),
+        _quote("USD", _daysAgo(1), 0.25),
+      ];
+      var bloc = buildBloc(
+          initialFromCurrency: Currencies.BRL,
+          initialToCurrency: Currencies.USD);
+
+      await bloc.loadHistory();
+
+      expect(bloc.history.points.map((point) => point.rate),
+          [closeTo(0.2, 0.000001), closeTo(0.25, 0.000001)]);
+      expect(currencyRepository.historicalDataCalls.map((call) => call.first),
+          [["USD"]],
+          reason: "não há o que pedir para a moeda da contrapartida");
+    });
+
+    test('o período pedido é a última semana', () async {
+      var bloc = buildBloc();
+
+      await bloc.loadHistory();
+
+      var today = DateTime.now();
+      expect(ConversionPageBloc.historyWindowInDays, 7);
+      expect(currencyRepository.historicalDataCalls.single.sublist(1), [
+        apiDateFormatter.format(today.subtract(const Duration(days: 6))),
+        apiDateFormatter.format(today)
+      ]);
+    });
+
+    test('só os dias com cotação das duas moedas entram no gráfico', () async {
+      // Feriado em um dos mercados: completar o dia que falta desenharia uma
+      // variação que não houve.
+      currencyRepository.historicalDataByCode["EUR"] = [
+        _quote("EUR", _daysAgo(2), 0.1),
+        _quote("EUR", _daysAgo(1), 0.1),
+      ];
+      currencyRepository.historicalDataByCode["USD"] = [
+        _quote("USD", _daysAgo(3), 0.2),
+        _quote("USD", _daysAgo(2), 0.2),
+        _quote("USD", _daysAgo(1), 0.25),
+      ];
+      var bloc = buildBloc(
+          initialFromCurrency: Currencies.EUR,
+          initialToCurrency: Currencies.USD);
+
+      await bloc.loadHistory();
+
+      expect(bloc.history.points.length, 2);
+      expect(bloc.history.points.first.date, _daysAgo(2));
+    });
+
+    test('cotações do mesmo dia não viram dois pontos', () async {
+      currencyRepository.historicalDataByCode["USD"] = [
+        _quote("USD", _daysAgo(2), 0.2),
+        _quote("USD", _daysAgo(1).add(const Duration(hours: 10)), 0.24),
+        _quote("USD", _daysAgo(1).add(const Duration(hours: 17)), 0.25),
+      ];
+      var bloc = buildBloc();
+
+      await bloc.loadHistory();
+
+      expect(bloc.history.points.length, 2);
+      expect(bloc.history.points.last.rate, closeTo(0.25, 0.000001),
+          reason: "vale a cotação mais recente do dia");
+    });
+
+    test('um ponto só não vira gráfico', () async {
+      currencyRepository.historicalDataByCode["USD"] = [
+        _quote("USD", _daysAgo(1), 0.2),
+      ];
+      var bloc = buildBloc();
+
+      await bloc.loadHistory();
+
+      expect(bloc.history.status, ConversionHistoryStatus.unavailable);
+      expect(bloc.history.points, isEmpty);
+    });
+
+    test('a busca que falha deixa a tela sem histórico', () async {
+      // Sem rede e sem nada salvo; para a tela é o mesmo que não ter histórico.
+      currencyRepository.failure = Exception("sem rede");
+      var bloc = buildBloc();
+
+      await bloc.loadHistory();
+
+      expect(bloc.history.status, ConversionHistoryStatus.unavailable);
+    });
+
+    test('anuncia o histórico pela stream', () async {
+      currencyRepository.historicalDataByCode["USD"] = [
+        _quote("USD", _daysAgo(2), 0.2),
+        _quote("USD", _daysAgo(1), 0.25),
+      ];
+      var bloc = buildBloc();
+      var emitted = <ConversionHistory>[];
+      bloc.conversionHistoryStream.listen(emitted.add);
+
+      await bloc.loadHistory();
+      // A stream é broadcast: os eventos chegam a quem escuta no ciclo
+      // seguinte do laço de eventos.
+      await Future<void>.delayed(Duration.zero);
+
+      expect(emitted.first.isLoading, isTrue);
+      expect(emitted.last.status, ConversionHistoryStatus.ready);
+    });
+
+    test('trocar de moeda busca o histórico do par novo', () async {
+      var bloc = buildBloc();
+
+      bloc.updateToCurrency(Currencies.EUR);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(bloc.history.to, Currencies.EUR);
+      expect(currencyRepository.historicalDataCalls.map((call) => call.first),
+          anyElement(equals(["EUR"])));
+    });
+
+    test('inverter o par redesenha o gráfico ao contrário', () async {
+      currencyRepository.historicalDataByCode["USD"] = [
+        _quote("USD", _daysAgo(2), 0.2),
+        _quote("USD", _daysAgo(1), 0.25),
+      ];
+      var bloc = buildBloc();
+      await bloc.loadHistory();
+
+      bloc.switchCurrencies();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(bloc.history.from, Currencies.USD);
+      expect(bloc.history.to, Currencies.BRL);
+      expect(bloc.history.points.map((point) => point.rate),
+          [closeTo(5, 0.000001), closeTo(4, 0.000001)],
+          reason: "um dólar valia cinco reais e passou a valer quatro");
+    });
+
+    test('o gráfico do par anterior fica na tela enquanto o novo não chega',
+        () async {
+      currencyRepository.historicalDataByCode["USD"] = [
+        _quote("USD", _daysAgo(2), 0.2),
+        _quote("USD", _daysAgo(1), 0.25),
+      ];
+      var bloc = buildBloc();
+      await bloc.loadHistory();
+
+      var reload = bloc.loadHistory();
+
+      expect(bloc.history.isLoading, isTrue);
+      expect(bloc.history.hasPoints, isTrue,
+          reason: "a linha some da tela a cada atualização se for descartada");
+      await reload;
+    });
+
+    test('não emite histórico depois de descartado', () async {
+      var bloc = ConversionPageBloc(
+          exchangeValueBloc: exchangeValueBloc,
+          currencyRepository: currencyRepository);
+
+      var loading = bloc.loadHistory();
+      bloc.dispose();
+
+      // Emitir numa stream fechada lançaria, e o erro chegaria aqui.
+      await loading;
     });
   });
 }

--- a/test/helpers/fakes.dart
+++ b/test/helpers/fakes.dart
@@ -77,6 +77,11 @@ class FakeCurrencyRepository implements CurrencyRepository {
   /// período pedido.
   List<Currency> historicalData = [];
 
+  /// Histórico por código, para quem pede a série de mais de uma moeda e
+  /// precisa de uma resposta diferente para cada uma (a tela de conversão pede
+  /// as duas moedas do par). Enquanto estiver vazio vale [historicalData].
+  final Map<String, List<Currency>> historicalDataByCode = {};
+
   Currency? latestCurrency;
   String counterCurrency = "BRL";
 
@@ -91,7 +96,11 @@ class FakeCurrencyRepository implements CurrencyRepository {
       List<String> currencyCodeList, initialDate, finalDate) async {
     historicalDataCalls.add([currencyCodeList, initialDate, finalDate]);
     if (failure != null) throw failure!;
-    return historicalData;
+    if (historicalDataByCode.isEmpty) return historicalData;
+    return [
+      for (var currencyCode in currencyCodeList)
+        ...?historicalDataByCode[currencyCode]
+    ];
   }
 
   @override

--- a/test/util/localizations_test.dart
+++ b/test/util/localizations_test.dart
@@ -27,6 +27,8 @@ List<String?> _allLabels(MyAppLocalizations localizations) => [
       localizations.conversionRateUnavailableLabel,
       localizations.conversionCopyResultTooltip,
       localizations.conversionResultCopiedLabel,
+      localizations.conversionHistorySectionLabel,
+      localizations.conversionHistoryUnavailableLabel,
       localizations.mainCurrenciesBottomNavItemLabel,
       localizations.currencyHistoryBottomNavItemLabel,
       localizations.aboutBottomNavItemLabel,
@@ -261,6 +263,16 @@ void main() {
           MyAppLocalizations(const Locale("en"))
               .homeCurrenciesSelectedCountLabel,
           contains("%s"));
+    });
+
+    // O título do gráfico da conversão traz o número de dias que o bloc fixou;
+    // sem o marcador, o texto diria um período diferente do desenhado.
+    test('conversionHistorySectionLabel traz o marcador de dias', () {
+      for (var locale in AppLocales.supported) {
+        expect(MyAppLocalizations(locale).conversionHistorySectionLabel,
+            contains("%s"),
+            reason: AppLocales.tagOf(locale));
+      }
     });
 
     test('homePageHeadsUpText traz o marcador de moeda', () {

--- a/test/view/conversion_widget_test.dart
+++ b/test/view/conversion_widget_test.dart
@@ -1,12 +1,16 @@
 import 'package:cotacao_direta/blocs/conversion_page_bloc.dart';
 import 'package:cotacao_direta/blocs/exchange_value_bloc.dart';
 import 'package:cotacao_direta/enums/currency_enum.dart';
+import 'package:cotacao_direta/model/currency.dart';
 import 'package:cotacao_direta/providers/conversion_page_bloc_provider.dart';
 import 'package:cotacao_direta/util/localizations.dart';
 import 'package:cotacao_direta/view/pages/conversion_page.dart';
+import 'package:cotacao_direta/view/widgets/charts.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+import '../helpers/fakes.dart';
 
 /// Cotações fixas no lugar da busca real, na convenção do CurrencyRepository:
 /// quantas unidades da moeda valem um real. O iene fica sem cotação, para a
@@ -37,11 +41,32 @@ Widget _conversionApp(ConversionPageBloc bloc) => MaterialApp(
           bloc: bloc, child: ConversionPage("Conversão de Moedas")),
     );
 
+/// Uma cotação de um dia, na convenção do CurrencyRepository.
+Currency _quote(String currencyCode, int daysAgo, double value) {
+  var today = DateTime.now();
+  return Currency(
+      id: currencyCode,
+      value: value,
+      historicalDate: DateTime(today.year, today.month, today.day)
+          .subtract(Duration(days: daysAgo))
+          .toIso8601String(),
+      counterCurrency: "BRL");
+}
+
 void main() {
+  late FakeCurrencyRepository currencyRepository;
   late ConversionPageBloc bloc;
 
-  setUp(() => bloc =
-      ConversionPageBloc(exchangeValueBloc: _FakeExchangeValueBloc()));
+  setUp(() {
+    currencyRepository = FakeCurrencyRepository();
+    currencyRepository.historicalDataByCode["USD"] = [
+      _quote("USD", 2, 0.2),
+      _quote("USD", 1, 0.25),
+    ];
+    bloc = ConversionPageBloc(
+        exchangeValueBloc: _FakeExchangeValueBloc(),
+        currencyRepository: currencyRepository);
+  });
 
   tearDown(() => bloc.dispose());
 
@@ -164,6 +189,7 @@ void main() {
       bloc.dispose();
       bloc = ConversionPageBloc(
           exchangeValueBloc: _FakeExchangeValueBloc(),
+          currencyRepository: currencyRepository,
           priorityCurrencies: [Currencies.EUR, Currencies.BRL]);
       await pumpConversionPage(tester);
 
@@ -185,6 +211,7 @@ void main() {
       bloc.dispose();
       bloc = ConversionPageBloc(
           exchangeValueBloc: _FakeExchangeValueBloc(),
+          currencyRepository: currencyRepository,
           priorityCurrencies: [Currencies.EUR, Currencies.BRL]);
       await pumpConversionPage(tester);
 
@@ -212,6 +239,7 @@ void main() {
       bloc.dispose();
       bloc = ConversionPageBloc(
           exchangeValueBloc: _FakeExchangeValueBloc(),
+          currencyRepository: currencyRepository,
           priorityCurrencies: [Currencies.EUR, Currencies.BRL]);
       await pumpConversionPage(tester);
 
@@ -229,6 +257,7 @@ void main() {
       bloc.dispose();
       bloc = ConversionPageBloc(
           exchangeValueBloc: _FakeExchangeValueBloc(),
+          currencyRepository: currencyRepository,
           initialFromCurrency: Currencies.USD,
           initialToCurrency: Currencies.BRL);
       await pumpConversionPage(tester);
@@ -248,6 +277,43 @@ void main() {
 
       expect(find.text("1 USD = 5,0000 BRL"), findsOneWidget,
           reason: "as duas pontas iguais não converteriam nada");
+    });
+
+    testWidgets('mostra o gráfico dos últimos sete dias do par',
+        (WidgetTester tester) async {
+      await pumpConversionPage(tester);
+
+      expect(find.text("Últimos 7 dias"), findsOneWidget);
+      expect(find.text("1 BRL → USD"), findsOneWidget,
+          reason: "a linha precisa dizer de que cotação ela é");
+      expect(find.byType(SimpleLineChart), findsOneWidget);
+    });
+
+    testWidgets('o gráfico acompanha a troca de moeda',
+        (WidgetTester tester) async {
+      currencyRepository.historicalDataByCode["EUR"] = [
+        _quote("EUR", 2, 0.1),
+        _quote("EUR", 1, 0.1),
+      ];
+      await pumpConversionPage(tester);
+
+      await tester.tap(find.text("USD"));
+      await tester.pumpAndSettle();
+      await searchInCurrencyPicker(tester, "euro");
+      await tester.tap(inCurrencyPicker(find.text("EUR")));
+      await tester.pumpAndSettle();
+
+      expect(find.text("1 BRL → EUR"), findsOneWidget);
+      expect(find.byType(SimpleLineChart), findsOneWidget);
+    });
+
+    testWidgets('avisa quando o par não tem histórico no período',
+        (WidgetTester tester) async {
+      currencyRepository.historicalDataByCode.clear();
+      await pumpConversionPage(tester);
+
+      expect(find.text("Sem histórico para o período"), findsOneWidget);
+      expect(find.byType(SimpleLineChart), findsNothing);
     });
   });
 }


### PR DESCRIPTION
## O que muda

A tela de conversão passa a mostrar, abaixo do cartão de cotação, o mesmo gráfico de linha da tela de histórico (`SimpleLineChart`), com o período fixo nos **últimos 7 dias**. O cartão traz o título "Últimos 7 dias", o par a que a linha se refere ("1 BRL → USD") e, enquanto a busca acontece, o gráfico anterior fica esmaecido em vez de sumir.

## Como a série do par é montada

A API cota cada moeda frente à contrapartida (BRL por padrão), e não uma moeda frente à outra, então a série do par é calculada no `ConversionPageBloc`: a razão entre as duas séries, dia a dia, é a mesma conta que a conversão do momento já fazia com as cotações atuais.

- Só os dias com cotação das **duas** moedas entram no gráfico — completar o dia que falta desenharia uma variação que não houve.
- A própria moeda de contrapartida não tem série no repositório (a consulta é pulada) e entra como uma unidade em todo dia, para o par mais comum (BRL → USD) não ficar sem gráfico.
- Mais de uma cotação no mesmo dia vira um ponto só, o mais recente.
- Menos de dois pontos, falha na busca ou ausência de histórico mostram "Sem histórico para o período".

O período é fixo de propósito: aqui o gráfico é um apoio à conversão; escolher intervalo continua sendo da tela de histórico.

## Arquivos principais

- `lib/blocs/conversion_page_bloc.dart`: `ConversionHistory`, `ConversionRatePoint` e `loadHistory()`, com o repositório de cotações injetável e o mesmo controle de resposta atrasada já usado pela conversão.
- `lib/view/widgets/charts.dart`: `SimpleLineChart` ganha o construtor `fromPoints`, para desenhar uma série que não é o valor de uma `Currency` só. O construtor a partir do histórico de uma moeda continua igual.
- `lib/view/widgets/conversion_widget.dart`: o cartão do gráfico.
- `lib/util/localizations.dart`: `conversionHistorySectionLabel` (com o marcador do número de dias) e `conversionHistoryUnavailableLabel` nos quatro idiomas.

## Testes

`flutter analyze` sem apontamentos e `flutter test` com os 578 testes passando, incluindo os novos:

- bloc: razão entre as séries, contrapartida valendo uma unidade, período de sete dias, dias sem cotação nas duas moedas, cotações repetidas no mesmo dia, ponto único, falha na busca, emissão pela stream, troca e inversão do par, e descarte durante a busca.
- widget: o gráfico na tela, o acompanhamento da troca de moeda e o aviso quando não há histórico.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S4RLyY8ufajhmYX6E8STRa)_