### PR TITLE
Corrige a relação invertida nos alertas de câmbio

### DIFF
--- a/lib/blocs/currency_alerts_bloc.dart
+++ b/lib/blocs/currency_alerts_bloc.dart
@@ -47,6 +47,14 @@ class CurrencyAlertsBloc extends BaseBloc {
   /// Confere os alertas ativos ainda não disparados: busca a cotação mais
   /// recente da moeda de cada um e, se a condição já for atendida, notifica o
   /// usuário e marca o alerta como disparado para não repetir o aviso.
+  ///
+  /// A comparação e o valor avisado usam a cotação na mesma convenção que o
+  /// usuário vê no app — quantas unidades da contrapartida valem uma unidade
+  /// da moeda ("um dólar a 5,50 reais") —, que é o inverso do que
+  /// `Currency.value` guarda (ver [CurrencyRepository]). É nessa convenção que
+  /// o alvo do alerta é digitado, então comparar direto com o valor guardado
+  /// invertia a relação: um alerta de "USD acima de 5,00" nunca disparava, e o
+  /// aviso reportaria 0,1818 no lugar de 5,50.
   Future<void> checkAlerts(
       {required String notificationTitle,
       required String Function(CurrencyAlert alert, double value)
@@ -62,7 +70,7 @@ class CurrencyAlertsBloc extends BaseBloc {
     var latestValueByCode = Map.fromEntries(
       await Future.wait(currencyCodes.map((code) async {
         var currency = await _currencyRepository.getLatestDataByCurrencyCode(code);
-        return MapEntry(code, currency?.value);
+        return MapEntry(code, _quotedRate(currency?.value));
       })),
     );
 
@@ -80,6 +88,12 @@ class CurrencyAlertsBloc extends BaseBloc {
     }
     if (triggeredAny) await loadAlerts();
   }
+
+  /// Converte o valor guardado em `Currency.value` na cotação exibida pelo
+  /// app. Valor ausente ou zerado não vira cotação nenhuma: dividir por zero
+  /// daria infinito, que atenderia qualquer alerta de "acima de".
+  double? _quotedRate(double? storedValue) =>
+      storedValue == null || storedValue == 0 ? null : 1 / storedValue;
 
   @override
   void dispose() {

--- a/test/blocs/currency_alerts_bloc_test.dart
+++ b/test/blocs/currency_alerts_bloc_test.dart
@@ -12,10 +12,13 @@ void main() {
   late FakeCurrencyDao currencyDao;
   late FakeNotificationService notificationService;
 
-  CurrencyAlertsBloc buildBloc({double currencyValue = 5.5}) {
+  /// [quotedRate] é a cotação na convenção que o usuário vê e digita no alerta
+  /// (quantos reais vale um dólar). O banco guarda o inverso disso, como faz o
+  /// CurrencyRepository.
+  CurrencyAlertsBloc buildBloc({double quotedRate = 5.5}) {
     currencyDao.latestCurrency = Currency(
         id: "USD",
-        value: currencyValue,
+        value: 1 / quotedRate,
         historicalDate: DateTime.now().toIso8601String(),
         timestamp: DateTime.now().toIso8601String(),
         friendlyName: "Dólar dos Estados Unidos");
@@ -85,21 +88,51 @@ void main() {
   group('CurrencyAlertsBloc.checkAlerts', () {
     test('dispara notificação e marca como disparado quando a condição é atendida',
         () async {
-      var bloc = buildBloc(currencyValue: 5.5);
+      var bloc = buildBloc(quotedRate: 5.5);
       await bloc.addAlert("USD", 5.0, CurrencyAlertCondition.above);
 
       await bloc.checkAlerts(
           notificationTitle: "Alerta",
-          notificationBody: (alert, value) => "${alert.currencyCode} $value");
+          notificationBody: (alert, value) =>
+              "${alert.currencyCode} ${value.toStringAsFixed(2)}");
 
       expect(alertRepository.alerts.single.triggered, isTrue);
       expect(notificationService.shown, hasLength(1));
       expect(notificationService.shown.single['title'], "Alerta");
-      expect(notificationService.shown.single['body'], "USD 5.5");
+      expect(notificationService.shown.single['body'], "USD 5.50");
+    });
+
+    test('avisa a cotação na mesma convenção da tela, e não o seu inverso',
+        () async {
+      var bloc = buildBloc(quotedRate: 5.5);
+      await bloc.addAlert("USD", 5.0, CurrencyAlertCondition.above);
+      double? reportedValue;
+
+      await bloc.checkAlerts(
+          notificationTitle: "Alerta",
+          notificationBody: (alert, value) {
+            reportedValue = value;
+            return "";
+          });
+
+      expect(reportedValue, closeTo(5.5, 0.0001));
+    });
+
+    test('não dispara "abaixo de" com a cotação acima do alvo', () async {
+      // O valor guardado para uma cotação de 5,50 é 0,1818: comparar direto com
+      // ele faria este alerta disparar na hora, com a relação invertida.
+      var bloc = buildBloc(quotedRate: 5.5);
+      await bloc.addAlert("USD", 5.0, CurrencyAlertCondition.below);
+
+      await bloc.checkAlerts(
+          notificationTitle: "Alerta", notificationBody: (alert, value) => "");
+
+      expect(alertRepository.alerts.single.triggered, isFalse);
+      expect(notificationService.shown, isEmpty);
     });
 
     test('não dispara quando a condição não é atendida', () async {
-      var bloc = buildBloc(currencyValue: 4.0);
+      var bloc = buildBloc(quotedRate: 4.0);
       await bloc.addAlert("USD", 5.0, CurrencyAlertCondition.above);
 
       await bloc.checkAlerts(
@@ -110,7 +143,7 @@ void main() {
     });
 
     test('ignora alertas já disparados', () async {
-      var bloc = buildBloc(currencyValue: 5.5);
+      var bloc = buildBloc(quotedRate: 5.5);
       await bloc.addAlert("USD", 5.0, CurrencyAlertCondition.above);
       alertRepository.alerts.single.triggered = true;
 
@@ -121,7 +154,7 @@ void main() {
     });
 
     test('ignora alertas inativos', () async {
-      var bloc = buildBloc(currencyValue: 5.5);
+      var bloc = buildBloc(quotedRate: 5.5);
       await bloc.addAlert("USD", 5.0, CurrencyAlertCondition.above);
       alertRepository.alerts.single.active = false;
 


### PR DESCRIPTION
## O problema

Na tela de alertas de câmbio, o valor reportado na notificação vinha com a relação entre as moedas invertida — e, junto com ele, a própria comparação que decide se o alerta dispara.

`CurrencyRepository` grava em `Currency.value` o **inverso** do `bid` da API (quantas unidades da moeda valem uma unidade da contrapartida — para USD-BRL a 5,50, guarda 0,1818); isso está documentado na própria classe. Todas as telas desfazem essa inversão ao exibir: a bolha da tela inicial mostra `1 / value` (`lib/view/widgets/exchange_rate_value.dart:89`) e a série do gráfico converte cada ponto do mesmo jeito (`lib/model/asset_series.dart:78`).

`CurrencyAlertsBloc.checkAlerts` era a exceção: comparava o alvo do alerta e montava o corpo da notificação com o número guardado, sem inverter. Como o alvo é digitado na convenção que aparece na tela, o efeito era:

- "USD **acima** de 5,00" nunca disparava (0,1818 nunca passa de 5);
- "USD **abaixo** de 5,00" disparava já na primeira checagem, com a cotação real bem acima do alvo;
- quando algo disparava, a notificação anunciava `0,1818` no lugar de `5,50`.

## A correção

`checkAlerts` passa a converter a cotação para a convenção da tela antes de comparar e de avisar. Valor ausente ou zerado não vira cotação nenhuma: dividir por zero daria infinito, que atenderia qualquer alerta de "acima de".

A mudança fica contida no bloc — o valor digitado no diálogo, o que o cartão do alerta mostra e o texto da notificação já estavam todos na mesma convenção; só faltava a cotação chegar nela.

## Testes

Os testes do bloc traziam a mesma confusão embutida: davam `5.5` como valor **guardado** e esperavam o disparo de "acima de 5,0". Agora montam o cenário pela cotação exibida e guardam o inverso dela, como faz o repositório.

Dois casos novos, que falham sem a correção:

- o valor passado para a notificação é a cotação da tela, e não o seu inverso;
- "abaixo de 5,00" não dispara com a cotação em 5,50.

Verificado com Flutter 3.47.0 (stable):

- os 3 testes novos/ajustados falham revertendo apenas o bloc, e passam com a correção;
- `flutter test`: **605 testes, todos passando**;
- `flutter analyze` nos arquivos alterados: sem problemas.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PPejDjqF9ph2uDEphQjBMv)_