### PR TITLE
Confere os alertas em segundo plano no Android

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,9 @@
+import 'dart:async';
+
 import 'package:cotacao_direta/providers/currency_alerts_bloc_provider.dart';
 import 'package:cotacao_direta/providers/home_bloc_provider.dart';
 import 'package:cotacao_direta/util/app_locale_controller.dart';
+import 'package:cotacao_direta/util/background_alert_service.dart';
 import 'package:cotacao_direta/util/currency_colors.dart';
 import 'package:cotacao_direta/util/localizations.dart';
 import 'package:cotacao_direta/util/notification_service.dart';
@@ -14,6 +17,13 @@ void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   // Stetho.initialize();
   await NotificationService().initialize();
+  // Agendar (ou reagendar) a checagem em segundo plano não pode atrasar a
+  // abertura da tela, nem derrubá-la se o serviço do sistema recusar o
+  // agendamento: só o Android tem esta tarefa, e lá ela é um extra por cima da
+  // checagem que a tela já faz.
+  unawaited(startBackgroundAlertChecks().catchError((Object error) {
+    debugPrint("Falha ao agendar a checagem de alertas em segundo plano: $error");
+  }));
   // Antes do primeiro quadro: a tela já abre no idioma escolhido, em vez de
   // aparecer no do aparelho e trocar em seguida.
   await AppLocaleController.instance.load();

--- a/lib/util/background_alert_check.dart
+++ b/lib/util/background_alert_check.dart
@@ -1,0 +1,66 @@
+import 'dart:ui';
+
+import 'package:cotacao_direta/blocs/currency_alerts_bloc.dart';
+import 'package:cotacao_direta/model/currency_alert.dart';
+import 'package:cotacao_direta/repository/configuration_repository.dart';
+import 'package:cotacao_direta/util/localizations.dart';
+import 'package:sprintf/sprintf.dart';
+
+/// Texto da notificação de um alerta atingido.
+///
+/// Fica aqui, e não em cada chamador, porque a checagem acontece em dois
+/// lugares — a tela inicial, com o app aberto, e a tarefa de segundo plano do
+/// Android — e o aviso precisa sair igual nos dois. A cotação vai com a
+/// contrapartida do próprio alerta: "USD atingiu 5,5000" fica ambíguo para
+/// quem cadastrou alertas frente a moedas diferentes.
+String currencyAlertNotificationBody(
+        MyAppLocalizations localization, CurrencyAlert alert, double value) =>
+    sprintf(localization.currencyAlertNotificationBody!, [
+      alert.currencyCode,
+      "${value.toStringAsFixed(4)} ${alert.counterCurrency}"
+    ]);
+
+/// Idioma da notificação disparada fora da interface.
+///
+/// Sem árvore de widgets não há [MyAppLocalizations.of], então a escolha é
+/// refeita aqui do mesmo jeito que o MaterialApp faz: vale o idioma gravado
+/// nas configurações e, quando ele está vazio ("seguir o aparelho"), o do
+/// próprio aparelho.
+Future<Locale> resolveBackgroundLocale(
+    {ConfigurationRepository? configurationRepository,
+    Locale? deviceLocale}) async {
+  var configuration =
+      await (configurationRepository ?? ConfigurationRepository())
+          .getConfiguration();
+  var chosen = AppLocales.localeFor(configuration.languageCode);
+  if (chosen != null) return chosen;
+  return AppLocales.resolve(deviceLocale ?? PlatformDispatcher.instance.locale) ??
+      AppLocales.supported.first;
+}
+
+/// Confere os alertas uma vez, fora da interface, e notifica os que já foram
+/// atingidos.
+///
+/// É o corpo da tarefa periódica do Android. Mora fora do arquivo do plugin
+/// para poder ser exercitado nos testes sem WorkManager: o que interessa aqui
+/// — o idioma escolhido e o texto do aviso — não depende de quem agendou a
+/// execução.
+Future<void> runBackgroundAlertCheck(
+    {CurrencyAlertsBloc? alertsBloc,
+    ConfigurationRepository? configurationRepository,
+    Locale? deviceLocale}) async {
+  var bloc = alertsBloc ?? CurrencyAlertsBloc();
+  try {
+    var localization = MyAppLocalizations(await resolveBackgroundLocale(
+        configurationRepository: configurationRepository,
+        deviceLocale: deviceLocale));
+    await bloc.checkAlerts(
+        notificationTitle: localization.currencyAlertNotificationTitle!,
+        notificationBody: (alert, value) =>
+            currencyAlertNotificationBody(localization, alert, value));
+  } finally {
+    // Só descarta o que foi criado aqui: um bloc recebido pronto pertence a
+    // quem o passou (nos testes, ao próprio teste).
+    if (alertsBloc == null) bloc.dispose();
+  }
+}

