### PR TITLE
fix(android): declara permissão INTERNET no manifest de release

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Sem esta permissão, o app funciona normalmente em builds debug/profile
+         (o Flutter injeta INTERNET automaticamente para hot reload, ver
+         android/app/src/debug/AndroidManifest.xml), mas todo acesso de rede
+         falha silenciosamente em release: sem cotação salva, a tela inicial
+         mostra o Real como "Sem Dados" e as conversões quebram. -->
+    <uses-permission android:name="android.permission.INTERNET"/>
     <!-- Necessária no Android 13+ para exibir a notificação dos alertas de
          câmbio; o app pede a permissão em tempo de execução (ver
          lib/util/notification_service_io.dart). -->


### PR DESCRIPTION
## Problema

No Android, ao abrir o app, o Real (BRL) aparece como "Sem Dados" e todas as conversões ficam quebradas. Isso não acontece na versão web.

## Causa raiz

`android/app/src/main/AndroidManifest.xml` — o manifesto usado nos builds **release** — não declarava `android.permission.INTERNET`. Essa permissão só existia em `android/app/src/debug/AndroidManifest.xml` e `android/app/src/profile/AndroidManifest.xml`, que o Flutter mescla automaticamente apenas em builds debug/profile para permitir hot reload/debugging, mas que não fazem parte de um APK/bundle de produção.

Resultado: num app instalado normalmente (release), toda chamada HTTP falha silenciosamente (`SocketException` capturada em `lib/util/network_util.dart` e em `CurrencyRepository`). Sem rede e sem cotação salva em cache (primeiro uso do app), `CurrencyRepository.getLatestDataByCurrencyCode` retorna `null`, e a tela mostra "Sem Dados" para o Real — quebrando também as conversões, que dependem desse valor. A versão web não é afetada porque o navegador não exige essa declaração de permissão para fazer requisições de rede.

## Correção

Adiciona `<uses-permission android:name="android.permission.INTERNET"/>` ao manifest principal (`android/app/src/main/AndroidManifest.xml`), garantindo que builds release também tenham acesso à rede.

## Test plan

- [ ] Gerar um APK/bundle de **release** (`flutter build apk --release`) e confirmar que o app consegue buscar cotações ao abrir, sem "Sem Dados" no Real
- [ ] Confirmar que builds debug seguem funcionando normalmente (comportamento inalterado, já tinham a permissão)
- [ ] Verificar que as conversões voltam a funcionar corretamente no build release

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsHFDAAjnTtp9g7Ud357eX)_