### PR TITLE
Corrige o sublinhado de debug na faixa de descarte

### DIFF
--- a/lib/view/widgets/reorderable_bento_grid.dart
+++ b/lib/view/widgets/reorderable_bento_grid.dart
@@ -338,66 +338,76 @@ class _ReorderableBentoGridState extends State<ReorderableBentoGrid> {
       left: 0,
       right: 0,
       bottom: 0,
-      child: SafeArea(
-        top: false,
-        child: Padding(
-          padding: const EdgeInsets.all(16),
-          child: DragTarget<int>(
-            onWillAcceptWithDetails: (_) => true,
-            onAcceptWithDetails: (details) => _deleteDragged(details.data),
-            builder: (BuildContext context, List<int?> candidateData, _) {
-              final isTarget = candidateData.isNotEmpty;
-              final background = isTarget
-                  ? colorScheme.error
-                  : colorScheme.errorContainer.withValues(alpha: 0.92);
-              final foreground = isTarget
-                  ? colorScheme.onError
-                  : colorScheme.onErrorContainer;
-              return AnimatedScale(
-                scale: isTarget ? 1.04 : 1.0,
-                duration: const Duration(milliseconds: 150),
-                curve: Curves.easeOut,
-                child: AnimatedContainer(
+      // O Overlay não tem Material, e sem um o texto e o ícone da faixa
+      // seriam pintados com o sublinhado amarelo e preto que o Flutter usa
+      // em debug para avisar da falta de um DefaultTextStyle — o mesmo motivo
+      // por trás do Material em _dragFeedback. Transparente para o fundo
+      // continuar sendo só o da própria faixa.
+      child: Material(
+        type: MaterialType.transparency,
+        child: SafeArea(
+          top: false,
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: DragTarget<int>(
+              onWillAcceptWithDetails: (_) => true,
+              onAcceptWithDetails: (details) => _deleteDragged(details.data),
+              builder: (BuildContext context, List<int?> candidateData, _) {
+                final isTarget = candidateData.isNotEmpty;
+                final background = isTarget
+                    ? colorScheme.error
+                    : colorScheme.errorContainer.withValues(alpha: 0.92);
+                final foreground = isTarget
+                    ? colorScheme.onError
+                    : colorScheme.onErrorContainer;
+                return AnimatedScale(
+                  scale: isTarget ? 1.04 : 1.0,
                   duration: const Duration(milliseconds: 150),
                   curve: Curves.easeOut,
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 20,
-                    vertical: 16,
-                  ),
-                  decoration: BoxDecoration(
-                    color: background,
-                    borderRadius: BorderRadius.circular(BentoRadius.hero),
-                    border: Border.all(
-                      color: isTarget ? foreground : Colors.transparent,
-                      width: 2,
+                  child: AnimatedContainer(
+                    duration: const Duration(milliseconds: 150),
+                    curve: Curves.easeOut,
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 20,
+                      vertical: 16,
                     ),
-                  ),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      Icon(
-                        isTarget ? Icons.delete_forever : Icons.delete_outline,
-                        color: foreground,
+                    decoration: BoxDecoration(
+                      color: background,
+                      borderRadius: BorderRadius.circular(BentoRadius.hero),
+                      border: Border.all(
+                        color: isTarget ? foreground : Colors.transparent,
+                        width: 2,
                       ),
-                      if (label != null) ...[
-                        const SizedBox(width: 10),
-                        Flexible(
-                          child: Text(
-                            label,
-                            textAlign: TextAlign.center,
-                            style: TextStyle(
-                              color: foreground,
-                              fontSize: 14,
-                              fontWeight: FontWeight.w600,
+                    ),
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Icon(
+                          isTarget
+                              ? Icons.delete_forever
+                              : Icons.delete_outline,
+                          color: foreground,
+                        ),
+                        if (label != null) ...[
+                          const SizedBox(width: 10),
+                          Flexible(
+                            child: Text(
+                              label,
+                              textAlign: TextAlign.center,
+                              style: TextStyle(
+                                color: foreground,
+                                fontSize: 14,
+                                fontWeight: FontWeight.w600,
+                              ),
                             ),
                           ),
-                        ),
+                        ],
                       ],
-                    ],
+                    ),
                   ),
-                ),
-              );
-            },
+                );
+              },
+            ),
           ),
         ),
       ),

--- a/test/view/reorderable_bento_grid_test.dart
+++ b/test/view/reorderable_bento_grid_test.dart
@@ -275,6 +275,32 @@ void main() {
       expect(find.text("Solte aqui para remover"), findsNothing);
     });
 
+    // Sem um Material por perto, o texto e o ícone da faixa levariam o
+    // sublinhado amarelo e preto que o Flutter desenha em debug por faltar um
+    // DefaultTextStyle — o Overlay em que a faixa vive não tem um por conta
+    // própria.
+    testWidgets('a faixa de descarte tem um Material por perto',
+        (WidgetTester tester) async {
+      await tester
+          .pumpWidget(_GridHarness(const ["A", "B", "C"], [], deletions: []));
+
+      final gesture =
+          await tester.startGesture(tester.getCenter(find.text("B")));
+      await tester.pump(kLongPressTimeout + const Duration(milliseconds: 50));
+      await tester.pump();
+
+      expect(
+        find.ancestor(
+          of: find.text("Solte aqui para remover"),
+          matching: find.byType(Material),
+        ),
+        findsWidgets,
+      );
+
+      await gesture.up();
+      await tester.pumpAndSettle();
+    });
+
     testWidgets('soltar o cartão sobre a faixa o tira da grade',
         (WidgetTester tester) async {
       final deletions = <int>[];


### PR DESCRIPTION
## O que muda

A faixa de descarte que aparece no rodapé da tela ao arrastar um cartão (introduzida em #65) mostrava um sublinhado amarelo e preto sob o ícone e o texto — o efeito de debug que o Flutter desenha quando um `Text` não encontra um `DefaultTextStyle` por perto.

## Causa

`_dragFeedback` (o cartão que segue o dedo) já envolvia seu conteúdo num `Material` transparente, com o comentário explicando o porquê: o `Overlay` não tem um `Material` ancestral, e sem ele a pintura de texto não tem onde acontecer. A faixa de descarte (`_buildDeleteZone`) é montada do mesmo jeito, direto como `OverlayEntry`, mas ficou de fora desse envolvimento.

## Correção

Envolve a faixa inteira (ícone e texto) no mesmo `Material` transparente que o `_dragFeedback` já usa.

## Teste

Acrescentei um teste (`a faixa de descarte tem um Material por perto`) que confere a presença de um `Material` como ancestral do texto da faixa. Confirmei que ele falha sem a correção — revertendo o widget temporariamente e rodando só esse teste, ele aponta corretamente `Found 0 widgets with type "Material"` — e passa com ela.

`flutter analyze` sem apontamentos e `flutter test` inteiro verde (624 testes).

---
_Generated by [Claude Code](https://claude.ai/code/session_0159ecd2LTVzKYkyyW6ELq6x)_