### PR TITLE
Traduz o nome do app para os idiomas já suportados

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
          lib/util/notification_service_io.dart). -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <application
-        android:label="cotacao_direta"
+        android:label="@string/app_name"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/android/app/src/main/res/values-en/strings.xml
+++ b/android/app/src/main/res/values-en/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Direct Quote</string>
+</resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Mesmo texto para as duas normas do espanhol (es-ES e es-419, ver
+         lib/util/localizations.dart): a tradução do nome não muda entre elas,
+         então um único qualificador "es" cobre as duas. -->
+    <string name="app_name">Cotización Directa</string>
+</resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Nome do app no launcher do Android. Traduzido em values-en/ e
+         values-es/, um por idioma suportado (ver lib/util/localizations.dart);
+         este arquivo, sem qualificador, é o padrão para português e para
+         qualquer idioma do aparelho que a build não traduz. -->
+    <string name="app_name">Cotação Direta</string>
+</resources>

--- a/linux/runner/my_application.cc
+++ b/linux/runner/my_application.cc
@@ -14,6 +14,20 @@ struct _MyApplication {
 
 G_DEFINE_TYPE(MyApplication, my_application, GTK_TYPE_APPLICATION)
 
+// Nome da janela no idioma do sistema, entre os que a build traduz (ver
+// lib/util/localizations.dart). O idioma escolhido nas configurações do app
+// não dá para ler daqui: mora no banco do Flutter, que só abre depois desta
+// janela.
+static const gchar* window_title() {
+  const gchar* const* languages = g_get_language_names();
+  for (int i = 0; languages[i] != nullptr; i++) {
+    if (g_str_has_prefix(languages[i], "en")) return "Direct Quote";
+    if (g_str_has_prefix(languages[i], "es")) return "Cotización Directa";
+    if (g_str_has_prefix(languages[i], "pt")) return "Cotação Direta";
+  }
+  return "Cotação Direta";
+}
+
 // Called when first Flutter frame received.
 static void first_frame_cb(MyApplication* self, FlView* view) {
   gtk_widget_show(gtk_widget_get_toplevel(GTK_WIDGET(view)));
@@ -45,11 +59,11 @@ static void my_application_activate(GApplication* application) {
   if (use_header_bar) {
     GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
     gtk_widget_show(GTK_WIDGET(header_bar));
-    gtk_header_bar_set_title(header_bar, "Cotação Direta");
+    gtk_header_bar_set_title(header_bar, window_title());
     gtk_header_bar_set_show_close_button(header_bar, TRUE);
     gtk_window_set_titlebar(window, GTK_WIDGET(header_bar));
   } else {
-    gtk_window_set_title(window, "Cotação Direta");
+    gtk_window_set_title(window, window_title());
   }
 
   gtk_window_set_default_size(window, 1280, 720);

--- a/web/index.html
+++ b/web/index.html
@@ -51,6 +51,36 @@
   <link rel="manifest" href="manifest.json">
 
   <script>
+    // Nome do app mostrado ao instalar (o título da aba, o rótulo do "Adicionar
+    // à tela de início" e o manifest do PWA) no idioma do navegador, entre os
+    // que a build traduz (ver lib/util/localizations.dart). Roda logo depois
+    // dos elementos acima para poder trocá-los antes de o navegador decidir se
+    // oferece a instalação — o idioma escolhido nas configurações do app não
+    // dá para ler daqui, porque mora no banco do Flutter, que ainda não
+    // carregou nesta hora.
+    (function () {
+      var language = (window.navigator.language || '').toLowerCase();
+      var appName = document.title;
+      var manifestHref = 'manifest.json';
+      var htmlLang = 'pt-BR';
+      if (language.indexOf('en') === 0) {
+        appName = 'Direct Quote';
+        manifestHref = 'manifest-en.json';
+        htmlLang = 'en';
+      } else if (language.indexOf('es') === 0) {
+        appName = 'Cotización Directa';
+        manifestHref = 'manifest-es.json';
+        htmlLang = 'es';
+      }
+      document.documentElement.lang = htmlLang;
+      document.title = appName;
+      document.querySelector('link[rel="manifest"]').href = manifestHref;
+      document.querySelector('meta[name="apple-mobile-web-app-title"]').content = appName;
+      document.querySelector('meta[name="application-name"]').content = appName;
+    })();
+  </script>
+
+  <script>
     // Ponte entre a instalação como PWA (uma API só do navegador) e o app
     // Flutter, consumida em lib/util/pwa_install_service_web.dart.
     //

--- a/web/manifest-en.json
+++ b/web/manifest-en.json
@@ -1,0 +1,46 @@
+{
+    "id": "/cotacao_direta/",
+    "name": "Direct Quote",
+    "short_name": "Direct Quote",
+    "lang": "en",
+    "dir": "ltr",
+    "start_url": "./",
+    "scope": "./",
+    "display": "standalone",
+    "display_override": ["standalone", "minimal-ui", "browser"],
+    "launch_handler": {
+        "client_mode": "focus-existing"
+    },
+    "background_color": "#6C4DFF",
+    "theme_color": "#6C4DFF",
+    "description": "A simple app that shows the exchange rate of the main currencies against the Brazilian real",
+    "orientation": "portrait-primary",
+    "categories": ["finance", "utilities"],
+    "prefer_related_applications": false,
+    "icons": [
+        {
+            "src": "icons/Icon-192.png",
+            "sizes": "192x192",
+            "type": "image/png",
+            "purpose": "any"
+        },
+        {
+            "src": "icons/Icon-512.png",
+            "sizes": "512x512",
+            "type": "image/png",
+            "purpose": "any"
+        },
+        {
+            "src": "icons/Icon-maskable-192.png",
+            "sizes": "192x192",
+            "type": "image/png",
+            "purpose": "maskable"
+        },
+        {
+            "src": "icons/Icon-maskable-512.png",
+            "sizes": "512x512",
+            "type": "image/png",
+            "purpose": "maskable"
+        }
+    ]
+}

--- a/web/manifest-es.json
+++ b/web/manifest-es.json
@@ -1,0 +1,46 @@
+{
+    "id": "/cotacao_direta/",
+    "name": "Cotización Directa",
+    "short_name": "Cotización Directa",
+    "lang": "es",
+    "dir": "ltr",
+    "start_url": "./",
+    "scope": "./",
+    "display": "standalone",
+    "display_override": ["standalone", "minimal-ui", "browser"],
+    "launch_handler": {
+        "client_mode": "focus-existing"
+    },
+    "background_color": "#6C4DFF",
+    "theme_color": "#6C4DFF",
+    "description": "Una aplicación sencilla que muestra la cotización de las principales monedas frente al real brasileño",
+    "orientation": "portrait-primary",
+    "categories": ["finance", "utilities"],
+    "prefer_related_applications": false,
+    "icons": [
+        {
+            "src": "icons/Icon-192.png",
+            "sizes": "192x192",
+            "type": "image/png",
+            "purpose": "any"
+        },
+        {
+            "src": "icons/Icon-512.png",
+            "sizes": "512x512",
+            "type": "image/png",
+            "purpose": "any"
+        },
+        {
+            "src": "icons/Icon-maskable-192.png",
+            "sizes": "192x192",
+            "type": "image/png",
+            "purpose": "maskable"
+        },
+        {
+            "src": "icons/Icon-maskable-512.png",
+            "sizes": "512x512",
+            "type": "image/png",
+            "purpose": "maskable"
+        }
+    ]
+}

--- a/web/service_worker.js
+++ b/web/service_worker.js
@@ -34,6 +34,8 @@ const NETWORK_FIRST_PATHS = [
   'flutter.js',
   'index.html',
   'manifest.json',
+  'manifest-en.json',
+  'manifest-es.json',
   'version.json',
 ];
 
@@ -45,7 +47,15 @@ const SCOPE = new URL('./', self.location.href);
 /// for pedido, porque parte disso é baixada antes de o service worker assumir
 /// o controle da página na primeira visita. O resto (CanvasKit, fontes,
 /// bandeiras, o SQLite em WASM) entra pela regra de busca, conforme é usado.
-const APP_SHELL = ['', 'flutter_bootstrap.js', 'main.dart.js', 'flutter.js', 'manifest.json'];
+const APP_SHELL = [
+  '',
+  'flutter_bootstrap.js',
+  'main.dart.js',
+  'flutter.js',
+  'manifest.json',
+  'manifest-en.json',
+  'manifest-es.json',
+];
 
 self.addEventListener('install', (event) => {
   event.waitUntil(


### PR DESCRIPTION
## Resumo

Traduz o nome do app mostrado na instalação em cada plataforma, seguindo os mesmos idiomas já suportados em `lib/util/localizations.dart` (pt, en, es-ES/es-419):

- **Android** — o rótulo do launcher caía no nome técnico do pacote (`android:label="cotacao_direta"`), em vez do nome da marca. Agora vem de `@string/app_name`, localizado por `values/` (padrão, português), `values-en/` ("Direct Quote") e `values-es/` ("Cotización Directa", cobrindo as duas normas do espanhol).
- **Web (PWA)** — `manifest.json`, o `<title>` e as metatags do iOS eram fixos em português. Um script no `<head>` de `web/index.html` detecta o idioma do navegador e troca o título, as metatags e o `<link rel="manifest">` para `manifest-en.json` ou `manifest-es.json` (novos arquivos, com `name`/`short_name`/`description` traduzidos); sem correspondência, mantém o padrão em português. `web/service_worker.js` passa a pré-cachear e tratar os dois manifests novos como os demais arquivos do app shell.
- **Linux** — o título da janela GTK era fixo em português; passa a seguir o idioma do sistema (`g_get_language_names()`), com o mesmo fallback para português.

Fora do escopo: os textos dentro do app (tela Sobre, `MaterialApp.title`) continuam com "Cotação Direta" fixo — é assim que o app já trata o nome como marca dentro da própria interface, mesmo nas traduções para inglês e espanhol (ex.: "Add **Cotação Direta** to your device").

## Test plan

- [x] Validação de sintaxe dos arquivos novos/alterados (XML do Android, JSON dos manifests)
- [ ] Instalar o APK em um aparelho/emulador com idioma en e es e conferir o nome no launcher
- [ ] Abrir `web/` com `navigator.language` em en/es (via DevTools) e conferir o título da aba e o nome oferecido na instalação do PWA
- [ ] Rodar o app Linux com `LANG=en_US.UTF-8` / `LANG=es_ES.UTF-8` e conferir o título da janela

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01QT9DapqE5WD8gv6PcmePrQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01QT9DapqE5WD8gv6PcmePrQ)_