### PR TITLE
Guarda a contrapartida no alerta de câmbio

### DIFF
--- a/lib/blocs/currency_alerts_bloc.dart
+++ b/lib/blocs/currency_alerts_bloc.dart
@@ -30,12 +30,22 @@ class CurrencyAlertsBloc extends BaseBloc {
     _alertsStreamController.sink.add(await _currencyAlertRepository.getAll());
   }
 
+  /// Moeda em que os alvos digitados agora estão expressos: a contrapartida
+  /// escolhida nas configurações. Não é guardada em cache porque esta tela
+  /// coexiste com a de opções no IndexedStack — a escolha pode mudar sem que o
+  /// bloc seja recriado.
+  Future<String> get counterCurrencyCode =>
+      _currencyRepository.resolveCounterCurrency();
+
+  /// Cadastra um alerta com a contrapartida em vigor agora, que passa a fazer
+  /// parte dele: é ela que dá sentido ao alvo digitado.
   Future<void> addAlert(String currencyCode, double targetValue,
       CurrencyAlertCondition condition) async {
     await _currencyAlertRepository.insert(CurrencyAlert(
         currencyCode: currencyCode,
         targetValue: targetValue,
-        condition: condition));
+        condition: condition,
+        counterCurrency: await counterCurrencyCode));
     await loadAlerts();
   }
 
