### PR TITLE
Adiciona chips de período rápido e período padrão de 7 dias ao histórico

### DIFF
--- a/lib/blocs/currency_history_menu_bloc.dart
+++ b/lib/blocs/currency_history_menu_bloc.dart
@@ -13,6 +13,12 @@ class CurrencyHistoryMenuBloc extends BaseBloc {
 
   Future<String>? _counterCurrencyFuture;
 
+  /// Exposto para a navegação ao histórico de uma moeda passar adiante o
+  /// mesmo repositório desta lista, em vez de deixar a tela seguinte cair no
+  /// singleton — o que faria a configuração injetada nos testes (ou trocada
+  /// nas opções) valer aqui e não lá.
+  CurrencyRepository get currencyRepository => _currencyRepository;
+
   CurrencyHistoryMenuBloc(
       {CountryNamesRepository? countryNamesRepository,
       CurrencyRepository? currencyRepository})

--- a/lib/blocs/selected_currency_details_bloc.dart
+++ b/lib/blocs/selected_currency_details_bloc.dart
@@ -7,11 +7,21 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
 class SelectedCurrencyDetailsBloc extends BaseBloc {
+  /// Períodos que os chips da tela oferecem como atalho, em dias.
+  static const List<int> quickPeriodOptions = [7, 15, 30, 360];
+
+  /// Período com que a tela abre, antes de qualquer escolha do usuário: os
+  /// últimos sete dias, o mesmo horizonte do gráfico da tela de conversão.
+  static const int defaultPeriodInDays = 7;
+
   StreamController<List<Currency>> _selectedCurrencyHistoryDataStreamController =
       StreamController<List<Currency>>.broadcast();
 
   StreamController<bool> _isLoadingStreamController =
       StreamController<bool>.broadcast();
+
+  final StreamController<int?> _selectedPeriodController =
+      StreamController<int?>.broadcast();
 
   final DateFormat _viewDateFormatter = DateFormat("dd/MM/yyyy");
   final DateFormat _apiDateFormatter = DateFormat("yyyy-MM-dd");
@@ -24,16 +34,27 @@ class SelectedCurrencyDetailsBloc extends BaseBloc {
 
   String _finalDate = "";
 
-  final _currencyRepository = CurrencyRepository();
+  /// Qual chip está marcado, ou nulo quando as datas vieram dos seletores
+  /// manuais e não correspondem a nenhum atalho.
+  int? _selectedPeriodInDays;
+
+  final CurrencyRepository _currencyRepository;
+
+  SelectedCurrencyDetailsBloc({CurrencyRepository? currencyRepository})
+      : _currencyRepository = currencyRepository ?? CurrencyRepository();
 
   Stream<List<Currency>> get currencyHistoryStream =>
       _selectedCurrencyHistoryDataStreamController.stream;
 
   Stream<bool> get isLoadingStream => _isLoadingStreamController.stream;
 
+  Stream<int?> get selectedPeriodStream => _selectedPeriodController.stream;
+
   TextEditingController get initialDateController => _initialDateController;
 
   TextEditingController get endDateController => _endDateController;
+
+  int? get selectedPeriodInDays => _selectedPeriodInDays;
 
   getCurrencyHistoryData(String selectedCurrencyCod) async {
     _isLoadingStreamController.sink.add(true);
@@ -46,20 +67,46 @@ class SelectedCurrencyDetailsBloc extends BaseBloc {
     }
   }
 
+  /// Marca o atalho de [days] dias, ajusta os dois campos de data para o
+  /// intervalo correspondente (hoje incluído) e já busca o histórico: um chip
+  /// é um filtro rápido, não precisa do botão de buscar para valer.
+  Future<void> selectPeriod(int days, String currencyCode) async {
+    var today = DateTime.now();
+    var start = DateTime(today.year, today.month, today.day)
+        .subtract(Duration(days: days - 1));
+    updateInitialDate(start);
+    updateFinalDate(today);
+    _selectedPeriodInDays = days;
+    _selectedPeriodController.add(days);
+    await getCurrencyHistoryData(currencyCode);
+  }
+
   updateInitialDate(dateValue){
     initialDateController.text = _viewDateFormatter.format(dateValue);
     _initialDate = _apiDateFormatter.format(dateValue);
+    _clearSelectedPeriod();
   }
 
   updateFinalDate(dateValue){
     _endDateController.text = _viewDateFormatter.format(dateValue);
     _finalDate = _apiDateFormatter.format(dateValue);
+    _clearSelectedPeriod();
+  }
+
+  /// Uma data escolhida à mão no seletor deixa de corresponder ao atalho
+  /// marcado, que também é chamado por [selectPeriod] antes de marcar o chip
+  /// novo — por isso só emite quando havia mesmo um chip para desmarcar.
+  void _clearSelectedPeriod() {
+    if (_selectedPeriodInDays == null) return;
+    _selectedPeriodInDays = null;
+    _selectedPeriodController.add(null);
   }
 
   @override
   void dispose() {
     _selectedCurrencyHistoryDataStreamController.close();
     _isLoadingStreamController.close();
+    _selectedPeriodController.close();
     // Os campos de data são ChangeNotifier: sem dispose, os ouvintes ficam
     // presos ao bloc depois que a tela sai.
     _initialDateController.dispose();

--- a/lib/util/localizations.dart
+++ b/lib/util/localizations.dart
@@ -179,6 +179,7 @@ class MyAppLocalizations {
       'currencyHistoryCryptocurrenciesSectionLabel': 'Cryptocurrencies',
       'noDataLabel': 'No Data',
       'getCurrencyHistoryBtnLabel': 'Get history',
+      'currencyHistoryPeriodOptionLabel': '%s days',
       'overrideDefaultCurrencySwitchLabel': 'Override default currency',
       'selectedOverrideCurrencyLabel': 'Currency',
       'homeCurrenciesSettingLabel': 'Quotes on the home screen',
@@ -339,6 +340,7 @@ class MyAppLocalizations {
       'currencyHistoryCryptocurrenciesSectionLabel': 'Criptomoedas',
       'noDataLabel': 'Sem Dados',
       'getCurrencyHistoryBtnLabel': 'Obter histórico',
+      'currencyHistoryPeriodOptionLabel': '%s dias',
       'overrideDefaultCurrencySwitchLabel': 'Sobrescrever moeda padrão',
       'selectedOverrideCurrencyLabel': 'Moeda',
       'homeCurrenciesSettingLabel': 'Cotações na tela inicial',
@@ -503,6 +505,7 @@ class MyAppLocalizations {
       'currencyHistoryCryptocurrenciesSectionLabel': 'Criptomonedas',
       'noDataLabel': 'Sin datos',
       'getCurrencyHistoryBtnLabel': 'Obtener el histórico',
+      'currencyHistoryPeriodOptionLabel': '%s días',
       'overrideDefaultCurrencySwitchLabel': 'Sustituir la divisa por defecto',
       'selectedOverrideCurrencyLabel': 'Divisa',
       'homeCurrenciesSettingLabel': 'Cotizaciones en la pantalla de inicio',
@@ -671,6 +674,7 @@ class MyAppLocalizations {
       'currencyHistoryCryptocurrenciesSectionLabel': 'Criptomonedas',
       'noDataLabel': 'Sin datos',
       'getCurrencyHistoryBtnLabel': 'Obtener el historial',
+      'currencyHistoryPeriodOptionLabel': '%s días',
       'overrideDefaultCurrencySwitchLabel':
           'Reemplazar la moneda predeterminada',
       'selectedOverrideCurrencyLabel': 'Moneda',
@@ -937,6 +941,12 @@ class MyAppLocalizations {
 
   String? get getCurrencyHistoryBtnLabel {
     return _values['getCurrencyHistoryBtnLabel'];
+  }
+
+  /// Rótulo de cada chip de período rápido da tela de histórico. Traz o
+  /// marcador do número de dias.
+  String? get currencyHistoryPeriodOptionLabel {
+    return _values['currencyHistoryPeriodOptionLabel'];
   }
 
   String? get getConfigBottomNavItemLabel {

--- a/lib/view/pages/main_menu_items/currency_history_menu.dart
+++ b/lib/view/pages/main_menu_items/currency_history_menu.dart
@@ -1,4 +1,5 @@
 import 'package:cotacao_direta/blocs/currency_history_menu_bloc.dart';
+import 'package:cotacao_direta/blocs/selected_currency_details_bloc.dart';
 import 'package:cotacao_direta/enums/cryptocurrency_enum.dart';
 import 'package:cotacao_direta/enums/currency_enum.dart';
 import 'package:cotacao_direta/providers/currency_history_menu_bloc_provider.dart';
@@ -104,6 +105,7 @@ class CurrencyHistory extends StatelessWidget {
                       padding: EdgeInsets.only(bottom: 10 * _scale),
                       child: _cryptocurrencyTile(
                         context,
+                        bloc,
                         entry.cryptocurrency,
                         _scale,
                       ),
@@ -128,6 +130,7 @@ class CurrencyHistory extends StatelessWidget {
     final currencyCode = _codeOf(currency);
     return _quoteTile(
       context,
+      bloc: bloc,
       currencyCode: currencyCode,
       scale: scale,
       accent: CurrencyColors.eur,
@@ -152,11 +155,13 @@ class CurrencyHistory extends StatelessWidget {
 
   Widget _cryptocurrencyTile(
     BuildContext context,
+    CurrencyHistoryMenuBloc bloc,
     Cryptocurrencies cryptocurrency,
     double scale,
   ) {
     return _quoteTile(
       context,
+      bloc: bloc,
       currencyCode: _codeOf(cryptocurrency),
       scale: scale,
       accent: CurrencyColors.usd,
@@ -187,6 +192,7 @@ class CurrencyHistory extends StatelessWidget {
 
   Widget _quoteTile(
     BuildContext context, {
+    required CurrencyHistoryMenuBloc bloc,
     required String currencyCode,
     required Widget badge,
     required Widget subtitle,
@@ -200,6 +206,8 @@ class CurrencyHistory extends StatelessWidget {
           context,
           MaterialPageRoute(
             builder: (context) => SelectedCurrencyDetailsBlocProvider(
+              bloc: SelectedCurrencyDetailsBloc(
+                  currencyRepository: bloc.currencyRepository),
               child: SelectedCurrencyDetails(
                 selectedCurrencyCode: currencyCode,
               ),

--- a/lib/view/pages/selected_currency_details.dart
+++ b/lib/view/pages/selected_currency_details.dart
@@ -1,3 +1,4 @@
+import 'package:cotacao_direta/blocs/selected_currency_details_bloc.dart';
 import 'package:cotacao_direta/model/currency.dart';
 import 'package:cotacao_direta/providers/selected_currency_details_bloc_provider.dart';
 import 'package:cotacao_direta/util/localizations.dart';
@@ -5,28 +6,53 @@ import 'package:cotacao_direta/util/responsive.dart';
 import 'package:cotacao_direta/view/widgets/bento_card.dart';
 import 'package:cotacao_direta/view/widgets/charts.dart';
 import 'package:flutter/material.dart';
+import 'package:sprintf/sprintf.dart';
 
-class SelectedCurrencyDetails extends StatelessWidget {
+class SelectedCurrencyDetails extends StatefulWidget {
   final String selectedCurrencyCode;
 
   SelectedCurrencyDetails({Key? key, required this.selectedCurrencyCode})
     : super(key: key);
 
   @override
+  State<SelectedCurrencyDetails> createState() =>
+      _SelectedCurrencyDetailsState();
+}
+
+class _SelectedCurrencyDetailsState extends State<SelectedCurrencyDetails> {
+  // O bloc pertence ao SelectedCurrencyDetailsBlocProvider, que o descarta
+  // junto com o próprio State: este widget apenas o consome.
+  late SelectedCurrencyDetailsBloc bloc;
+
+  SelectedCurrencyDetailsBloc? _initializedBloc;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    bloc = SelectedCurrencyDetailsBlocProvider.of(context);
+    if (identical(_initializedBloc, bloc)) return;
+    _initializedBloc = bloc;
+    // A tela já abre com o período padrão buscado, em vez de um gráfico vazio
+    // esperando o primeiro toque num chip ou no botão de buscar.
+    WidgetsBinding.instance.addPostFrameCallback((_) => bloc.selectPeriod(
+        SelectedCurrencyDetailsBloc.defaultPeriodInDays,
+        widget.selectedCurrencyCode));
+  }
+
+  @override
   Widget build(BuildContext context) {
     final localizations = MyAppLocalizations.of(context)!;
-    var bloc = SelectedCurrencyDetailsBlocProvider.of(context);
     final _contentWidth = Responsive.contentMaxWidth(context);
     final _scale = Responsive.scaleFactor(context);
 
     return Scaffold(
-      appBar: AppBar(title: Text(selectedCurrencyCode)),
+      appBar: AppBar(title: Text(widget.selectedCurrencyCode)),
       floatingActionButton: FloatingActionButton.extended(
         // Esta tela abre em rota própria, mas a tag explícita evita o mesmo
         // conflito caso ela passe a ser embutida em outra tela.
         heroTag: "currencyHistoryFab",
         onPressed: () {
-          bloc.getCurrencyHistoryData(selectedCurrencyCode);
+          bloc.getCurrencyHistoryData(widget.selectedCurrencyCode);
         },
         icon: const Icon(Icons.query_stats),
         label: Text(localizations.getCurrencyHistoryBtnLabel!),
@@ -44,30 +70,40 @@ class SelectedCurrencyDetails extends StatelessWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
-                // Os dois seletores de data moram no mesmo cartão: são um
-                // controle só, o intervalo do gráfico.
+                // Os chips e os seletores de data moram no mesmo cartão: são
+                // um controle só, o intervalo do gráfico. Os chips são o
+                // atalho para os períodos mais pedidos; os seletores cobrem o
+                // resto.
                 BentoCard(
                   padding: EdgeInsets.all(12 * _scale),
-                  child: Row(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
                     children: [
-                      Expanded(
-                        child: _dateField(
-                          context,
-                          controller: bloc.initialDateController,
-                          label: localizations.currencyHistoryFromDateLabel!,
-                          scale: _scale,
-                          onPicked: bloc.updateInitialDate,
-                        ),
-                      ),
-                      SizedBox(width: 12 * _scale),
-                      Expanded(
-                        child: _dateField(
-                          context,
-                          controller: bloc.endDateController,
-                          label: localizations.currencyHistoryToDateLabel!,
-                          scale: _scale,
-                          onPicked: bloc.updateFinalDate,
-                        ),
+                      _periodChips(localizations, _scale),
+                      SizedBox(height: 12 * _scale),
+                      Row(
+                        children: [
+                          Expanded(
+                            child: _dateField(
+                              context,
+                              controller: bloc.initialDateController,
+                              label:
+                                  localizations.currencyHistoryFromDateLabel!,
+                              scale: _scale,
+                              onPicked: bloc.updateInitialDate,
+                            ),
+                          ),
+                          SizedBox(width: 12 * _scale),
+                          Expanded(
+                            child: _dateField(
+                              context,
+                              controller: bloc.endDateController,
+                              label: localizations.currencyHistoryToDateLabel!,
+                              scale: _scale,
+                              onPicked: bloc.updateFinalDate,
+                            ),
+                          ),
+                        ],
                       ),
                     ],
                   ),
@@ -118,6 +154,35 @@ class SelectedCurrencyDetails extends StatelessWidget {
           ),
         ),
       ),
+    );
+  }
+
+  /// Um chip por período de [SelectedCurrencyDetailsBloc.quickPeriodOptions]:
+  /// tocar num deles já preenche as duas datas e busca o histórico, sem
+  /// passar pelos seletores nem pelo botão de buscar.
+  Widget _periodChips(MyAppLocalizations localizations, double scale) {
+    return StreamBuilder<int?>(
+      initialData: bloc.selectedPeriodInDays,
+      stream: bloc.selectedPeriodStream,
+      builder: (context, snapshot) {
+        var selectedDays = snapshot.data;
+        return Wrap(
+          spacing: 8 * scale,
+          runSpacing: 8 * scale,
+          children: SelectedCurrencyDetailsBloc.quickPeriodOptions
+              .map((days) => ChoiceChip(
+                    label: Text(sprintf(
+                        localizations.currencyHistoryPeriodOptionLabel!,
+                        ["$days"])),
+                    labelStyle: TextStyle(fontSize: 13 * scale),
+                    visualDensity: VisualDensity.compact,
+                    selected: selectedDays == days,
+                    onSelected: (_) => bloc.selectPeriod(
+                        days, widget.selectedCurrencyCode),
+                  ))
+              .toList(),
+        );
+      },
     );
   }
 

--- a/test/blocs/selected_currency_details_bloc_test.dart
+++ b/test/blocs/selected_currency_details_bloc_test.dart
@@ -1,11 +1,25 @@
 import 'package:cotacao_direta/blocs/selected_currency_details_bloc.dart';
+import 'package:cotacao_direta/model/currency.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/intl.dart';
+
+import '../helpers/fakes.dart';
+
+DateTime _daysAgo(int days) {
+  var today = DateTime.now();
+  return DateTime(today.year, today.month, today.day)
+      .subtract(Duration(days: days));
+}
 
 void main() {
+  late FakeCurrencyRepository currencyRepository;
   late SelectedCurrencyDetailsBloc bloc;
 
-  setUp(() => bloc = SelectedCurrencyDetailsBloc());
+  setUp(() {
+    currencyRepository = FakeCurrencyRepository();
+    bloc = SelectedCurrencyDetailsBloc(currencyRepository: currencyRepository);
+  });
 
   group('SelectedCurrencyDetailsBloc', () {
     test('a data inicial aparece formatada no campo', () {
@@ -29,9 +43,123 @@ void main() {
     });
   });
 
+  group('SelectedCurrencyDetailsBloc: períodos rápidos', () {
+    final apiDateFormatter = DateFormat("yyyy-MM-dd");
+
+    test('a tela abre com o período padrão de sete dias', () {
+      expect(SelectedCurrencyDetailsBloc.defaultPeriodInDays, 7);
+    });
+
+    test('os chips oferecidos são sete, quinze, trinta e trezentos e '
+        'sessenta dias', () {
+      expect(SelectedCurrencyDetailsBloc.quickPeriodOptions,
+          [7, 15, 30, 360]);
+    });
+
+    test('nenhum chip começa marcado', () {
+      expect(bloc.selectedPeriodInDays, isNull);
+    });
+
+    test('escolher um período preenche as duas datas e busca o histórico',
+        () async {
+      await bloc.selectPeriod(7, "USD");
+
+      expect(bloc.selectedPeriodInDays, 7);
+      expect(bloc.initialDateController.text,
+          DateFormat("dd/MM/yyyy").format(_daysAgo(6)));
+      expect(bloc.endDateController.text,
+          DateFormat("dd/MM/yyyy").format(_daysAgo(0)));
+      expect(currencyRepository.historicalDataCalls.single, [
+        ["USD"],
+        apiDateFormatter.format(_daysAgo(6)),
+        apiDateFormatter.format(_daysAgo(0)),
+      ]);
+    });
+
+    test('o intervalo inclui hoje, então quinze dias começam catorze dias '
+        'atrás', () async {
+      await bloc.selectPeriod(15, "USD");
+
+      expect(currencyRepository.historicalDataCalls.single[1],
+          apiDateFormatter.format(_daysAgo(14)));
+    });
+
+    test('escolher outro período marca o chip novo', () async {
+      await bloc.selectPeriod(7, "USD");
+
+      await bloc.selectPeriod(30, "USD");
+
+      expect(bloc.selectedPeriodInDays, 30);
+    });
+
+    test('editar a data à mão desmarca o chip', () async {
+      await bloc.selectPeriod(7, "USD");
+
+      bloc.updateInitialDate(DateTime(2024, 1, 1));
+
+      expect(bloc.selectedPeriodInDays, isNull);
+    });
+
+    test('editar a data final também desmarca o chip', () async {
+      await bloc.selectPeriod(7, "USD");
+
+      bloc.updateFinalDate(DateTime(2024, 1, 1));
+
+      expect(bloc.selectedPeriodInDays, isNull);
+    });
+
+    test('anuncia o período marcado pela stream', () async {
+      var emitted = <int?>[];
+      bloc.selectedPeriodStream.listen(emitted.add);
+
+      await bloc.selectPeriod(15, "USD");
+      bloc.updateInitialDate(DateTime(2024, 1, 1));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(emitted, [15, null]);
+    });
+
+    test('a stream do período não repete uma desmarcação já anunciada',
+        () async {
+      var emitted = <int?>[];
+      bloc.selectedPeriodStream.listen(emitted.add);
+
+      // Sem chip nenhum marcado, editar a data não deveria anunciar nada.
+      bloc.updateInitialDate(DateTime(2024, 1, 1));
+      bloc.updateFinalDate(DateTime(2024, 1, 2));
+
+      await Future<void>.delayed(Duration.zero);
+      expect(emitted, isEmpty);
+    });
+
+    test('mostra o histórico buscado na stream', () async {
+      currencyRepository.historicalData = [
+        Currency(id: "USD", value: 0.2, historicalDate: "2024-01-01")
+      ];
+
+      var emittedLoading = <bool>[];
+      bloc.isLoadingStream.listen(emittedLoading.add);
+      var history = bloc.currencyHistoryStream.first;
+
+      await bloc.selectPeriod(7, "USD");
+      await Future<void>.delayed(Duration.zero);
+
+      expect(await history, currencyRepository.historicalData);
+      expect(emittedLoading, [true, false]);
+    });
+  });
+
   group('SelectedCurrencyDetailsBloc.dispose', () {
     test('fecha a stream do histórico', () async {
       var stream = bloc.currencyHistoryStream;
+
+      bloc.dispose();
+
+      expect(await stream.isEmpty, isTrue);
+    });
+
+    test('fecha a stream do período marcado', () async {
+      var stream = bloc.selectedPeriodStream;
 
       bloc.dispose();
 

--- a/test/util/localizations_test.dart
+++ b/test/util/localizations_test.dart
@@ -38,6 +38,7 @@ List<String?> _allLabels(MyAppLocalizations localizations) => [
       localizations.currencyHistoryCryptocurrenciesSectionLabel,
       localizations.noDataLabel,
       localizations.getCurrencyHistoryBtnLabel,
+      localizations.currencyHistoryPeriodOptionLabel,
       localizations.getConfigBottomNavItemLabel,
       localizations.overrideDefaultCurrencySwitchLabel,
       localizations.selectedOverrideCurrencyLabel,
@@ -270,6 +271,16 @@ void main() {
     test('conversionHistorySectionLabel traz o marcador de dias', () {
       for (var locale in AppLocales.supported) {
         expect(MyAppLocalizations(locale).conversionHistorySectionLabel,
+            contains("%s"),
+            reason: AppLocales.tagOf(locale));
+      }
+    });
+
+    // O rótulo de cada chip de período traz o número de dias que o bloc
+    // calculou; sem o marcador, todo chip diria o mesmo texto.
+    test('currencyHistoryPeriodOptionLabel traz o marcador de dias', () {
+      for (var locale in AppLocales.supported) {
+        expect(MyAppLocalizations(locale).currencyHistoryPeriodOptionLabel,
             contains("%s"),
             reason: AppLocales.tagOf(locale));
       }

--- a/test/view/currency_history_menu_test.dart
+++ b/test/view/currency_history_menu_test.dart
@@ -47,10 +47,14 @@ void main() {
               headers: {"content-type": "application/json; charset=utf-8"});
         })),
         // Sem isto, resolveCounterCurrency() cairia no CurrencyRepository
-        // real e tentaria abrir o banco de configuração de verdade.
+        // real e tentaria abrir o banco de configuração de verdade. O DAO e a
+        // rede fakes evitam o mesmo problema ao abrir o histórico de uma
+        // moeda, que agora busca sozinho ao abrir a tela.
         currencyRepository: CurrencyRepository.withDependencies(
             configurationRepository:
-                FakeConfigurationRepository(configuration: configuration)));
+                FakeConfigurationRepository(configuration: configuration),
+            currencyDao: FakeCurrencyDao(),
+            networkUtils: FakeNetworkUtils(available: false)));
   }
 
   Future<CurrencyHistoryMenuBloc> pumpMenu(WidgetTester tester,

--- a/test/view/selected_currency_details_test.dart
+++ b/test/view/selected_currency_details_test.dart
@@ -1,0 +1,135 @@
+import 'package:cotacao_direta/blocs/selected_currency_details_bloc.dart';
+import 'package:cotacao_direta/model/currency.dart';
+import 'package:cotacao_direta/providers/selected_currency_details_bloc_provider.dart';
+import 'package:cotacao_direta/util/localizations.dart';
+import 'package:cotacao_direta/view/pages/selected_currency_details.dart';
+import 'package:cotacao_direta/view/widgets/charts.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/intl.dart';
+
+import '../helpers/fakes.dart';
+
+DateTime _daysAgo(int days) {
+  var today = DateTime.now();
+  return DateTime(today.year, today.month, today.day)
+      .subtract(Duration(days: days));
+}
+
+/// Uma cotação de um dia, na convenção do CurrencyRepository.
+Currency _quote(int daysAgo, double value) => Currency(
+    id: "USD", value: value, historicalDate: _daysAgo(daysAgo).toIso8601String());
+
+Widget _detailsApp(SelectedCurrencyDetailsBloc bloc) => MaterialApp(
+      locale: const Locale("pt"),
+      localizationsDelegates: [
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+        MyAppLocalizationsDelegate()
+      ],
+      supportedLocales: const [Locale("pt"), Locale("en")],
+      home: SelectedCurrencyDetailsBlocProvider(
+        bloc: bloc,
+        child: SelectedCurrencyDetails(selectedCurrencyCode: "USD"),
+      ),
+    );
+
+void main() {
+  late FakeCurrencyRepository currencyRepository;
+  late SelectedCurrencyDetailsBloc bloc;
+
+  setUp(() {
+    currencyRepository = FakeCurrencyRepository();
+    currencyRepository.historicalData = [
+      _quote(6, 0.19),
+      _quote(3, 0.2),
+      _quote(0, 0.21),
+    ];
+    bloc = SelectedCurrencyDetailsBloc(currencyRepository: currencyRepository);
+  });
+
+  tearDown(() => bloc.dispose());
+
+  Future<void> pumpDetails(WidgetTester tester) async {
+    await tester.pumpWidget(_detailsApp(bloc));
+    await tester.pumpAndSettle();
+  }
+
+  group('SelectedCurrencyDetails', () {
+    testWidgets('abre já buscando os últimos sete dias',
+        (WidgetTester tester) async {
+      await pumpDetails(tester);
+
+      var dateFormatter = DateFormat("dd/MM/yyyy");
+      expect(currencyRepository.historicalDataCalls.single.first, ["USD"]);
+      expect(bloc.initialDateController.text,
+          dateFormatter.format(_daysAgo(6)));
+      expect(bloc.endDateController.text, dateFormatter.format(_daysAgo(0)));
+      expect(find.byType(SimpleLineChart), findsOneWidget);
+      expect(find.widgetWithText(ChoiceChip, "7 dias"), findsOneWidget);
+    });
+
+    testWidgets('o chip de sete dias começa marcado',
+        (WidgetTester tester) async {
+      await pumpDetails(tester);
+
+      var chip =
+          tester.widget<ChoiceChip>(find.widgetWithText(ChoiceChip, "7 dias"));
+      expect(chip.selected, isTrue);
+    });
+
+    testWidgets('mostra um chip para cada período rápido',
+        (WidgetTester tester) async {
+      await pumpDetails(tester);
+
+      for (var days in SelectedCurrencyDetailsBloc.quickPeriodOptions) {
+        expect(find.widgetWithText(ChoiceChip, "$days dias"), findsOneWidget,
+            reason: "faltou o chip de $days dias");
+      }
+    });
+
+    testWidgets('tocar em outro chip busca o período correspondente',
+        (WidgetTester tester) async {
+      await pumpDetails(tester);
+
+      await tester.tap(find.widgetWithText(ChoiceChip, "30 dias"));
+      await tester.pumpAndSettle();
+
+      var dateFormatter = DateFormat("dd/MM/yyyy");
+      expect(bloc.initialDateController.text,
+          dateFormatter.format(_daysAgo(29)));
+      expect(bloc.endDateController.text, dateFormatter.format(_daysAgo(0)));
+      expect(currencyRepository.historicalDataCalls, hasLength(2),
+          reason: "a busca automática mais o toque no chip");
+
+      var sevenDaysChip =
+          tester.widget<ChoiceChip>(find.widgetWithText(ChoiceChip, "7 dias"));
+      var thirtyDaysChip = tester
+          .widget<ChoiceChip>(find.widgetWithText(ChoiceChip, "30 dias"));
+      expect(sevenDaysChip.selected, isFalse);
+      expect(thirtyDaysChip.selected, isTrue);
+    });
+
+    testWidgets('sem histórico no período mostra o aviso de sem dados',
+        (WidgetTester tester) async {
+      currencyRepository.historicalData = [];
+
+      await pumpDetails(tester);
+
+      expect(find.text("Sem Dados"), findsOneWidget);
+      expect(find.byType(SimpleLineChart), findsNothing);
+    });
+
+    testWidgets('o botão de buscar refaz a consulta com as datas atuais',
+        (WidgetTester tester) async {
+      await pumpDetails(tester);
+
+      await tester.tap(find.text("Obter histórico"));
+      await tester.pumpAndSettle();
+
+      expect(currencyRepository.historicalDataCalls, hasLength(2));
+    });
+  });
+}


### PR DESCRIPTION
## O que muda

Na tela de histórico de uma moeda (`SelectedCurrencyDetails`):

- **Período padrão de 7 dias**: a tela deixa de abrir em branco esperando o usuário escolher datas e tocar em "Obter histórico". Agora ela já busca automaticamente os últimos 7 dias ao abrir — o mesmo horizonte do gráfico que a tela de conversão ganhou no PR #50.
- **Chips de período rápido**: 7, 15, 30 e 360 dias, acima dos seletores de data. Tocar num chip preenche as duas datas e busca na hora, sem precisar do botão "Obter histórico".

Os seletores de data manuais continuam funcionando como antes (com o botão para buscar); editar uma data à mão desmarca o chip, já que o intervalo deixou de corresponder a um atalho.

## Detalhes de implementação

- `lib/blocs/selected_currency_details_bloc.dart`: `quickPeriodOptions`, `defaultPeriodInDays` e `selectPeriod(days, currencyCode)`, que calcula o intervalo (hoje incluído), atualiza os campos de data e já dispara a busca. Uma stream nova (`selectedPeriodStream`) avisa a tela qual chip marcar. O repositório de cotações virou parâmetro injetável, como já era no `ConversionPageBloc`.
- `lib/view/pages/selected_currency_details.dart`: virou `StatefulWidget` para disparar a busca automática ao abrir (mesmo padrão do `ConversionWidget`), e ganhou a linha de `ChoiceChip`.
- `lib/util/localizations.dart`: `currencyHistoryPeriodOptionLabel` (com o marcador do número de dias) nos quatro idiomas.

### Efeito colateral corrigido

Buscar automaticamente ao abrir expôs uma inconsistência: a navegação até então criava o `SelectedCurrencyDetailsBloc` com o `CurrencyRepository` **singleton**, e não com o repositório (às vezes injetado, como nos testes) da lista de onde a navegação partiu — antes disso não importava, porque nada era buscado até o usuário tocar no botão. `CurrencyHistoryMenuBloc` agora expõe seu repositório (`lib/blocs/currency_history_menu_bloc.dart`) e a navegação em `lib/view/pages/main_menu_items/currency_history_menu.dart` passa esse mesmo repositório adiante.

## Testes

`flutter analyze` sem apontamentos e `flutter test` com os 597 testes passando, incluindo:

- `test/blocs/selected_currency_details_bloc_test.dart`: período padrão, cálculo do intervalo de cada chip (incluindo hoje), marcação/desmarcação ao trocar de chip ou editar data à mão, emissão pela stream, e o histórico buscado.
- `test/view/selected_currency_details_test.dart` (novo): a tela abre já buscando os 7 dias, os quatro chips aparecem, tocar num chip busca o período certo e marca o chip, "Sem Dados" quando não há histórico, e o botão de buscar continua funcionando.
- `test/view/currency_history_menu_test.dart`: ajustado para injetar DAO e rede fake também na navegação ao histórico, já que ela busca sozinha agora.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S4RLyY8ufajhmYX6E8STRa)_