### PR TITLE
Remove uma bolha arrastando-a até a lixeira

### DIFF
--- a/lib/util/localizations.dart
+++ b/lib/util/localizations.dart
@@ -147,9 +147,12 @@ class MyAppLocalizations {
       'conversionButtonLabel': 'Conversions',
       'conversionPageTitle': "Currency Conversion",
       'homePageHeadsUpText': 'Exchange rates in %s',
-      'homeReorderHintLabel': 'Press and hold a quote to rearrange the grid.',
+      'homeReorderHintLabel': 'Press and hold a quote to rearrange the grid, '
+          'or drag it onto the bin to remove it.',
       'homeReorderMoveEarlierLabel': 'Move one position back',
       'homeReorderMoveLaterLabel': 'Move one position forward',
+      'homeRemoveDropZoneLabel': 'Drop here to remove',
+      'homeRemoveCardLabel': 'Remove from the home screen',
       'homeAddCurrencyCardLabel': 'Add currency',
       'conversionMultiplierHint': 'Amount',
       'conversionPageExplanationText': 'Insert the amount value of the currency '
@@ -321,10 +324,12 @@ class MyAppLocalizations {
       'conversionButtonLabel': "Conversões",
       'conversionPageTitle': "Conversão de Moedas",
       'homePageHeadsUpText': "Cotações em %s",
-      'homeReorderHintLabel':
-          'Segure uma cotação para reorganizar a grade.',
+      'homeReorderHintLabel': 'Segure uma cotação para reorganizar a grade '
+          'ou arraste-a até a lixeira para removê-la.',
       'homeReorderMoveEarlierLabel': 'Mover uma posição para trás',
       'homeReorderMoveLaterLabel': 'Mover uma posição para frente',
+      'homeRemoveDropZoneLabel': 'Solte aqui para remover',
+      'homeRemoveCardLabel': 'Remover da tela inicial',
       'homeAddCurrencyCardLabel': 'Adicionar moeda',
       'conversionMultiplierHint': 'Quantidade',
       'conversionPageExplanationText': 'Insira a quantidade da moeda que será '
@@ -501,10 +506,12 @@ class MyAppLocalizations {
       'conversionButtonLabel': 'Conversiones',
       'conversionPageTitle': 'Conversión de divisas',
       'homePageHeadsUpText': 'Cotizaciones en %s',
-      'homeReorderHintLabel':
-          'Mantén pulsada una cotización para reorganizar la cuadrícula.',
+      'homeReorderHintLabel': 'Mantén pulsada una cotización para reorganizar '
+          'la cuadrícula o arrástrala a la papelera para quitarla.',
       'homeReorderMoveEarlierLabel': 'Mover una posición hacia atrás',
       'homeReorderMoveLaterLabel': 'Mover una posición hacia delante',
+      'homeRemoveDropZoneLabel': 'Suelta aquí para quitar',
+      'homeRemoveCardLabel': 'Quitar de la pantalla de inicio',
       'homeAddCurrencyCardLabel': 'Añadir divisa',
       'conversionMultiplierHint': 'Cantidad',
       'conversionPageExplanationText': 'Introduce la cantidad de la divisa que '
@@ -686,10 +693,13 @@ class MyAppLocalizations {
       'conversionButtonLabel': 'Conversiones',
       'conversionPageTitle': 'Conversión de monedas',
       'homePageHeadsUpText': 'Cotizaciones en %s',
-      'homeReorderHintLabel':
-          'Mantén presionada una cotización para reorganizar la cuadrícula.',
+      'homeReorderHintLabel': 'Mantén presionada una cotización para '
+          'reorganizar la cuadrícula o arrástrala al bote de basura para '
+          'quitarla.',
       'homeReorderMoveEarlierLabel': 'Mover una posición hacia atrás',
       'homeReorderMoveLaterLabel': 'Mover una posición hacia adelante',
+      'homeRemoveDropZoneLabel': 'Suelta aquí para quitar',
+      'homeRemoveCardLabel': 'Quitar de la pantalla de inicio',
       'homeAddCurrencyCardLabel': 'Agregar moneda',
       'conversionMultiplierHint': 'Cantidad',
       'conversionPageExplanationText': 'Ingresa la cantidad de la moneda que '
@@ -892,6 +902,18 @@ class MyAppLocalizations {
 
   String? get homeReorderMoveLaterLabel {
     return _values['homeReorderMoveLaterLabel'];
+  }
+
+  /// Texto da faixa que aparece no rodapé enquanto uma bolha está sendo
+  /// arrastada: soltá-la ali tira a moeda da tela inicial.
+  String? get homeRemoveDropZoneLabel {
+    return _values['homeRemoveDropZoneLabel'];
+  }
+
+  /// A mesma remoção, oferecida ao leitor de tela como ação — arrastar até a
+  /// faixa não é um gesto disponível para quem navega por ele.
+  String? get homeRemoveCardLabel {
+    return _values['homeRemoveCardLabel'];
   }
 
   /// Rótulo do cartão que fecha a grade da tela inicial e abre a escolha das

--- a/lib/view/pages/home.dart
+++ b/lib/view/pages/home.dart
@@ -304,6 +304,13 @@ class HomeState extends State<Home> with TickerProviderStateMixin {
   /// A ordem das bolhas é a da configuração, mas pode ser mudada aqui mesmo:
   /// segurar o dedo sobre uma bolha e soltá-la sobre outra põe a arrastada
   /// naquela posição, empurrando as demais (ver [ReorderableBentoGrid]).
+  ///
+  /// O mesmo arrasto também tira uma bolha da tela: enquanto ela está presa ao
+  /// dedo, uma faixa com uma lixeira aparece no rodapé, e soltá-la ali remove
+  /// a moeda. A remoção só é oferecida com mais de uma bolha na grade: a lista
+  /// vazia significa "o usuário nunca escolheu" e traria de volta as moedas
+  /// padrão, então a tela inicial sem nenhuma cotação não é um estado que dê
+  /// para gravar.
   Widget _buildBentoGrid(BuildContext context, double scale) {
     final localization = MyAppLocalizations.of(context)!;
     return Padding(
@@ -312,8 +319,11 @@ class HomeState extends State<Home> with TickerProviderStateMixin {
         itemCount: _homeCurrencies.length,
         spacing: 12 * scale,
         onReorder: _reorderHomeCurrencies,
+        onDelete: _homeCurrencies.length > 1 ? _removeHomeCurrency : null,
         moveEarlierSemanticsLabel: localization.homeReorderMoveEarlierLabel,
         moveLaterSemanticsLabel: localization.homeReorderMoveLaterLabel,
+        deleteZoneLabel: localization.homeRemoveDropZoneLabel,
+        deleteSemanticsLabel: localization.homeRemoveCardLabel,
         itemBuilder: (BuildContext context, int index, bool hero) =>
             _animatedTile(
           index,
@@ -371,6 +381,25 @@ class HomeState extends State<Home> with TickerProviderStateMixin {
     if (newIndex < 0 || newIndex >= _homeCurrencies.length) return;
     final currencies = List.of(_homeCurrencies);
     currencies.insert(newIndex, currencies.removeAt(oldIndex));
+    setState(() => _homeCurrencies = currencies);
+    _bloc.saveHomeCurrencies(currencies);
+  }
+
+  /// Tira a bolha de [index] da tela inicial: a moeda que foi solta sobre a
+  /// faixa de descarte da grade.
+  ///
+  /// Como na reordenação, a tela muda na hora e a gravação vem depois — é a
+  /// mesma lista de moedas escolhidas, mexida pelo arrasto em vez de pela
+  /// folha de escolha, e a moeda removida continua a um toque de distância no
+  /// cartão de acrescentar.
+  ///
+  /// A última bolha não é removida: a grade só oferece o descarte quando há
+  /// mais de uma, e a conferência se repete aqui porque a ação equivalente do
+  /// leitor de tela chega pelo mesmo caminho.
+  void _removeHomeCurrency(int index) {
+    if (index < 0 || index >= _homeCurrencies.length) return;
+    if (_homeCurrencies.length <= 1) return;
+    final currencies = List.of(_homeCurrencies)..removeAt(index);
     setState(() => _homeCurrencies = currencies);
     _bloc.saveHomeCurrencies(currencies);
   }

--- a/lib/view/widgets/reorderable_bento_grid.dart
+++ b/lib/view/widgets/reorderable_bento_grid.dart
@@ -18,9 +18,16 @@ typedef BentoTileBuilder = Widget Function(
 /// posição é o que promove uma moeda ao destaque — antes isso só era possível
 /// refazendo a escolha inteira.
 ///
-/// A reordenação não é gravada aqui: [onReorder] avisa quem monta a grade, que
-/// é quem conhece a lista de moedas e o que fazer com a ordem nova.
-class ReorderableBentoGrid extends StatelessWidget {
+/// Enquanto um cartão está preso ao dedo, uma faixa com um ícone de lixeira
+/// aparece no rodapé da tela: soltar o cartão em cima dela tira aquele cartão
+/// da grade. É o mesmo arrasto que reordena — a área de descarte só dá ao
+/// gesto um segundo destino, e só existe quando quem monta a grade informa
+/// [onDelete].
+///
+/// Nem a reordenação nem a remoção são gravadas aqui: [onReorder] e [onDelete]
+/// avisam quem monta a grade, que é quem conhece a lista de moedas e o que
+/// fazer com ela.
+class ReorderableBentoGrid extends StatefulWidget {
   final int itemCount;
   final BentoTileBuilder itemBuilder;
 
@@ -38,6 +45,14 @@ class ReorderableBentoGrid extends StatelessWidget {
   /// passar a ocupar [newIndex], empurrando os demais.
   final void Function(int oldIndex, int newIndex) onReorder;
 
+  /// Chamado quando um cartão é solto sobre a área de descarte: o cartão de
+  /// [index] deve sair da grade.
+  ///
+  /// Nulo desliga a remoção por arrasto — a faixa nem chega a aparecer. É
+  /// assim que quem monta a grade impede que ela fique sem nenhum cartão:
+  /// basta não informar o retorno enquanto sobrar um só.
+  final void Function(int index)? onDelete;
+
   /// Espaço entre cartões, na horizontal e na vertical.
   final double spacing;
 
@@ -48,20 +63,53 @@ class ReorderableBentoGrid extends StatelessWidget {
   final String? moveEarlierSemanticsLabel;
   final String? moveLaterSemanticsLabel;
 
+  /// Texto da faixa de descarte, que diz o que soltar o cartão ali faz. Sem
+  /// ele a faixa mostra só o ícone de lixeira.
+  final String? deleteZoneLabel;
+
+  /// Rótulo da ação de remover oferecida ao leitor de tela, no lugar do
+  /// arrasto até a faixa. Só entra quando [onDelete] existe.
+  final String? deleteSemanticsLabel;
+
   const ReorderableBentoGrid({
     super.key,
     required this.itemCount,
     required this.itemBuilder,
     required this.onReorder,
+    this.onDelete,
     this.footerBuilder,
     this.spacing = 12,
     this.moveEarlierSemanticsLabel,
     this.moveLaterSemanticsLabel,
+    this.deleteZoneLabel,
+    this.deleteSemanticsLabel,
   });
+
+  @override
+  State<ReorderableBentoGrid> createState() => _ReorderableBentoGridState();
+}
+
+class _ReorderableBentoGridState extends State<ReorderableBentoGrid> {
+  /// A faixa de descarte, enquanto um cartão está no ar.
+  ///
+  /// Ela vive no Overlay, e não dentro da grade: a grade mora num
+  /// SingleChildScrollView e pode estar rolada para qualquer altura, então uma
+  /// faixa desenhada nela poderia nascer fora da tela. No Overlay ela fica
+  /// presa ao rodapé, sempre alcançável pelo dedo que está segurando o cartão,
+  /// e por cima da grade — o que também faz dela o primeiro alvo a ser
+  /// consultado quando o cartão é solto sobre a região que ela ocupa.
+  OverlayEntry? _deleteZone;
+
+  @override
+  void dispose() {
+    _hideDeleteZone();
+    super.dispose();
+  }
 
   /// Quantas posições a grade desenha: os cartões reordenáveis mais o cartão
   /// fixo do fim, quando ele existe.
-  int get _slotCount => itemCount + (footerBuilder == null ? 0 : 1);
+  int get _slotCount =>
+      widget.itemCount + (widget.footerBuilder == null ? 0 : 1);
 
   @override
   Widget build(BuildContext context) {
@@ -73,14 +121,14 @@ class ReorderableBentoGrid extends StatelessWidget {
     return LayoutBuilder(
       builder: (BuildContext context, BoxConstraints constraints) {
         final heroWidth = constraints.maxWidth;
-        final pairedWidth = (constraints.maxWidth - spacing) / 2;
+        final pairedWidth = (constraints.maxWidth - widget.spacing) / 2;
         final rows = <Widget>[
           _slot(context, 0, hero: true, width: heroWidth),
         ];
 
         for (var first = 1; first < slotCount; first += 2) {
           final second = first + 1;
-          rows.add(SizedBox(height: spacing));
+          rows.add(SizedBox(height: widget.spacing));
           // O IntrinsicHeight é obrigatório aqui: a Row usa
           // CrossAxisAlignment.stretch para os dois cartões terminarem com a
           // mesma altura, mas o eixo transversal de uma Row é o vertical, que
@@ -94,7 +142,7 @@ class ReorderableBentoGrid extends StatelessWidget {
                 Expanded(
                   child: _slot(context, first, hero: false, width: pairedWidth),
                 ),
-                SizedBox(width: spacing),
+                SizedBox(width: widget.spacing),
                 // Numa linha ímpar o espaço vazio à direita fica reservado,
                 // para o cartão sozinho ter a mesma largura dos das outras
                 // linhas.
@@ -116,12 +164,15 @@ class ReorderableBentoGrid extends StatelessWidget {
     );
   }
 
-  /// Uma posição da grade. Até [itemCount] é um cartão reordenável; a posição
-  /// seguinte, quando existe, é o cartão fixo do fim, desenhado como está —
-  /// sem arrasto, sem alvo de soltura e sem as ações de mover.
+  /// Uma posição da grade. Até [ReorderableBentoGrid.itemCount] é um cartão
+  /// reordenável; a posição seguinte, quando existe, é o cartão fixo do fim,
+  /// desenhado como está — sem arrasto, sem alvo de soltura e sem as ações de
+  /// mover.
   Widget _slot(BuildContext context, int index,
       {required bool hero, required double width}) {
-    if (index >= itemCount) return footerBuilder!(context, index, hero);
+    if (index >= widget.itemCount) {
+      return widget.footerBuilder!(context, index, hero);
+    }
     return _tile(context, index, hero: hero, width: width);
   }
 
@@ -130,7 +181,7 @@ class ReorderableBentoGrid extends StatelessWidget {
   Widget _tile(BuildContext context, int index,
       {required bool hero, required double width}) {
     final radius = hero ? BentoRadius.hero : BentoRadius.standard;
-    final child = itemBuilder(context, index, hero);
+    final child = widget.itemBuilder(context, index, hero);
 
     final draggable = LongPressDraggable<int>(
       data: index,
@@ -141,7 +192,14 @@ class ReorderableBentoGrid extends StatelessWidget {
       childWhenDragging: _emptySlot(context, child, radius),
       // O mesmo retorno tátil de quem já arrastou um ícone na tela inicial do
       // aparelho: sem ele não fica claro que o toque longo pegou o cartão.
-      onDragStarted: () => HapticFeedback.mediumImpact(),
+      onDragStarted: () {
+        HapticFeedback.mediumImpact();
+        _showDeleteZone(index);
+      },
+      // A faixa acompanha o dedo: existe enquanto o cartão está no ar e some
+      // assim que ele é solto, tenha caído onde tiver caído.
+      onDragEnd: (_) => _hideDeleteZone(),
+      onDraggableCanceled: (_, __) => _hideDeleteZone(),
       child: child,
     );
 
@@ -150,7 +208,7 @@ class ReorderableBentoGrid extends StatelessWidget {
       onWillAcceptWithDetails: (details) => details.data != index,
       onAcceptWithDetails: (details) {
         HapticFeedback.selectionClick();
-        onReorder(details.data, index);
+        widget.onReorder(details.data, index);
       },
       builder: (BuildContext context, List<int?> candidateData, _) {
         final isTarget = candidateData.isNotEmpty;
@@ -181,22 +239,28 @@ class ReorderableBentoGrid extends StatelessWidget {
     );
   }
 
-  /// Ações de reordenação para o leitor de tela, quando os rótulos foram
-  /// informados. Sem elas, a grade seria reordenável só por arrasto — um gesto
-  /// que não existe para quem usa TalkBack ou VoiceOver.
+  /// Ações de reordenação e de remoção para o leitor de tela, quando os
+  /// rótulos foram informados. Sem elas, a grade seria reordenável (e o cartão,
+  /// removível) só por arrasto — um gesto que não existe para quem usa TalkBack
+  /// ou VoiceOver.
   Widget _semantics(int index, Widget child) {
-    final moveEarlier = moveEarlierSemanticsLabel;
-    final moveLater = moveLaterSemanticsLabel;
-    if (moveEarlier == null && moveLater == null) return child;
+    final moveEarlier = widget.moveEarlierSemanticsLabel;
+    final moveLater = widget.moveLaterSemanticsLabel;
+    final onDelete = widget.onDelete;
+    final delete = widget.deleteSemanticsLabel;
+    final hasDelete = onDelete != null && delete != null;
+    if (moveEarlier == null && moveLater == null && !hasDelete) return child;
     return Semantics(
       container: true,
       customSemanticsActions: {
         if (moveEarlier != null && index > 0)
           CustomSemanticsAction(label: moveEarlier): () =>
-              onReorder(index, index - 1),
-        if (moveLater != null && index < itemCount - 1)
+              widget.onReorder(index, index - 1),
+        if (moveLater != null && index < widget.itemCount - 1)
           CustomSemanticsAction(label: moveLater): () =>
-              onReorder(index, index + 1),
+              widget.onReorder(index, index + 1),
+        if (hasDelete)
+          CustomSemanticsAction(label: delete): () => onDelete(index),
       },
       child: child,
     );
@@ -217,7 +281,7 @@ class ReorderableBentoGrid extends StatelessWidget {
           width: width,
           child: Opacity(
             opacity: 0.92,
-            child: itemBuilder(context, index, hero),
+            child: widget.itemBuilder(context, index, hero),
           ),
         ),
       ),
@@ -240,5 +304,117 @@ class ReorderableBentoGrid extends StatelessWidget {
         child: IgnorePointer(child: child),
       ),
     );
+  }
+
+  /// Põe a faixa de descarte no rodapé da tela, para o cartão que acabou de
+  /// sair da grade. Sem [ReorderableBentoGrid.onDelete] não há o que a faixa
+  /// faça, então ela não aparece.
+  void _showDeleteZone(int index) {
+    if (widget.onDelete == null) return;
+    if (_deleteZone != null) return;
+    final overlay = Overlay.maybeOf(context);
+    if (overlay == null) return;
+    final entry = OverlayEntry(builder: _buildDeleteZone);
+    _deleteZone = entry;
+    overlay.insert(entry);
+  }
+
+  /// Tira a faixa da tela. Chamada tanto ao fim do arrasto quanto na hora da
+  /// remoção: quando o cartão arrastado sai da grade, o arrastável que
+  /// avisaria o fim do gesto já não existe mais.
+  void _hideDeleteZone() {
+    _deleteZone?.remove();
+    _deleteZone = null;
+  }
+
+  /// A faixa: um alvo de soltura que ocupa o rodapé da tela, com o ícone de
+  /// lixeira e o texto do que soltar ali faz. Fica vermelha e cresce quando o
+  /// cartão está em cima dela, para não haver dúvida do que vai acontecer se o
+  /// dedo levantar naquele ponto.
+  Widget _buildDeleteZone(BuildContext overlayContext) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final label = widget.deleteZoneLabel;
+    return Positioned(
+      left: 0,
+      right: 0,
+      bottom: 0,
+      child: SafeArea(
+        top: false,
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: DragTarget<int>(
+            onWillAcceptWithDetails: (_) => true,
+            onAcceptWithDetails: (details) => _deleteDragged(details.data),
+            builder: (BuildContext context, List<int?> candidateData, _) {
+              final isTarget = candidateData.isNotEmpty;
+              final background = isTarget
+                  ? colorScheme.error
+                  : colorScheme.errorContainer.withValues(alpha: 0.92);
+              final foreground = isTarget
+                  ? colorScheme.onError
+                  : colorScheme.onErrorContainer;
+              return AnimatedScale(
+                scale: isTarget ? 1.04 : 1.0,
+                duration: const Duration(milliseconds: 150),
+                curve: Curves.easeOut,
+                child: AnimatedContainer(
+                  duration: const Duration(milliseconds: 150),
+                  curve: Curves.easeOut,
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 20,
+                    vertical: 16,
+                  ),
+                  decoration: BoxDecoration(
+                    color: background,
+                    borderRadius: BorderRadius.circular(BentoRadius.hero),
+                    border: Border.all(
+                      color: isTarget ? foreground : Colors.transparent,
+                      width: 2,
+                    ),
+                  ),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Icon(
+                        isTarget ? Icons.delete_forever : Icons.delete_outline,
+                        color: foreground,
+                      ),
+                      if (label != null) ...[
+                        const SizedBox(width: 10),
+                        Flexible(
+                          child: Text(
+                            label,
+                            textAlign: TextAlign.center,
+                            style: TextStyle(
+                              color: foreground,
+                              fontSize: 14,
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// Solta o cartão de [index] fora da grade: tira a faixa da tela e avisa
+  /// quem monta a grade, que é quem sabe remover a moeda da lista.
+  void _deleteDragged(int index) {
+    final onDelete = widget.onDelete;
+    // A faixa some antes da remoção: depois dela a grade é reconstruída sem o
+    // cartão arrastado, e o arrastável que avisaria o fim do gesto some junto.
+    _hideDeleteZone();
+    if (onDelete == null) return;
+    // Um retorno mais forte que o da reordenação: remover é a ação que não se
+    // desfaz com outro arrasto.
+    HapticFeedback.heavyImpact();
+    onDelete(index);
   }
 }

--- a/test/util/localizations_test.dart
+++ b/test/util/localizations_test.dart
@@ -12,6 +12,8 @@ List<String?> _allLabels(MyAppLocalizations localizations) => [
       localizations.homeReorderHintLabel,
       localizations.homeReorderMoveEarlierLabel,
       localizations.homeReorderMoveLaterLabel,
+      localizations.homeRemoveDropZoneLabel,
+      localizations.homeRemoveCardLabel,
       localizations.homeAddCurrencyCardLabel,
       localizations.conversionMultiplierHint,
       localizations.conversionPageExplanationText,

--- a/test/view/reorderable_bento_grid_test.dart
+++ b/test/view/reorderable_bento_grid_test.dart
@@ -18,8 +18,12 @@ class _GridHarness extends StatefulWidget {
   final String? footerLabel;
   final VoidCallback? onTapFooter;
 
+  /// Posições soltas sobre a faixa de descarte. Nulo monta a grade sem
+  /// remoção — a faixa nem chega a aparecer.
+  final List<int>? deletions;
+
   const _GridHarness(this.items, this.reorders,
-      {this.onTapItem, this.footerLabel, this.onTapFooter});
+      {this.onTapItem, this.footerLabel, this.onTapFooter, this.deletions});
 
   @override
   State<_GridHarness> createState() => _GridHarnessState();
@@ -37,6 +41,14 @@ class _GridHarnessState extends State<_GridHarness> {
             itemCount: _items.length,
             moveEarlierSemanticsLabel: "Mover para trás",
             moveLaterSemanticsLabel: "Mover para frente",
+            deleteZoneLabel: "Solte aqui para remover",
+            deleteSemanticsLabel: "Remover",
+            onDelete: widget.deletions == null
+                ? null
+                : (index) {
+                    widget.deletions!.add(index);
+                    setState(() => _items.removeAt(index));
+                  },
             footerBuilder: widget.footerLabel == null
                 ? null
                 : (BuildContext context, int index, bool hero) =>
@@ -238,6 +250,115 @@ void main() {
           .pumpWidget(_GridHarness(const [], [], footerLabel: "Adicionar"));
 
       expect(find.text("Adicionar (destaque)"), findsOneWidget);
+    });
+
+    // A faixa de descarte só existe enquanto um cartão está no ar: fora do
+    // arrasto ela tomaria o rodapé da tela sem ter o que receber.
+    testWidgets('a faixa de descarte só aparece durante o arrasto',
+        (WidgetTester tester) async {
+      await tester
+          .pumpWidget(_GridHarness(const ["A", "B", "C"], [], deletions: []));
+
+      expect(find.text("Solte aqui para remover"), findsNothing);
+
+      final gesture =
+          await tester.startGesture(tester.getCenter(find.text("B")));
+      await tester.pump(kLongPressTimeout + const Duration(milliseconds: 50));
+      await tester.pump();
+
+      expect(find.text("Solte aqui para remover"), findsOneWidget);
+      expect(find.byIcon(Icons.delete_outline), findsOneWidget);
+
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      expect(find.text("Solte aqui para remover"), findsNothing);
+    });
+
+    testWidgets('soltar o cartão sobre a faixa o tira da grade',
+        (WidgetTester tester) async {
+      final deletions = <int>[];
+      final reorders = <List<int>>[];
+      await tester.pumpWidget(
+          _GridHarness(const ["A", "B", "C"], reorders, deletions: deletions));
+
+      final gesture =
+          await tester.startGesture(tester.getCenter(find.text("B")));
+      await tester.pump(kLongPressTimeout + const Duration(milliseconds: 50));
+      await gesture
+          .moveTo(tester.getCenter(find.text("Solte aqui para remover")));
+      await tester.pump();
+      // Em cima da faixa o ícone muda: é o aviso de que levantar o dedo ali
+      // remove o cartão.
+      expect(find.byIcon(Icons.delete_forever), findsOneWidget);
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      expect(deletions, [1]);
+      expect(reorders, isEmpty,
+          reason: "soltar na faixa remove o cartão, não o reordena");
+      expect(_renderedOrder(tester), ["A", "C"]);
+      expect(find.text("Solte aqui para remover"), findsNothing,
+          reason: "a faixa some junto com o cartão removido");
+    });
+
+    // Sem retorno de remoção o arrasto continua sendo só o que era: uma
+    // reordenação.
+    testWidgets('sem onDelete a faixa não aparece',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(_GridHarness(const ["A", "B", "C"], []));
+
+      final gesture =
+          await tester.startGesture(tester.getCenter(find.text("B")));
+      await tester.pump(kLongPressTimeout + const Duration(milliseconds: 50));
+      await tester.pump();
+
+      expect(find.text("Solte aqui para remover"), findsNothing);
+
+      await gesture.up();
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('soltar um cartão sobre outro continua reordenando',
+        (WidgetTester tester) async {
+      final deletions = <int>[];
+      final reorders = <List<int>>[];
+      await tester.pumpWidget(
+          _GridHarness(const ["A", "B", "C"], reorders, deletions: deletions));
+
+      await _dragTile(tester,
+          from: tester.getCenter(find.text("C")),
+          to: tester.getCenter(find.text("A (destaque)")));
+
+      expect(deletions, isEmpty);
+      expect(reorders, [
+        [2, 0]
+      ]);
+    });
+
+    // Arrastar até a faixa não existe para quem navega pelo leitor de tela: a
+    // remoção precisa estar disponível como ação.
+    testWidgets('oferece a ação de remover ao leitor de tela',
+        (WidgetTester tester) async {
+      final deletions = <int>[];
+      await tester.pumpWidget(
+          _GridHarness(const ["A", "B", "C"], [], deletions: deletions));
+
+      final actions = tester
+          .widgetList<Semantics>(find.byType(Semantics))
+          .map((widget) => widget.properties.customSemanticsActions)
+          .whereType<Map<CustomSemanticsAction, VoidCallback>>()
+          .where((actions) => actions.isNotEmpty)
+          .toList();
+
+      // A ação de remover do último cartão o tira da grade.
+      final remove =
+          actions.last.entries.firstWhere((entry) => entry.key.label == "Remover");
+      remove.value();
+      await tester.pumpAndSettle();
+
+      expect(deletions, [2]);
+      expect(_renderedOrder(tester), ["A", "B"]);
     });
 
     testWidgets('oferece as ações de mover ao leitor de tela',


### PR DESCRIPTION
## O que muda

Enquanto um cartão da grade da tela inicial está preso ao dedo, uma faixa com o ícone de lixeira aparece no rodapé da tela, dizendo que soltar o cartão ali o remove. A faixa fica vermelha e cresce quando o cartão está em cima dela (`delete_outline` → `delete_forever`), e soltá-lo naquele ponto tira a moeda da grade.

Antes, tirar uma moeda da tela inicial só dava para fazer refazendo a escolha inteira na folha do cartão de acrescentar: abrir a lista, achar a moeda entre as marcadas, desmarcá-la e confirmar.

## Como foi feito

- `ReorderableBentoGrid` virou `StatefulWidget` e ganhou `onDelete`, `deleteZoneLabel` e `deleteSemanticsLabel`. A faixa é inserida no `Overlay` no início do arrasto e removida no fim — a grade mora num scroll e pode estar rolada para qualquer altura, então uma faixa desenhada dentro dela poderia nascer fora do alcance do dedo. No Overlay ela fica presa ao rodapé e por cima da grade, o que também faz dela o primeiro alvo consultado quando o cartão é solto sobre a região que ocupa.
- Sem `onDelete` nada muda: a faixa não aparece e o arrasto continua sendo só reordenação.
- A tela inicial só oferece a remoção com mais de uma bolha na grade: a lista vazia significa "o usuário nunca escolheu" e traria de volta as moedas padrão, então ficar sem nenhuma cotação não é um estado que dê para gravar. `_removeHomeCurrency` repete a conferência, porque a ação do leitor de tela chega pelo mesmo caminho.
- Como na reordenação, a tela muda na hora e a gravação (`saveHomeCurrencies`) vem depois.
- A remoção também existe como ação de acessibilidade ("Remover da tela inicial"), ao lado das de mover: arrastar até a faixa não é um gesto disponível para quem navega por TalkBack ou VoiceOver.
- Textos novos (`homeRemoveDropZoneLabel`, `homeRemoveCardLabel`) nos quatro idiomas, e a dica da grade passa a mencionar as duas coisas que o arrasto faz.

## Testes

`flutter analyze` sem apontamentos e `flutter test` inteiro verde (623 testes), com cinco casos novos em `reorderable_bento_grid_test.dart`: a faixa só existe durante o arrasto, soltar nela remove o cartão (e não reordena), sem `onDelete` ela não aparece, soltar sobre outro cartão continua reordenando, e a ação de remover do leitor de tela tira o cartão da grade.

---
_Generated by [Claude Code](https://claude.ai/code/session_0159ecd2LTVzKYkyyW6ELq6x)_