### PR TITLE
Move os chips de período para baixo dos campos de data e arredonda a borda

### DIFF
--- a/lib/view/pages/selected_currency_details.dart
+++ b/lib/view/pages/selected_currency_details.dart
@@ -71,16 +71,14 @@ class _SelectedCurrencyDetailsState extends State<SelectedCurrencyDetails> {
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
                 // Os chips e os seletores de data moram no mesmo cartão: são
-                // um controle só, o intervalo do gráfico. Os chips são o
-                // atalho para os períodos mais pedidos; os seletores cobrem o
-                // resto.
+                // um controle só, o intervalo do gráfico. Os seletores cobrem
+                // o intervalo por extenso; os chips, logo abaixo, são o
+                // atalho para os períodos mais pedidos.
                 BentoCard(
                   padding: EdgeInsets.all(12 * _scale),
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.stretch,
                     children: [
-                      _periodChips(localizations, _scale),
-                      SizedBox(height: 12 * _scale),
                       Row(
                         children: [
                           Expanded(
@@ -105,6 +103,8 @@ class _SelectedCurrencyDetailsState extends State<SelectedCurrencyDetails> {
                           ),
                         ],
                       ),
+                      SizedBox(height: 12 * _scale),
+                      _periodChips(localizations, _scale),
                     ],
                   ),
                 ),
@@ -176,6 +176,9 @@ class _SelectedCurrencyDetailsState extends State<SelectedCurrencyDetails> {
                         ["$days"])),
                     labelStyle: TextStyle(fontSize: 13 * scale),
                     visualDensity: VisualDensity.compact,
+                    // Chip em pílula, para se diferenciar dos cartões
+                    // (arredondados, mas em retângulo) do resto da tela.
+                    shape: const StadiumBorder(),
                     selected: selectedDays == days,
                     onSelected: (_) => bloc.selectPeriod(
                         days, widget.selectedCurrencyCode),


### PR DESCRIPTION
## O que muda

Ajustes visuais nos chips de período rápido da tela de histórico (`SelectedCurrencyDetails`), adicionados no PR #51:

- **Posição**: os chips ficavam acima dos dois campos de data; agora ficam abaixo deles, dentro do mesmo cartão. Os seletores por extenso vêm primeiro, os chips como atalho logo depois.
- **Borda**: os chips ganharam `shape: StadiumBorder()` — borda em pílula (totalmente arredondada), em vez do arredondamento discreto padrão do Material 3.

## Arquivo

- `lib/view/pages/selected_currency_details.dart`: só reordena os widgets dentro do `Column` do cartão e adiciona o `shape` no `ChoiceChip`. Nenhuma mudança de comportamento — a lógica de seleção de período (`SelectedCurrencyDetailsBloc.selectPeriod`) não foi tocada.

## Testes

`flutter analyze` sem apontamentos e `flutter test` com os 597 testes passando (o teste de widget da tela, `test/view/selected_currency_details_test.dart`, não depende de posição, então segue cobrindo o comportamento sem alteração). Conferi o novo layout com uma captura de tela renderizada localmente antes de enviar.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S4RLyY8ufajhmYX6E8STRa)_