@@ -55,6 +65,10 @@ class CurrencyAlertsBloc extends BaseBloc {
   /// o alvo do alerta é digitado, então comparar direto com o valor guardado
   /// invertia a relação: um alerta de "USD acima de 5,00" nunca disparava, e o
   /// aviso reportaria 0,1818 no lugar de 5,50.
+  ///
+  /// Cada alerta é conferido contra a contrapartida que ele guarda, e não
+  /// contra a escolhida agora nas configurações: um alvo digitado em reais
+  /// continua sendo lido em reais depois de o app passar a cotar em euros.
   Future<void> checkAlerts(
       {required String notificationTitle,
       required String Function(CurrencyAlert alert, double value)
@@ -64,19 +78,23 @@ class CurrencyAlertsBloc extends BaseBloc {
         alerts.where((alert) => alert.active && !alert.triggered).toList();
     if (pendingAlerts.isEmpty) return;
 
-    // Vários alertas costumam ser da mesma moeda: busca cada código uma única
-    // vez, e em paralelo, em vez de uma consulta sequencial por alerta.
-    var currencyCodes = pendingAlerts.map((alert) => alert.currencyCode).toSet();
-    var latestValueByCode = Map.fromEntries(
-      await Future.wait(currencyCodes.map((code) async {
-        var currency = await _currencyRepository.getLatestDataByCurrencyCode(code);
-        return MapEntry(code, _quotedRate(currency?.value));
+    // Vários alertas costumam ser do mesmo par: busca cada um uma única vez, e
+    // em paralelo, em vez de uma consulta sequencial por alerta. A chave é o
+    // par inteiro — a mesma moeda cotada frente a contrapartidas diferentes dá
+    // cotações diferentes.
+    var pairs = pendingAlerts.map(_pairOf).toSet();
+    var latestValueByPair = Map.fromEntries(
+      await Future.wait(pairs.map((pair) async {
+        var currency = await _currencyRepository.getLatestDataByCurrencyCode(
+            pair.currencyCode,
+            counterCurrency: pair.counterCurrency);
+        return MapEntry(pair, _quotedRate(currency?.value));
       })),
     );
 
     var triggeredAny = false;
     for (var alert in pendingAlerts) {
-      var value = latestValueByCode[alert.currencyCode];
+      var value = latestValueByPair[_pairOf(alert)];
       if (value == null || !alert.isMetBy(value)) continue;
       alert.triggered = true;
       await _currencyAlertRepository.update(alert);
@@ -88,6 +106,14 @@ class CurrencyAlertsBloc extends BaseBloc {
     }
     if (triggeredAny) await loadAlerts();
   }
+
+  /// O par cotado de um alerta, usado para agrupar as consultas.
+  ({String currencyCode, String counterCurrency}) _pairOf(
+          CurrencyAlert alert) =>
+      (
+        currencyCode: alert.currencyCode,
+        counterCurrency: alert.counterCurrency
+      );
 
   /// Converte o valor guardado em `Currency.value` na cotação exibida pelo
   /// app. Valor ausente ou zerado não vira cotação nenhuma: dividir por zero

--- a/lib/dao/currency_alert_dao.dart
+++ b/lib/dao/currency_alert_dao.dart
@@ -10,6 +10,7 @@ class CurrencyAlertDao {
     "currencyCode",
     "targetValue",
     "condition",
+    "counterCurrency",
     "triggered",
     "active"
   ];
@@ -56,6 +57,7 @@ class CurrencyAlertDao {
       currencyCode: row["currencyCode"] as String,
       targetValue: (row["targetValue"] as num).toDouble(),
       condition: CurrencyAlertCondition.values.byName(row["condition"] as String),
+      counterCurrency: row["counterCurrency"] as String,
       triggered: row["triggered"] == 1,
       active: row["active"] == 1,
     );

--- a/lib/model/currency_alert.dart
+++ b/lib/model/currency_alert.dart
@@ -9,11 +9,21 @@ class CurrencyAlert extends BaseModel {
   bool triggered;
   bool active;
 
+  /// Moeda em que [targetValue] está expresso: a contrapartida do par cotado.
+  /// "USD acima de 5,00" só quer dizer alguma coisa junto dela — cinco reais e
+  /// cinco euros são alvos diferentes.
+  ///
+  /// Fica gravada no alerta, e não lida das configurações na hora da checagem,
+  /// para que trocar a moeda de referência não mude por baixo do pano o que um
+  /// alerta já cadastrado significa.
+  String counterCurrency;
+
   CurrencyAlert(
       {this.id,
       required this.currencyCode,
       required this.targetValue,
       required this.condition,
+      required this.counterCurrency,
       this.triggered = false,
       this.active = true});
 
@@ -30,6 +40,7 @@ class CurrencyAlert extends BaseModel {
       'currencyCode': currencyCode,
       'targetValue': targetValue,
       'condition': condition.name,
+      'counterCurrency': counterCurrency,
       'triggered': triggered ? 1 : 0,
       'active': active ? 1 : 0,
     };
@@ -42,6 +53,7 @@ class CurrencyAlert extends BaseModel {
         "currencyCode: $currencyCode,\n"
         "targetValue: $targetValue,\n"
         "condition: $condition,\n"
+        "counterCurrency: $counterCurrency,\n"
         "triggered: $triggered,\n"
         "active: $active,\n"
         "}";

--- a/lib/repository/currency_repository.dart
+++ b/lib/repository/currency_repository.dart
@@ -131,18 +131,26 @@ class CurrencyRepository {
     return friendlyCurrencyNamesMap;
   }
 
-  Future<Currency?> getLatestDataByCurrencyCode(String? currencyCode) async {
+  /// Última cotação de [currencyCode].
+  ///
+  /// [counterCurrency] cota a moeda frente a uma contrapartida específica, em
+  /// vez da escolhida nas configurações. É o que os alertas de câmbio pedem:
+  /// cada um guarda a moeda em que seu alvo foi digitado e precisa continuar
+  /// sendo avaliado contra ela, mesmo depois de a referência do app mudar.
+  Future<Currency?> getLatestDataByCurrencyCode(String? currencyCode,
+      {String? counterCurrency}) async {
     var networkAvailable = await _networkUtils.isNetworkAvailable();
-    var counterCurrency = await resolveCounterCurrency();
+    var pairCounterCurrency = counterCurrency ?? await resolveCounterCurrency();
     // A busca é pelo par, e não só pela moeda cotada: trocar a contrapartida
     // nas configurações precisa provocar uma consulta nova, mesmo que exista
     // uma cotação recente da mesma moeda frente à contrapartida anterior.
     var savedCurrency = await _currencyDao.getLatestDataByCurrencyCode(
-        currencyCode, counterCurrency);
+        currencyCode, pairCounterCurrency);
     if (networkAvailable &&
         (savedCurrency == null ||
             !_isCurrencyTimestampValid(savedCurrency.timestamp))) {
-      var newCurrency = await _fetchLatestQuote(currencyCode);
+      var newCurrency =
+          await _fetchLatestQuote(currencyCode, pairCounterCurrency);
       // Sem cotação nova (resposta inesperada, par inexistente), o que já está
       // salvo continua valendo: gravar um registro sem valor esconderia a
       // última cotação boa pela hora seguinte.
@@ -162,9 +170,9 @@ class CurrencyRepository {
     }
   }
 
-  Future<Currency?> _fetchLatestQuote(String? currencyCode) async {
+  Future<Currency?> _fetchLatestQuote(
+      String? currencyCode, String counterCurrency) async {
     if (currencyCode == null || currencyCode.isEmpty) return null;
-    var counterCurrency = await resolveCounterCurrency();
     // Uma moeda cotada contra ela mesma vale exatamente uma unidade; a API não
     // tem esse par.
     if (currencyCode == counterCurrency) {

--- a/lib/util/database.dart
+++ b/lib/util/database.dart
@@ -92,6 +92,19 @@ class AppDatabase {
     "ALTER TABLE Configurations ADD languageCode TEXT NOT NULL DEFAULT ''"
   ];
 
+  // Um alerta guarda um alvo numérico ("USD acima de 5,00"), e esse número só
+  // significa alguma coisa junto da moeda em que ele foi digitado. A tabela não
+  // guardava essa contrapartida: quem trocasse a moeda de referência nas
+  // configurações passava a ter os alertas antigos avaliados contra o par novo,
+  // com o alvo pensado para o antigo. A contrapartida passa a ser parte do
+  // alerta.
+  //
+  // Os alertas já cadastrados são migrados como BRL, a contrapartida padrão do
+  // app — a mesma escolha da migração 6→7 para a tabela de cotações.
+  var migrationsScripts9_10 = [
+    "ALTER TABLE CurrencyAlerts ADD counterCurrency TEXT NOT NULL DEFAULT 'BRL'"
+  ];
+
   /// Scripts a aplicar para chegar em cada versão, na ordem.
   Map<int, List<String>> get _migrationsByVersion => {
         2: migrationsScripts1_2,
@@ -102,6 +115,7 @@ class AppDatabase {
         7: migrationsScripts6_7,
         8: migrationsScripts7_8,
         9: migrationsScripts8_9,
+        10: migrationsScripts9_10,
       };
 
   /// A abertura em andamento. Guardar o Future (e não só o Database pronto) é o
@@ -124,7 +138,7 @@ class AppDatabase {
         await db.execute(
             "CREATE TABLE Configurations(id INT PRIMARY KEY, overrideDefaultCurrency INTEGER, selectedOverrideCurrencyCode TEXT, homeCurrencyCodes TEXT NOT NULL DEFAULT '', languageCode TEXT NOT NULL DEFAULT '')");
         await db.execute(
-            "CREATE TABLE CurrencyAlerts(id INTEGER PRIMARY KEY AUTOINCREMENT, currencyCode TEXT NOT NULL, targetValue REAL NOT NULL, condition TEXT NOT NULL, triggered INTEGER NOT NULL DEFAULT 0, active INTEGER NOT NULL DEFAULT 1)");
+            "CREATE TABLE CurrencyAlerts(id INTEGER PRIMARY KEY AUTOINCREMENT, currencyCode TEXT NOT NULL, targetValue REAL NOT NULL, condition TEXT NOT NULL, counterCurrency TEXT NOT NULL DEFAULT 'BRL', triggered INTEGER NOT NULL DEFAULT 0, active INTEGER NOT NULL DEFAULT 1)");
       }, onUpgrade: (database, oldVersion, newVersion) async {
         // Aplica todas as versões intermediárias, uma de cada vez: quem estava
         // na versão 1 precisa passar por 2, 3 e 4 antes de chegar na 5.
@@ -133,7 +147,7 @@ class AppDatabase {
             await database.execute(script);
           }
         }
-      }, version: 9);
+      }, version: 10);
     return _database;
   }
 }

--- a/lib/view/pages/home.dart
+++ b/lib/view/pages/home.dart
@@ -251,9 +251,14 @@ class HomeState extends State<Home> with TickerProviderStateMixin {
     final _localization = MyAppLocalizations.of(context)!;
     _alertsBloc.checkAlerts(
       notificationTitle: _localization.currencyAlertNotificationTitle!,
+      // A cotação vai com a contrapartida do próprio alerta: "USD atingiu
+      // 5,5000" fica ambíguo para quem cadastrou alertas frente a moedas
+      // diferentes.
       notificationBody: (alert, value) => sprintf(
-          _localization.currencyAlertNotificationBody!,
-          [alert.currencyCode, value.toStringAsFixed(4)]),
+          _localization.currencyAlertNotificationBody!, [
+        alert.currencyCode,
+        "${value.toStringAsFixed(4)} ${alert.counterCurrency}"
+      ]),
     );
   }
 

--- a/lib/view/pages/main_menu_items/currency_alerts_page.dart
+++ b/lib/view/pages/main_menu_items/currency_alerts_page.dart
@@ -38,7 +38,7 @@ class _CurrencyAlertsPageState extends State<CurrencyAlertsPage> {
         // Ver a nota no FAB da home: as duas telas coexistem no IndexedStack.
         heroTag: "addCurrencyAlertFab",
         onPressed: () =>
-            _showAddAlertDialog(context, _bloc, _localization, _currencyList),
+            _openAddAlertDialog(context, _bloc, _localization, _currencyList),
         label: Text(_localization.addCurrencyAlertBtnLabel!),
         icon: const Icon(Icons.add_alert),
       ),
@@ -152,8 +152,24 @@ class _CurrencyAlertsPageState extends State<CurrencyAlertsPage> {
     );
   }
 
-  void _showAddAlertDialog(BuildContext context, CurrencyAlertsBloc bloc,
-      MyAppLocalizations localization, List<String> currencyList) {
+  /// Resolve a contrapartida antes de abrir o diálogo, em vez de deixar a tela
+  /// guardá-la: esta página fica montada ao lado da de opções no IndexedStack,
+  /// então a escolha pode ter mudado desde o último build. Ler na hora do toque
+  /// garante que o alerta nasça com a moeda que o rótulo mostrou.
+  Future<void> _openAddAlertDialog(BuildContext context, CurrencyAlertsBloc bloc,
+      MyAppLocalizations localization, List<String> currencyList) async {
+    var counterCurrency = await bloc.counterCurrencyCode;
+    if (!context.mounted) return;
+    _showAddAlertDialog(
+        context, bloc, localization, currencyList, counterCurrency);
+  }
+
+  void _showAddAlertDialog(
+      BuildContext context,
+      CurrencyAlertsBloc bloc,
+      MyAppLocalizations localization,
+      List<String> currencyList,
+      String counterCurrency) {
     var selectedCurrency = currencyList.first;
     var selectedCondition = CurrencyAlertCondition.above;
     var targetValueController = TextEditingController();
@@ -213,7 +229,11 @@ class _CurrencyAlertsPageState extends State<CurrencyAlertsPage> {
                     keyboardType:
                         const TextInputType.numberWithOptions(decimal: true),
                     decoration: InputDecoration(
-                      labelText: localization.currencyAlertTargetValueLabel,
+                      // O alvo é um número solto ("5,00"): sem a moeda em que
+                      // ele é lido, não dá para saber o que se está pedindo.
+                      labelText:
+                          "${localization.currencyAlertTargetValueLabel} "
+                          "($counterCurrency)",
                       errorText: errorText,
                       border: OutlineInputBorder(
                         borderRadius:
@@ -306,7 +326,8 @@ class _AlertCard extends StatelessWidget {
               children: [
                 Text(
                   "${alert.currencyCode} $conditionLabel "
-                  "${alert.targetValue.toStringAsFixed(4)}",
+                  "${alert.targetValue.toStringAsFixed(4)} "
+                  "${alert.counterCurrency}",
                   style: TextStyle(
                     fontSize: 15 * scale,
                     fontWeight: FontWeight.w600,

--- a/test/blocs/currency_alerts_bloc_test.dart
+++ b/test/blocs/currency_alerts_bloc_test.dart
@@ -2,6 +2,7 @@ import 'package:cotacao_direta/blocs/currency_alerts_bloc.dart';
 import 'package:cotacao_direta/enums/currency_alert_condition.dart';
 import 'package:cotacao_direta/model/currency.dart';
 import 'package:cotacao_direta/model/currency_alert.dart';
+import 'package:cotacao_direta/model/configuration.dart';
 import 'package:cotacao_direta/repository/currency_repository.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -12,21 +13,33 @@ void main() {
   late FakeCurrencyDao currencyDao;
   late FakeNotificationService notificationService;
 
-  /// [quotedRate] é a cotação na convenção que o usuário vê e digita no alerta
-  /// (quantos reais vale um dólar). O banco guarda o inverso disso, como faz o
+  /// Cotação guardada no banco para um par, montada a partir de [quotedRate] —
+  /// a cotação na convenção que o usuário vê e digita no alerta (quantos reais
+  /// vale um dólar). O banco guarda o inverso disso, como faz o
   /// CurrencyRepository.
-  CurrencyAlertsBloc buildBloc({double quotedRate = 5.5}) {
-    currencyDao.latestCurrency = Currency(
-        id: "USD",
-        value: 1 / quotedRate,
-        historicalDate: DateTime.now().toIso8601String(),
-        timestamp: DateTime.now().toIso8601String(),
-        friendlyName: "Dólar dos Estados Unidos");
+  Currency storedQuote(double quotedRate) => Currency(
+      id: "USD",
+      value: 1 / quotedRate,
+      historicalDate: DateTime.now().toIso8601String(),
+      timestamp: DateTime.now().toIso8601String(),
+      friendlyName: "Dólar dos Estados Unidos");
+
+  /// [counterCurrency] é a contrapartida escolhida nas configurações, que é a
+  /// que os alertas criados daqui em diante recebem.
+  CurrencyAlertsBloc buildBloc(
+      {double quotedRate = 5.5, String? counterCurrency}) {
+    currencyDao.latestCurrency = storedQuote(quotedRate);
+    var configuration = Configuration(1);
+    if (counterCurrency != null) {
+      configuration.overrideDefaultCurrency = true;
+      configuration.selectedOverrideCurrencyCode = counterCurrency;
+    }
     return CurrencyAlertsBloc(
         currencyAlertRepository: alertRepository,
         currencyRepository: CurrencyRepository.withDependencies(
             currencyDao: currencyDao,
-            configurationRepository: FakeConfigurationRepository(),
+            configurationRepository:
+                FakeConfigurationRepository(configuration: configuration),
             networkUtils: FakeNetworkUtils(available: false)),
         notificationService: notificationService);
   }
@@ -42,7 +55,8 @@ void main() {
       alertRepository.alerts.add(CurrencyAlert(
           currencyCode: "USD",
           targetValue: 5.0,
-          condition: CurrencyAlertCondition.above));
+          condition: CurrencyAlertCondition.above,
+          counterCurrency: "BRL"));
       var bloc = buildBloc();
       var received = bloc.alertsStream.first;
 
@@ -61,6 +75,22 @@ void main() {
       expect(alertRepository.alerts, hasLength(1));
       expect(alertRepository.alerts.single.currencyCode, "USD");
       expect(alertRepository.alerts.single.targetValue, 5.0);
+    });
+
+    test('grava a contrapartida em vigor no alerta', () async {
+      var bloc = buildBloc(counterCurrency: "EUR");
+
+      await bloc.addAlert("USD", 5.0, CurrencyAlertCondition.above);
+
+      expect(alertRepository.alerts.single.counterCurrency, "EUR");
+    });
+
+    test('usa BRL quando nenhuma contrapartida foi escolhida', () async {
+      var bloc = buildBloc();
+
+      await bloc.addAlert("USD", 5.0, CurrencyAlertCondition.above);
+
+      expect(alertRepository.alerts.single.counterCurrency, "BRL");
     });
 
     test('atualiza a stream depois de adicionar', () async {
@@ -140,6 +170,74 @@ void main() {
 
       expect(alertRepository.alerts.single.triggered, isFalse);
       expect(notificationService.shown, isEmpty);
+    });
+
+    test('confere o alerta contra a contrapartida que ele guarda, e não contra a '
+        'escolhida nas configurações', () async {
+      // O alerta nasceu frente ao real; depois disso o app passou a cotar em
+      // euros. Ler o alvo em euros mudaria o que o alerta quer dizer.
+      var bloc = buildBloc(counterCurrency: "EUR");
+      alertRepository.alerts.add(CurrencyAlert(
+          id: 1,
+          currencyCode: "USD",
+          targetValue: 5.0,
+          condition: CurrencyAlertCondition.above,
+          counterCurrency: "BRL"));
+
+      await bloc.checkAlerts(
+          notificationTitle: "Alerta", notificationBody: (alert, value) => "");
+
+      expect(currencyDao.latestDataCounterCurrencies, ["BRL"]);
+    });
+
+    test('consulta um par por vez quando os alertas têm contrapartidas '
+        'diferentes', () async {
+      var bloc = buildBloc();
+      currencyDao.latestCurrencyByPair.addAll({
+        // Frente ao real o dólar já passou do alvo; frente ao euro, não.
+        "USD-BRL": storedQuote(5.5),
+        "USD-EUR": storedQuote(0.9),
+      });
+      alertRepository.alerts.addAll([
+        CurrencyAlert(
+            id: 1,
+            currencyCode: "USD",
+            targetValue: 5.0,
+            condition: CurrencyAlertCondition.above,
+            counterCurrency: "BRL"),
+        CurrencyAlert(
+            id: 2,
+            currencyCode: "USD",
+            targetValue: 5.0,
+            condition: CurrencyAlertCondition.above,
+            counterCurrency: "EUR"),
+      ]);
+
+      await bloc.checkAlerts(
+          notificationTitle: "Alerta",
+          notificationBody: (alert, value) =>
+              "${alert.currencyCode} ${value.toStringAsFixed(2)} "
+              "${alert.counterCurrency}");
+
+      expect(currencyDao.latestDataCounterCurrencies.toSet(), {"BRL", "EUR"});
+      expect(notificationService.shown, hasLength(1));
+      expect(notificationService.shown.single['body'], "USD 5.50 BRL");
+      expect(alertRepository.alerts.firstWhere((a) => a.id == 1).triggered,
+          isTrue);
+      expect(alertRepository.alerts.firstWhere((a) => a.id == 2).triggered,
+          isFalse);
+    });
+
+    test('consulta o par uma única vez quando vários alertas o compartilham',
+        () async {
+      var bloc = buildBloc(quotedRate: 4.0);
+      await bloc.addAlert("USD", 5.0, CurrencyAlertCondition.above);
+      await bloc.addAlert("USD", 6.0, CurrencyAlertCondition.above);
+
+      await bloc.checkAlerts(
+          notificationTitle: "Alerta", notificationBody: (alert, value) => "");
+
+      expect(currencyDao.latestDataCounterCurrencies, ["BRL"]);
     });
 
     test('ignora alertas já disparados', () async {

--- a/test/dao/currency_alert_dao_test.dart
+++ b/test/dao/currency_alert_dao_test.dart
@@ -10,6 +10,7 @@ CurrencyAlert _alert(String currencyCode,
         {int? id,
         double targetValue = 5.0,
         CurrencyAlertCondition condition = CurrencyAlertCondition.above,
+        String counterCurrency = "BRL",
         bool triggered = false,
         bool active = true}) =>
     CurrencyAlert(
@@ -17,6 +18,7 @@ CurrencyAlert _alert(String currencyCode,
         currencyCode: currencyCode,
         targetValue: targetValue,
         condition: condition,
+        counterCurrency: counterCurrency,
         triggered: triggered,
         active: active);
 
@@ -31,7 +33,7 @@ void main() {
 
   group('CurrencyAlertDao.insert', () {
     test('grava o alerta com todas as colunas', () async {
-      await dao.insert(_alert("USD", targetValue: 5.5));
+      await dao.insert(_alert("USD", targetValue: 5.5, counterCurrency: "EUR"));
 
       var db = (await AppDatabase().openAppDatabase())!;
       var row = (await db.query("CurrencyAlerts")).single;
@@ -39,6 +41,7 @@ void main() {
       expect(row["currencyCode"], "USD");
       expect(row["targetValue"], 5.5);
       expect(row["condition"], "above");
+      expect(row["counterCurrency"], "EUR");
       expect(row["triggered"], 0);
       expect(row["active"], 1);
     });

--- a/test/helpers/fakes.dart
+++ b/test/helpers/fakes.dart
@@ -34,6 +34,12 @@ class FakeCurrencyDao implements CurrencyDao {
   Currency? currencyByCode;
   List<Currency> historicalData = [];
 
+  /// Cotações por par, na chave "MOEDA-CONTRAPARTIDA" ("USD-BRL"), para os
+  /// testes que precisam de mais de um par ao mesmo tempo. Enquanto o mapa
+  /// estiver vazio vale [latestCurrency]; a partir do momento em que ele é
+  /// preenchido, um par ausente não tem cotação nenhuma.
+  final Map<String, Currency> latestCurrencyByPair = {};
+
   @override
   Future<void> insert(Currency currency) async => inserted.add(currency);
 
@@ -47,6 +53,8 @@ class FakeCurrencyDao implements CurrencyDao {
   Future<Currency?> getLatestDataByCurrencyCode(
       String? currencyCode, String counterCurrency) async {
     latestDataCounterCurrencies.add(counterCurrency);
+    if (latestCurrencyByPair.isNotEmpty)
+      return latestCurrencyByPair["$currencyCode-$counterCurrency"];
     // Uma cotação salva só serve para o par que a originou: devolvê-la para
     // outra contrapartida é justamente o bug que o registro do par evita.
     if (latestCurrency?.counterCurrency != null &&
@@ -104,7 +112,8 @@ class FakeCurrencyRepository implements CurrencyRepository {
   }
 
   @override
-  Future<Currency?> getLatestDataByCurrencyCode(String? currencyCode) async =>
+  Future<Currency?> getLatestDataByCurrencyCode(String? currencyCode,
+          {String? counterCurrency}) async =>
       latestCurrency;
 
   @override

--- a/test/model/currency_alert_test.dart
+++ b/test/model/currency_alert_test.dart
@@ -10,7 +10,8 @@ void main() {
           CurrencyAlert(
               currencyCode: "USD",
               targetValue: 5.0,
-              condition: CurrencyAlertCondition.above),
+              condition: CurrencyAlertCondition.above,
+              counterCurrency: "BRL"),
           isA<BaseModel>());
     });
 
@@ -18,7 +19,8 @@ void main() {
       var alert = CurrencyAlert(
           currencyCode: "USD",
           targetValue: 5.0,
-          condition: CurrencyAlertCondition.above);
+          condition: CurrencyAlertCondition.above,
+          counterCurrency: "BRL");
 
       expect(alert.id, isNull);
       expect(alert.triggered, isFalse);
@@ -31,7 +33,8 @@ void main() {
         var alert = CurrencyAlert(
             currencyCode: "USD",
             targetValue: 5.0,
-            condition: CurrencyAlertCondition.above);
+            condition: CurrencyAlertCondition.above,
+            counterCurrency: "BRL");
 
         expect(alert.isMetBy(5.0), isTrue);
         expect(alert.isMetBy(5.5), isTrue);
@@ -42,7 +45,8 @@ void main() {
         var alert = CurrencyAlert(
             currencyCode: "USD",
             targetValue: 5.0,
-            condition: CurrencyAlertCondition.below);
+            condition: CurrencyAlertCondition.below,
+            counterCurrency: "BRL");
 
         expect(alert.isMetBy(5.0), isTrue);
         expect(alert.isMetBy(4.5), isTrue);
@@ -56,6 +60,7 @@ void main() {
               currencyCode: "EUR",
               targetValue: 6.2,
               condition: CurrencyAlertCondition.below,
+              counterCurrency: "EUR",
               triggered: true,
               active: false)
           .toMap();
@@ -65,6 +70,7 @@ void main() {
         'currencyCode': "EUR",
         'targetValue': 6.2,
         'condition': "below",
+        'counterCurrency': "EUR",
         'triggered': 1,
         'active': 0,
       });
@@ -75,12 +81,14 @@ void main() {
               id: 1,
               currencyCode: "GBP",
               targetValue: 7.0,
-              condition: CurrencyAlertCondition.above)
+              condition: CurrencyAlertCondition.above,
+              counterCurrency: "BRL")
           .toString();
 
       expect(text, contains("id: 1"));
       expect(text, contains("currencyCode: GBP"));
       expect(text, contains("targetValue: 7.0"));
+      expect(text, contains("counterCurrency: BRL"));
     });
   });
 }

--- a/test/repository/currency_alert_repository_test.dart
+++ b/test/repository/currency_alert_repository_test.dart
@@ -19,7 +19,8 @@ void main() {
       var alert = CurrencyAlert(
           currencyCode: "USD",
           targetValue: 5.0,
-          condition: CurrencyAlertCondition.above);
+          condition: CurrencyAlertCondition.above,
+          counterCurrency: "BRL");
 
       await repository.insert(alert);
 
@@ -31,7 +32,8 @@ void main() {
           id: 1,
           currencyCode: "USD",
           targetValue: 5.0,
-          condition: CurrencyAlertCondition.above);
+          condition: CurrencyAlertCondition.above,
+          counterCurrency: "BRL");
       dao.alerts.add(alert);
 
       alert.triggered = true;
@@ -45,7 +47,8 @@ void main() {
           id: 1,
           currencyCode: "USD",
           targetValue: 5.0,
-          condition: CurrencyAlertCondition.above));
+          condition: CurrencyAlertCondition.above,
+          counterCurrency: "BRL"));
 
       await repository.delete(1);
 
@@ -56,7 +59,8 @@ void main() {
       dao.alerts.add(CurrencyAlert(
           currencyCode: "USD",
           targetValue: 5.0,
-          condition: CurrencyAlertCondition.above));
+          condition: CurrencyAlertCondition.above,
+          counterCurrency: "BRL"));
 
       expect(await repository.getAll(), hasLength(1));
     });
@@ -66,11 +70,13 @@ void main() {
         CurrencyAlert(
             currencyCode: "USD",
             targetValue: 5.0,
-            condition: CurrencyAlertCondition.above),
+            condition: CurrencyAlertCondition.above,
+          counterCurrency: "BRL"),
         CurrencyAlert(
             currencyCode: "EUR",
             targetValue: 6.0,
-            condition: CurrencyAlertCondition.above),
+            condition: CurrencyAlertCondition.above,
+          counterCurrency: "BRL"),
       ]);
 
       var result = await repository.getActiveByCurrencyCode("USD");

--- a/test/util/database_test.dart
+++ b/test/util/database_test.dart
@@ -46,12 +46,12 @@ void main() {
       expect(identical(AppDatabase(), AppDatabase()), isTrue);
     });
 
-    test('abre o banco na versão 9', () async {
+    test('abre o banco na versão 10', () async {
       var db = await AppDatabase().openAppDatabase();
 
       expect(db, isNotNull);
       expect(db!.isOpen, isTrue);
-      expect(await db.getVersion(), 9);
+      expect(await db.getVersion(), 10);
     });
 
     test('reaproveita a mesma conexão em chamadas seguintes', () async {
@@ -139,6 +139,7 @@ void main() {
             "currencyCode",
             "targetValue",
             "condition",
+            "counterCurrency",
             "triggered",
             "active"
           ]));
@@ -162,7 +163,7 @@ void main() {
       expect(await reopened.query("Currency"), isEmpty);
     });
 
-    test('migra um banco da versão 1 até a 9, passando por todas as etapas',
+    test('migra um banco da versão 1 até a 10, passando por todas as etapas',
         () async {
       var path = await _createLegacyDatabase(version: 1, tables: [
         "CREATE TABLE Currency(id TEXT PRIMARY KEY, value REAL, timestamp TEXT)"
@@ -177,7 +178,7 @@ void main() {
 
       var db = (await AppDatabase().openAppDatabase())!;
 
-      expect(await db.getVersion(), 9);
+      expect(await db.getVersion(), 10);
       expect(await _columnsOf(db, "Currency"),
           containsAll(["historicalDate", "friendlyName"]));
       expect(await _columnsOf(db, "Configurations"),
@@ -192,12 +193,15 @@ void main() {
       expect(await _columnsOf(db, "Configurations"),
           containsAll(["languageCode"]),
           reason: "a etapa 8→9 não pode ser pulada");
+      expect(await _columnsOf(db, "CurrencyAlerts"),
+          containsAll(["counterCurrency"]),
+          reason: "a etapa 9→10 não pode ser pulada");
       var row = (await db.query("Currency")).single;
       expect(row["id"], "USD");
       expect(row["value"], 5.0);
     });
 
-    test('migra um banco da versão 4 para a 9 acrescentando o friendlyName e '
+    test('migra um banco da versão 4 para a 10 acrescentando o friendlyName e '
         'os alertas', () async {
       var path = await _createLegacyDatabase(version: 4, tables: [
         "CREATE TABLE Currency(id TEXT, value REAL, timestamp TEXT, historicalDate TEXT, PRIMARY KEY(id, historicalDate))",
@@ -214,7 +218,7 @@ void main() {
 
       var db = (await AppDatabase().openAppDatabase())!;
 
-      expect(await db.getVersion(), 9);
+      expect(await db.getVersion(), 10);
       var row = (await db.query("Currency")).single;
       expect(row["historicalDate"], "2024-01-01T00:00:00.000");
       expect(row["friendlyName"], "",
@@ -349,6 +353,34 @@ void main() {
           reason: "a configuração que já existia não pode se perder");
     });
 
+    test('a migração 9→10 marca os alertas existentes como sendo frente ao BRL',
+        () async {
+      var path = await _createLegacyDatabase(version: 9, tables: [
+        "CREATE TABLE Currency(id TEXT, historicalDate TEXT, value REAL, timestamp TEXT, friendlyName TEXT NOT NULL DEFAULT '', counterCurrency TEXT NOT NULL DEFAULT 'BRL', PRIMARY KEY(id, historicalDate, counterCurrency))",
+        "CREATE TABLE Configurations(id INT PRIMARY KEY, overrideDefaultCurrency INTEGER, selectedOverrideCurrencyCode TEXT, homeCurrencyCodes TEXT NOT NULL DEFAULT '', languageCode TEXT NOT NULL DEFAULT '')",
+        "CREATE TABLE CurrencyAlerts(id INTEGER PRIMARY KEY AUTOINCREMENT, currencyCode TEXT NOT NULL, targetValue REAL NOT NULL, condition TEXT NOT NULL, triggered INTEGER NOT NULL DEFAULT 0, active INTEGER NOT NULL DEFAULT 1)"
+      ], rows: {
+        "CurrencyAlerts": {
+          "id": 1,
+          "currencyCode": "USD",
+          "targetValue": 5.0,
+          "condition": "above",
+          "triggered": 0,
+          "active": 1
+        }
+      });
+      AppDatabase.databasePathOverride = path;
+
+      var db = (await AppDatabase().openAppDatabase())!;
+
+      var row = (await db.query("CurrencyAlerts")).single;
+      expect(row["counterCurrency"], "BRL",
+          reason: "o real era a contrapartida padrão antes da coluna existir");
+      expect(row["targetValue"], 5.0,
+          reason: "o alvo cadastrado não pode se perder");
+      expect(row["currencyCode"], "USD");
+    });
+
     test('os dados sobrevivem à reabertura quando o banco é um arquivo',
         () async {
       var directory =
@@ -366,7 +398,7 @@ void main() {
       await AppDatabase.reset();
 
       var reopened = (await AppDatabase().openAppDatabase())!;
-      expect(await reopened.getVersion(), 9,
+      expect(await reopened.getVersion(), 10,
           reason: "reabrir não deve disparar onCreate/onUpgrade de novo");
       expect((await reopened.query("Currency")).single["id"], "USD");
     });


### PR DESCRIPTION
Substitui a #55, que nasceu apontada para a branch da #54 (as duas mexiam em `checkAlerts`). Com a #54 mergeada, aquela branch foi apagada e o GitHub fechou a #55 automaticamente — e não deixa reabrir um PR cuja base não existe mais. Mesmo commit, rebaseado em `master`.

## O problema

Um alerta guardava só a moeda cotada e um alvo numérico. O número, sozinho, não diz nada: "USD acima de 5,00" é uma coisa em reais e outra em euros.

Como `checkAlerts` lia a contrapartida das configurações na hora de conferir, quem trocasse a moeda de referência passava a ter os alertas antigos avaliados contra o par novo, com o alvo pensado para o antigo. Um "USD acima de 5,00" criado frente ao real vira, depois da troca para euro, uma condição que dispara na primeira checagem — o dólar não chega perto de 5 euros, mas passa de 5 reais.

## A correção

A contrapartida passa a fazer parte do alerta, gravada no momento do cadastro:

- coluna `counterCurrency` na tabela `CurrencyAlerts` (**migração 9→10**), com os alertas já cadastrados migrados como `BRL` — a contrapartida padrão do app, a mesma escolha da migração 6→7 para a tabela de cotações;
- `checkAlerts` consulta cada alerta no par que ele guarda, agrupando as consultas **por par** em vez de por moeda: a mesma moeda frente a contrapartidas diferentes dá cotações diferentes;
- `getLatestDataByCurrencyCode` aceita uma contrapartida explícita, em vez de sempre resolver a das configurações (o comportamento sem o parâmetro não muda).

## Na tela

A moeda do alvo deixa de ser implícita:

- o campo do diálogo mostra em que moeda o valor é lido — `Valor alvo (BRL)`;
- o cartão do alerta mostra a contrapartida ao lado do alvo — `USD Subir acima de 5,0000 BRL`;
- a notificação avisa `USD atingiu 5,5000 BRL`.

A contrapartida do diálogo é resolvida no toque do botão, e não guardada na tela: esta página fica montada ao lado da de opções no `IndexedStack`, então a escolha pode mudar sem que a tela seja recriada.

## Testes

Seis casos novos:

- `addAlert` grava a contrapartida em vigor, e cai em `BRL` quando nenhuma foi escolhida;
- `checkAlerts` confere o alerta contra a contrapartida que ele guarda, e não contra a escolhida nas configurações;
- alertas do mesmo par ainda geram uma consulta só, e alertas de pares diferentes geram uma consulta por par — com só o alerta cujo alvo foi atingido disparando;
- a migração 9→10 marca os alertas existentes como frente ao `BRL`, sem perder o alvo cadastrado.

O `FakeCurrencyDao` ganhou um mapa de cotações por par, para os testes que precisam de mais de um par ao mesmo tempo.

Verificado com Flutter 3.47.0 (stable), já rebaseado em `master`: `flutter test` roda **611 testes, todos passando**; `flutter analyze` sem problemas.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PPejDjqF9ph2uDEphQjBMv)_