--- a/lib/util/background_alert_service.dart
+++ b/lib/util/background_alert_service.dart
@@ -1,0 +1,15 @@
+import 'background_alert_service_io.dart'
+    if (dart.library.js_interop) 'background_alert_service_web.dart';
+
+/// Checagem periódica dos alertas de câmbio com o app fechado.
+///
+/// Existe só no Android, onde o WorkManager do sistema acorda o app de tempos
+/// em tempos. Nas outras plataformas os alertas continuam sendo conferidos
+/// quando a tela inicial busca cotações (ver `home.dart`):
+///
+/// - na web não há como rodar código periodicamente em segundo plano sem um
+///   servidor que envie os pushes — o Safari, em especial, não implementa
+///   Periodic Background Sync, então nem no PWA instalado isso existe;
+/// - no Linux Desktop o app só roda enquanto a janela está aberta.
+Future<void> startBackgroundAlertChecks() =>
+    startPlatformBackgroundAlertChecks();

--- a/lib/util/background_alert_service_io.dart
+++ b/lib/util/background_alert_service_io.dart
@@ -1,0 +1,59 @@
+import 'dart:io';
+
+import 'package:cotacao_direta/util/background_alert_check.dart';
+import 'package:cotacao_direta/util/notification_service.dart';
+import 'package:flutter/widgets.dart';
+import 'package:workmanager/workmanager.dart';
+
+/// Identifica a tarefa dentro do app; trocar este nome faz o WorkManager
+/// tratar o agendamento como outro, deixando o anterior para trás.
+const _uniqueName = "cotacao-direta-currency-alerts";
+
+/// Nome que chega ao [Workmanager.executeTask]. Há uma tarefa só, mas ele é o
+/// que permitiria distinguir outras no futuro.
+const _taskName = "currencyAlertsCheck";
+
+/// De quanto em quanto tempo o sistema acorda o app.
+///
+/// Uma hora acompanha a validade da cotação salva (ver `CurrencyRepository`):
+/// acordar com mais frequência releria o mesmo valor do banco, sem consultar a
+/// API, e só gastaria bateria. O WorkManager trata isto como um alvo, não uma
+/// promessa — ele agrupa as execuções e respeita o modo economia.
+const _frequency = Duration(hours: 1);
+
+/// Ponto de entrada da tarefa, chamado pelo sistema num isolate novo.
+///
+/// A anotação impede que a compilação AOT descarte a função: nada no código do
+/// app a chama, só o plugin, pelo nome.
+@pragma('vm:entry-point')
+void backgroundAlertCallbackDispatcher() {
+  Workmanager().executeTask((taskName, inputData) async {
+    // Isolate novo: nada do que o main() preparou existe aqui, então os canais
+    // de plataforma e as notificações precisam ser inicializados de novo.
+    WidgetsFlutterBinding.ensureInitialized();
+    await NotificationService().initialize();
+    await runBackgroundAlertCheck();
+    return true;
+  });
+}
+
+/// Agenda a checagem periódica no Android.
+///
+/// Fora do Android é um no-op: no Linux Desktop o app não fica em segundo
+/// plano, e chamar o plugin lá levantaria exceção por falta de implementação.
+Future<void> startPlatformBackgroundAlertChecks() async {
+  if (!Platform.isAndroid) return;
+  await Workmanager().initialize(backgroundAlertCallbackDispatcher);
+  await Workmanager().registerPeriodicTask(
+    _uniqueName,
+    _taskName,
+    frequency: _frequency,
+    // Sem rede não há cotação nova para comparar; deixar o sistema escolher a
+    // hora evita acordar o app para não fazer nada.
+    constraints: Constraints(networkType: NetworkType.connected),
+    // `update` mantém o agendamento que já existe em vez de recriá-lo a cada
+    // abertura do app — recriar reiniciaria a contagem, e um app aberto com
+    // frequência nunca chegaria a rodar a tarefa.
+    existingWorkPolicy: ExistingPeriodicWorkPolicy.update,
+  );
+}

--- a/lib/util/background_alert_service_web.dart
+++ b/lib/util/background_alert_service_web.dart
@@ -1,0 +1,3 @@
+/// Sem checagem em segundo plano na web: ver a nota em
+/// `background_alert_service.dart`.
+Future<void> startPlatformBackgroundAlertChecks() async {}

--- a/lib/view/pages/home.dart
+++ b/lib/view/pages/home.dart
@@ -7,6 +7,7 @@ import 'package:cotacao_direta/providers/conversion_page_bloc_provider.dart';
 import 'package:cotacao_direta/providers/currency_alerts_bloc_provider.dart';
 import 'package:cotacao_direta/providers/currency_history_menu_bloc_provider.dart';
 import 'package:cotacao_direta/providers/home_bloc_provider.dart';
+import 'package:cotacao_direta/util/background_alert_check.dart';
 import 'package:cotacao_direta/util/color_utils.dart';
 import 'package:cotacao_direta/util/currency_name.dart';
 import 'package:cotacao_direta/util/currency_visuals.dart';
@@ -251,14 +252,10 @@ class HomeState extends State<Home> with TickerProviderStateMixin {
     final _localization = MyAppLocalizations.of(context)!;
     _alertsBloc.checkAlerts(
       notificationTitle: _localization.currencyAlertNotificationTitle!,
-      // A cotação vai com a contrapartida do próprio alerta: "USD atingiu
-      // 5,5000" fica ambíguo para quem cadastrou alertas frente a moedas
-      // diferentes.
-      notificationBody: (alert, value) => sprintf(
-          _localization.currencyAlertNotificationBody!, [
-        alert.currencyCode,
-        "${value.toStringAsFixed(4)} ${alert.counterCurrency}"
-      ]),
+      // O mesmo texto da tarefa de segundo plano do Android: o aviso não pode
+      // mudar conforme o app estava aberto ou não.
+      notificationBody: (alert, value) =>
+          currencyAlertNotificationBody(_localization, alert, value),
     );
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -281,10 +281,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      sha256: "1ca20c894b1717686a2319b8548763d812bc0aabdac580420a44c5178c57a867"
       url: "https://pub.dev"
     source: hosted
-    version: "0.20.2"
+    version: "0.20.3"
   json_annotation:
     dependency: transitive
     description:
@@ -329,10 +329,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.20"
   material_color_utilities:
     dependency: transitive
     description:
@@ -345,10 +345,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   native_toolchain_c:
     dependency: transitive
     description:
@@ -582,10 +582,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.12"
   timezone:
     dependency: transitive
     description:
@@ -694,10 +694,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.2"
   vm_service:
     dependency: transitive
     description:
@@ -722,6 +722,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.15.0"
+  workmanager:
+    dependency: "direct main"
+    description:
+      name: workmanager
+      sha256: "06fc5bdd83e2da35f33b682e25167245d0ccb8b56e9a9ada5bfa079fa3af4b9c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.10.7"
+  workmanager_android:
+    dependency: transitive
+    description:
+      name: workmanager_android
+      sha256: f89029cbcf0695c772287aa8fbbd7af776f1ea63bc95b60a00617f69468ddaa0
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.10.6"
+  workmanager_apple:
+    dependency: transitive
+    description:
+      name: workmanager_apple
+      sha256: "15558fb54415a010910c3529eaf8f61f94d23903dac620331895c472602d6f6e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.10"
+  workmanager_linux:
+    dependency: transitive
+    description:
+      name: workmanager_linux
+      sha256: "7d8520e1103b910a43d8bafe37ec2415f4c7c148afcb1eee0ec73ae67b4cdd22"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.1+1"
+  workmanager_platform_interface:
+    dependency: transitive
+    description:
+      name: workmanager_platform_interface
+      sha256: "378b392db15ee88cd878ab983d3a0b4b1e460cfbb0f096ff74fda2614b1ba172"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.10.4"
+  workmanager_web:
+    dependency: transitive
+    description:
+      name: workmanager_web
+      sha256: "2ac481ade599bdd957ee2891be09a0c34be87923a2c3ca4dfe36add6fc735ffd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   # elas saem pela Notification API do navegador, sem pacote nenhum (ver
   # lib/util/notification_service_web.dart).
   flutter_local_notifications: ^19.0.0
+  workmanager: ^0.10.7
 
 dev_dependencies:
   flutter_launcher_icons: ^0.14.4

--- a/test/util/background_alert_check_test.dart
+++ b/test/util/background_alert_check_test.dart
@@ -1,0 +1,145 @@
+import 'dart:ui';
+
+import 'package:cotacao_direta/blocs/currency_alerts_bloc.dart';
+import 'package:cotacao_direta/enums/currency_alert_condition.dart';
+import 'package:cotacao_direta/model/configuration.dart';
+import 'package:cotacao_direta/model/currency.dart';
+import 'package:cotacao_direta/model/currency_alert.dart';
+import 'package:cotacao_direta/repository/currency_repository.dart';
+import 'package:cotacao_direta/util/background_alert_check.dart';
+import 'package:cotacao_direta/util/localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../helpers/fakes.dart';
+
+void main() {
+  late FakeCurrencyAlertRepository alertRepository;
+  late FakeCurrencyDao currencyDao;
+  late FakeNotificationService notificationService;
+
+  /// Guarda a cotação já na convenção do banco (o inverso da que o usuário vê,
+  /// ver CurrencyRepository).
+  CurrencyAlertsBloc buildBloc(
+      {double quotedRate = 5.5, required Configuration configuration}) {
+    currencyDao.latestCurrency = Currency(
+        id: "USD",
+        value: 1 / quotedRate,
+        historicalDate: DateTime.now().toIso8601String(),
+        timestamp: DateTime.now().toIso8601String(),
+        friendlyName: "Dólar dos Estados Unidos");
+    return CurrencyAlertsBloc(
+        currencyAlertRepository: alertRepository,
+        currencyRepository: CurrencyRepository.withDependencies(
+            currencyDao: currencyDao,
+            configurationRepository:
+                FakeConfigurationRepository(configuration: configuration),
+            networkUtils: FakeNetworkUtils(available: false)),
+        notificationService: notificationService);
+  }
+
+  setUp(() {
+    alertRepository = FakeCurrencyAlertRepository();
+    currencyDao = FakeCurrencyDao();
+    notificationService = FakeNotificationService();
+  });
+
+  group('currencyAlertNotificationBody', () {
+    test('leva a cotação junto da contrapartida do alerta', () {
+      var body = currencyAlertNotificationBody(
+          MyAppLocalizations(const Locale("pt")),
+          CurrencyAlert(
+              currencyCode: "USD",
+              targetValue: 5.0,
+              condition: CurrencyAlertCondition.above,
+              counterCurrency: "BRL"),
+          5.5);
+
+      expect(body, "USD atingiu 5.5000 BRL");
+    });
+  });
+
+  group('resolveBackgroundLocale', () {
+    test('usa o idioma escolhido nas configurações', () async {
+      var locale = await resolveBackgroundLocale(
+          configurationRepository: FakeConfigurationRepository(
+              configuration: Configuration(1, languageCode: "en")),
+          deviceLocale: const Locale("pt"));
+
+      expect(locale, const Locale("en"));
+    });
+
+    test('segue o aparelho quando nenhum idioma foi escolhido', () async {
+      var locale = await resolveBackgroundLocale(
+          configurationRepository: FakeConfigurationRepository(
+              configuration: Configuration(1, languageCode: "")),
+          deviceLocale: const Locale("pt"));
+
+      expect(locale, const Locale("pt"));
+    });
+
+    test('resolve a variante de espanhol pela região do aparelho', () async {
+      var locale = await resolveBackgroundLocale(
+          configurationRepository: FakeConfigurationRepository(
+              configuration: Configuration(1)),
+          deviceLocale: const Locale("es", "MX"));
+
+      expect(locale, const Locale("es", "419"));
+    });
+
+    test('cai no primeiro idioma da build quando o do aparelho não está nela',
+        () async {
+      var locale = await resolveBackgroundLocale(
+          configurationRepository: FakeConfigurationRepository(
+              configuration: Configuration(1)),
+          deviceLocale: const Locale("de"));
+
+      expect(locale, AppLocales.supported.first);
+    });
+  });
+
+  group('runBackgroundAlertCheck', () {
+    test('notifica o alerta atingido no idioma escolhido', () async {
+      var configuration = Configuration(1, languageCode: "pt");
+      var bloc = buildBloc(quotedRate: 5.5, configuration: configuration);
+      alertRepository.alerts.add(CurrencyAlert(
+          id: 1,
+          currencyCode: "USD",
+          targetValue: 5.0,
+          condition: CurrencyAlertCondition.above,
+          counterCurrency: "BRL"));
+
+      await runBackgroundAlertCheck(
+          alertsBloc: bloc,
+          configurationRepository:
+              FakeConfigurationRepository(configuration: configuration),
+          deviceLocale: const Locale("en"));
+
+      expect(notificationService.shown, hasLength(1));
+      expect(notificationService.shown.single['title'], "Alerta de câmbio");
+      expect(notificationService.shown.single['body'], "USD atingiu 5.5000 BRL");
+      expect(alertRepository.alerts.single.triggered, isTrue);
+      bloc.dispose();
+    });
+
+    test('não notifica quando nenhum alvo foi atingido', () async {
+      var configuration = Configuration(1);
+      var bloc = buildBloc(quotedRate: 4.0, configuration: configuration);
+      alertRepository.alerts.add(CurrencyAlert(
+          id: 1,
+          currencyCode: "USD",
+          targetValue: 5.0,
+          condition: CurrencyAlertCondition.above,
+          counterCurrency: "BRL"));
+
+      await runBackgroundAlertCheck(
+          alertsBloc: bloc,
+          configurationRepository:
+              FakeConfigurationRepository(configuration: configuration),
+          deviceLocale: const Locale("pt"));
+
+      expect(notificationService.shown, isEmpty);
+      expect(alertRepository.alerts.single.triggered, isFalse);
+      bloc.dispose();
+    });
+  });
+}


### PR DESCRIPTION
## O problema

Os alertas só eram conferidos com o app **aberto**: a tela inicial chama `checkAlerts` na carga (`home.dart:357`) e a cada atualização de cotações (`home.dart:160`), e é dali que a notificação nasce. Com o app fechado, nada rodava — em nenhuma plataforma. Foi o que apareceu ao testar no Safari, onde a notificação só chegou depois de abrir o web app.

## O que esta mudança faz

No Android dá para resolver sem servidor: o WorkManager do sistema acorda o app de tempos em tempos e roda a mesma checagem num isolate próprio.

- tarefa periódica **de hora em hora**, com `NetworkType.connected` — sem rede não há cotação nova para comparar, e deixar o sistema escolher a hora evita acordar o app à toa. A frequência acompanha a validade da cotação salva (`CurrencyRepository`): mais curta releria o mesmo valor do banco, sem consultar a API;
- `ExistingPeriodicWorkPolicy.update`, para o agendamento não ser recriado a cada abertura do app — recriar reiniciaria a contagem, e quem abre o app com frequência nunca chegaria a rodar a tarefa;
- o isolate é novo, então os canais de plataforma e as notificações são inicializados de novo dentro dele.

## Onde o código mora

O corpo da tarefa fica em `background_alert_check.dart`, **fora** do arquivo do plugin, para poder ser exercitado nos testes sem WorkManager. É lá também que passa a morar o texto da notificação, que antes era montado na tela inicial: a checagem acontece agora em dois lugares e o aviso não pode mudar conforme o app estava aberto ou não.

Sem árvore de widgets não existe `MyAppLocalizations.of`, então o idioma é resolvido do mesmo jeito que o `MaterialApp` faz — o escolhido nas configurações e, na falta dele, o do aparelho (incluindo a escolha entre as duas variantes de espanhol).

O agendamento é um no-op fora do Android, pelo mesmo esquema de importação condicional das notificações (`_io` / `_web`). Falhar ao agendar não derruba a partida do app: a chamada sai do `main` sem bloquear o primeiro quadro, com o erro apenas registrado.

## O que isto **não** resolve

Continua não havendo notificação com o app fechado na **web** — inclusive no Safari, que foi onde o problema apareceu. Não há como rodar código periodicamente em segundo plano sem um servidor que envie os pushes, e o Safari não implementa Periodic Background Sync, então nem no PWA instalado isso existe. Lá os alertas seguem sendo conferidos na abertura do app. Cobrir esse caso exigiria Web Push com backend (chaves VAPID, armazenamento de inscrições e os alertas saindo do aparelho), que é uma mudança de arquitetura à parte.

No Linux Desktop também não muda nada: o app só roda enquanto a janela está aberta.

## Efeito colateral a saber

O `workmanager_android` traz no manifesto dele `FOREGROUND_SERVICE` e `FOREGROUND_SERVICE_SHORT_SERVICE`, que passam a constar no APK mesmo sem o app usar serviço em primeiro plano. Nenhuma das duas é "special type" do Play Console (a `FOREGROUND_SERVICE_DATA_SYNC`, que é, fica de fora por padrão), mas vale saber que aparecem.

## Testes

Sete casos novos em `test/util/background_alert_check_test.dart`:

- o texto da notificação leva a cotação junto da contrapartida do alerta;
- o idioma sai das configurações quando escolhido, e do aparelho quando não;
- a variante de espanhol é resolvida pela região do aparelho (`es-MX` → `es-419`);
- idioma fora da build cai no primeiro da lista;
- a checagem notifica o alerta atingido no idioma certo, e não notifica quando nenhum alvo foi atingido.

Verificado com Flutter 3.47.0 (stable): `flutter test` roda **618 testes, todos passando**; `flutter analyze` sem problemas.

**Não consegui compilar o APK aqui** — o Android SDK não está instalado neste ambiente. Confirmei estaticamente o que costuma quebrar (o plugin pede `minSdk 23`/`compileSdk 35`, abaixo do que o projeto usa, e aplica o próprio `kotlin-android` com AGP 8.13), mas quem valida de fato é o job **Build Android** do CI — vou acompanhar e corrigir se ele acusar algo.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PPejDjqF9ph2uDEphQjBMv)_